### PR TITLE
fix: update log config to grpc logger

### DIFF
--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -40,6 +40,7 @@ func main() {
 
 	defer catch(logger)
 
+	grpc.SetLogConfig(c.Log)
 	serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)
 	httpClient := &http.Client{
 		Transport: &http.Transport{

--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -168,6 +168,8 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 
 func main() {
 	c := configs.New()
+
+	grpc.SetLogConfig(c.Log)
 	logger := logging.New("parser", c.Log)
 	defer catch(logger)
 	if c.Parser.DexConfig == nil {

--- a/pkg/grpc/init.go
+++ b/pkg/grpc/init.go
@@ -3,11 +3,21 @@ package grpc
 import (
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+	"github.com/sirupsen/logrus"
 )
 
 var logger logging.Logger
 
 func init() {
-	// FIXME: Log config should come from the file
-	logger = logging.New("common", configs.LogConfig{})
+	logger = logging.New(
+		"grpc",
+		configs.LogConfig{
+			Level:      logrus.InfoLevel,
+			FormatJSON: true,
+		},
+	)
+}
+
+func SetLogConfig(c configs.LogConfig) {
+	logger = logging.New("grpc", c)
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
grpc error log isn't written due to unspecified log level, making it tough to diagnose the issue.

## Summary
add SetLogConfig and set default log level as `Info`

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
