### PR TITLE
Use `transfer` instead of `from_contract` event message for `withdraw` Tx 

### DIFF
--- a/parser/terraswap/app_test.go
+++ b/parser/terraswap/app_test.go
@@ -125,7 +125,7 @@ var (
 	createTx       = parser.ParsedTx{hash, time.Time{}, parser.CreatePair, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
 	swapTx         = parser.ParsedTx{hash, time.Time{}, parser.Swap, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", map[string]interface{}{"tax_amount": parser.Asset{pair.Assets[1], "0"}}}
 	provideTx      = parser.ParsedTx{hash, time.Time{}, parser.Provide, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	withdrawTx     = parser.ParsedTx{hash, time.Time{}, parser.Withdraw, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", "-993"}, {"Asset1", "-993"}}, "Lp", "1000", "", nil}
+	withdrawTx     = parser.ParsedTx{hash, time.Time{}, parser.Withdraw, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", map[string]interface{}{"withdraw_assets": []parser.Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}}}
 	transferTx     = parser.ParsedTx{hash, time.Time{}, parser.Transfer, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", make(map[string]interface{})}
 	wasmTransferTx = parser.ParsedTx{hash, time.Time{}, parser.Transfer, sender, "PAIR_ADDR", [2]parser.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", make(map[string]interface{})}
 )

--- a/parser/terraswap/mappers.go
+++ b/parser/terraswap/mappers.go
@@ -150,10 +150,6 @@ func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair 
 		return nil, errors.Wrap(err, "pairMapper.withdrawMatchedToParsedTx")
 	}
 	for idx := range assets {
-		assets[idx].Amount, err = parser.AmountMul(assets[idx].Amount, "0.9939285487078243")
-		if err != nil {
-			return nil, errors.Wrap(err, "pairMapper.withdrawMatchedToParsedTx")
-		}
 		assets[idx].Amount = fmt.Sprintf("-%s", assets[idx].Amount)
 	}
 
@@ -164,9 +160,12 @@ func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair 
 	return &parser.ParsedTx{
 		Type:         parser.Withdraw,
 		ContractAddr: res[t.PairAddrIdx].Value,
-		Assets:       [2]parser.Asset{assets[0], assets[1]},
+		Assets:       [2]parser.Asset{{assets[0].Addr, "0"}, {assets[1].Addr, "0"}},
 		LpAddr:       pair.LpAddr,
 		LpAmount:     res[t.PairWithdrawWithdrawShareIdx].Value,
+		Meta: map[string]interface{}{
+			"withdraw_assets": assets,
+		},
 	}, nil
 
 }

--- a/parser/terraswap/mappers.go
+++ b/parser/terraswap/mappers.go
@@ -160,7 +160,7 @@ func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair 
 	return &parser.ParsedTx{
 		Type:         parser.Withdraw,
 		ContractAddr: res[t.PairAddrIdx].Value,
-		Assets:       [2]parser.Asset{{assets[0].Addr, "0"}, {assets[1].Addr, "0"}},
+		Assets:       [2]parser.Asset{{Addr: assets[0].Addr, Amount: "0"}, {Addr: assets[1].Addr, Amount: "0"}},
 		LpAddr:       pair.LpAddr,
 		LpAmount:     res[t.PairWithdrawWithdrawShareIdx].Value,
 		Meta: map[string]interface{}{
@@ -217,7 +217,7 @@ func (m *wasmCommonTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult,
 	return &parser.ParsedTx{
 		Type:         parser.Transfer,
 		Sender:       res[t.WasmTransferFromIdx].Value,
-		ContractAddr: res[t.WasmTransferToIdx].Value,
+		ContractAddr: pair.ContractAddr,
 		Assets:       assets,
 		Meta:         meta,
 	}, nil

--- a/parser/terraswap/mappers_test.go
+++ b/parser/terraswap/mappers_test.go
@@ -283,7 +283,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "withdrawn_share", Value: "12418119"},
 				{Key: "refund_assets", Value: fmt.Sprintf("%s%s, %s%s", "24999998", pair.Assets[0], "24939789", pair.Assets[1])},
 			},
-			&parser.ParsedTx{"", time.Time{}, parser.Withdraw, "", pair.ContractAddr, [2]parser.Asset{{pair.Assets[0], "-24848211"}, {pair.Assets[1], "-24788368"}}, pair.LpAddr, "12418119", "", nil},
+			&parser.ParsedTx{"", time.Time{}, parser.Withdraw, "", pair.ContractAddr, [2]parser.Asset{{pair.Assets[0], "0"}, {pair.Assets[1], "0"}}, pair.LpAddr, "12418119", "", map[string]interface{}{"withdraw_assets": []parser.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}}},
 			"",
 		},
 		{

--- a/parser/utils.go
+++ b/parser/utils.go
@@ -6,8 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/shopspring/decimal"
-
 	"github.com/pkg/errors"
 )
 
@@ -77,25 +75,4 @@ func AmountAdd(amount1, amount2 string) (string, error) {
 	}
 
 	return a1.Add(a1, a2).String(), nil
-}
-
-func AmountMul(amount1, amount2 string) (string, error) {
-	toDecimal := func(amount string) (*decimal.Decimal, error) {
-		amountDec, err := decimal.NewFromString(amount)
-		if err != nil {
-			return nil, errors.Wrap(err, "toDecimal")
-		}
-		return &amountDec, nil
-	}
-
-	a1, err := toDecimal(amount1)
-	if err != nil {
-		return "", errors.Wrap(err, "parser.AmountAdd")
-	}
-	a2, err := toDecimal(amount2)
-	if err != nil {
-		return "", errors.Wrap(err, "parser.AmountAdd")
-	}
-
-	return a1.Mul(*a2).BigInt().String(), nil
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- TerraSwap `withdraw` action doesn't have the tax amount related message and the tax ratio is different from the LCD response. 

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- use transfer message 

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
