### PR TITLE
chore: docker image version to 1.20.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #   docker run --rm -it --env-file=path/to/.env --name cosmwasm-etl-app dezswap/cosmwasm-etl-service
 
 ### BUILD
-FROM golang:1.20-alpine AS build
+FROM golang:1.20.10-alpine AS build
 ARG APP_TYPE=collector
 ARG LIBWASMVM_VERSION=v1.0.0
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- build failed on the latest 1.20.12 alpine linux

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- fix go version to `1.20.10`

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
