### PR TITLE
Key based mapper for TerraSwap

### DIFF
--- a/pkg/eventlog/util.go
+++ b/pkg/eventlog/util.go
@@ -1,0 +1,32 @@
+package eventlog
+
+import (
+	"sort"
+
+	"github.com/pkg/errors"
+)
+
+func SortAttributes(attrs Attributes, filter map[string]bool) (*Attributes, error) {
+	if len(filter) == 0 {
+		return nil, errors.New("filter must be provided")
+	}
+
+	filtered := make(Attributes, 0, len(attrs))
+	for _, attr := range attrs {
+		if _, ok := filter[attr.Key]; ok {
+			filtered = append(filtered, attr)
+		}
+	}
+
+	idx := 0
+	end := len(filter)
+	for end <= len(filtered) {
+		sort.Slice(filtered[idx:end], func(i, j int) bool {
+			return filtered[i].Key < attrs[j].Key
+		})
+		idx = end
+		end = idx + len(filter)
+	}
+
+	return &filtered, nil
+}

--- a/pkg/rules/terraswap/phoenix/consts.go
+++ b/pkg/rules/terraswap/phoenix/consts.go
@@ -13,12 +13,8 @@ const (
 )
 
 const (
-	CreatePairMatchedLen   = FactoryLpAddrIdx + 1
-	PairSwapMatchedLen     = PairSwapCommissionAmountIdx + 1
-	PairProvideMatchedLen  = PairProvideShareIdx + 1
-	PairWithdrawMatchedLen = PairWithdrawRefundAssetsIdx + 1
-	WasmTransferMatchedLen = WasmTransferAmountIdx + 1
-	TransferMatchedLen     = TransferAmountIdx + 1
+	CreatePairMatchedLen     = FactoryLpAddrIdx + 1
+	SortedTransferMatchedLen = SortedTransferSenderIdx + 1
 )
 
 const (
@@ -35,39 +31,50 @@ const (
 )
 
 const (
-	PairSwapSenderIdx = iota + PairActionIdx + 1
-	PairSwapReceiverIdx
-	PairSwapOfferAssetIdx
-	PairSwapAskAssetIdx
-	PairSwapOfferAmountIdx
-	PairSwapReturnAmountIdx
-	PairSwapSpreadAmountIdx
-	PairSwapCommissionAmountIdx
+	SortedTransferAmountIdx = iota
+	SortedTransferRecipientIdx
+	SortedTransferSenderIdx
 )
 
 const (
-	PairProvideSenderIdx = iota + PairActionIdx + 1
-	PairProvideReceiverIdx
-	PairProvideAssetsIdx
-	PairProvideShareIdx
+	PairAddrKey   = "_contract_address"
+	PairActionKey = "action"
 )
 
 const (
-	PairWithdrawSenderIdx = iota + PairActionIdx + 1
-	PairWithdrawWithdrawShareIdx
-	PairWithdrawRefundAssetsIdx
+	PairSwapAskAssetKey         = "ask_asset"
+	PairSwapCommissionAmountKey = "commission_amount"
+	PairSwapOfferAmountKey      = "offer_amount"
+	PairSwapOfferAssetKey       = "offer_asset"
+	PairSwapReceiverKey         = "receiver"
+	PairSwapReturnAmountKey     = "return_amount"
+	PairSwapSenderKey           = "sender"
+	PairSwapSpreadAmountKey     = "spread_amount"
 )
 
 const (
-	WasmTransferCw20AddrIdx = iota
-	WasmTransferActionIdx
-	WasmTransferFromIdx
-	WasmTransferToIdx
-	WasmTransferAmountIdx
+	SortedTransferAmountKey    = "amount"
+	SortedTransferRecipientKey = "recipient"
+	SortedTransferSenderKey    = "sender"
 )
 
 const (
-	TransferRecipientIdx = iota
-	TransferSenderIdx
-	TransferAmountIdx
+	PairProvideAssetsKey   = "assets"
+	PairProvideSenderKey   = "sender"
+	PairProvideReceiverKey = "receiver"
+	PairProvideShareKey    = "share"
+)
+
+const (
+	PairWithdrawRefundAssetsKey  = "refund_assets"
+	PairWithdrawSenderKey        = "sender"
+	PairWithdrawWithdrawShareKey = "withdrawn_share"
+)
+
+const (
+	WasmTransferCw20AddrKey = "_contract_address"
+	WasmTransferActionKey   = "action"
+	WasmTransferAmountKey   = "amount"
+	WasmTransferFromKey     = "from"
+	WasmTransferToKey       = "to"
 )

--- a/pkg/rules/terraswap/phoenix/logfinders.go
+++ b/pkg/rules/terraswap/phoenix/logfinders.go
@@ -36,7 +36,7 @@ func CreateWasmCommonTransferRuleFinder(pairs map[string]bool) (eventlog.LogFind
 }
 
 // Track transfer from user to Pair
-func CreateTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
+func CreateSortedTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
 	var filter func(v string) bool
 	if pairs != nil {
 		filter = func(v string) bool {
@@ -44,8 +44,8 @@ func CreateTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error)
 			return ok
 		}
 	}
-	rule := transferRule
-	rule.Items[TransferRecipientIdx].Filter = filter
+	rule := sortedTransferRule
+	rule.Items[SortedTransferRecipientIdx].Filter = filter
 
 	return eventlog.NewLogFinder(rule)
 }
@@ -72,8 +72,8 @@ var wasmTransferCommonRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_con
 	}},
 }}
 
-var transferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
+var sortedTransferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
+	eventlog.RuleItem{Key: "amount", Filter: nil},
 	eventlog.RuleItem{Key: "recipient", Filter: nil},
 	eventlog.RuleItem{Key: "sender", Filter: nil},
-	eventlog.RuleItem{Key: "amount", Filter: nil},
 }}

--- a/pkg/rules/terraswap/phoenix/logfinders_test.go
+++ b/pkg/rules/terraswap/phoenix/logfinders_test.go
@@ -71,23 +71,22 @@ func Test_LogFinders(t *testing.T) {
 	}
 
 	tcs := []struct {
-		rawLogStr         string
-		pairs             map[string]bool
-		finderFunc        func(map[string]bool) (eventlog.LogFinder, error)
-		expectedResultLen int
-		matchedLen        int
-		errMsg            string
+		rawLogStr  string
+		pairs      map[string]bool
+		finderFunc func(map[string]bool) (eventlog.LogFinder, error)
+		matchedLen int
+		errMsg     string
 	}{
 		//Swap
-		{PairSwapRawLogStr, nil, CreatePairCommonRulesFinder, 1, PairSwapMatchedLen, "must match once"},
+		{PairSwapRawLogStr, nil, CreatePairCommonRulesFinder, 1, "must match once"},
 		// Provide
-		{PairProvideRawLogStr, nil, CreatePairCommonRulesFinder, 1, PairProvideMatchedLen, "must match once"},
+		{PairProvideRawLogStr, nil, CreatePairCommonRulesFinder, 1, "must match once"},
 		// Withdraw
-		{PairWithdrawRawLogStr, nil, CreatePairCommonRulesFinder, 1, PairWithdrawMatchedLen, "must match once"},
+		{PairWithdrawRawLogStr, nil, CreatePairCommonRulesFinder, 1, "must match once"},
 		// WasmTransfer
-		{WasmTransferRawLogStr, nil, CreateWasmCommonTransferRuleFinder, 1, WasmTransferMatchedLen, "must match once"},
+		{WasmTransferRawLogStr, nil, CreateWasmCommonTransferRuleFinder, 1, "must match once"},
 		// Transfer
-		{TransferRawLogStr, nil, CreateTransferRuleFinder, 1, TransferMatchedLen, "must match once"},
+		{TransferRawLogStr, nil, CreateSortedTransferRuleFinder, 1, "must match once"},
 	}
 
 	for idx, tc := range tcs {
@@ -96,10 +95,7 @@ func Test_LogFinders(t *testing.T) {
 
 		setUp(tc.rawLogStr, tc.pairs, tc.finderFunc)
 		matchedResults := logFinder.FindFromLogs(eventLogs)
-		assert.Len(matchedResults, tc.expectedResultLen, errMsg)
-		if tc.expectedResultLen > 0 {
-			assert.Len(matchedResults[0], tc.matchedLen, "must return all matched value")
-		}
+		assert.NotEmpty(matchedResults, errMsg)
 	}
 
 }
@@ -194,5 +190,5 @@ const TransferRawLogStr = `[
 	{"type":"coin_received","attributes":[{"key":"receiver","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"amount","value":"1000000uluna"}]},
 	{"type":"coin_spent","attributes":[{"key":"spender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"amount","value":"1000000uluna"}]},
 	{"type":"message","attributes":[{"key":"action","value":"/cosmos.bank.v1beta1.MsgSend"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"module","value":"bank"}]},
-	{"type":"transfer","attributes":[{"key":"recipient","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"amount","value":"1000000uluna"}]}
+	{"type":"transfer","attributes":[{"key":"amount","value":"1000000uluna"},{"key":"recipient","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"}]}
 ]`


### PR DESCRIPTION
<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- block result messages are sorted after the `4712300` block
  - [tx of 4711794](https://finder.terra.money/mainnet/tx/baffe980532210ecda594655b14f0a5ab1845e86667948372d53869577aee997)
  - [tx of 4712325](https://finder.terra.money/mainnet/tx/a4c180510eedc84f16459718100b833007c7b90f69c512c3fa73acd825def67b)
- it sorts from the second event message 

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- sort all transfer message
- change mapper from index based to key based


<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
