### PR TITLE
fix: support cosmos-sdk v50 on cube testnet

### DIFF
--- a/parser/dex/dezswap/mappers_test.go
+++ b/parser/dex/dezswap/mappers_test.go
@@ -12,44 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_mapperMixin(t *testing.T) {
-	mapperMixin := mapperMixin{}
-
-	tcs := []struct {
-		matchedResults el.MatchedResult
-		expectedLen    int
-		errMsg         string
-	}{
-		{
-			el.MatchedResult{
-				{Key: "amount", Value: "1000Asset1"}, {Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
-			},
-			3,
-			"",
-		},
-		{
-			el.MatchedResult{
-				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
-				{Key: "amount", Value: "1000Asset1"}, {Key: "WRONG_MATCHED_LENGTH", Value: "LENGTH"},
-			},
-			3,
-			"must return error when matched result length is not equal to expected",
-		},
-	}
-
-	for idx, tc := range tcs {
-		assert := assert.New(t)
-		errMsg := fmt.Sprintf("tc(%d)", idx)
-
-		err := mapperMixin.checkResult(tc.matchedResults, tc.expectedLen)
-		if tc.errMsg != "" {
-			assert.Error(err, errMsg, tc.errMsg)
-		} else {
-			assert.NoError(err, errMsg)
-		}
-	}
-}
-
 func Test_TransferMapper(t *testing.T) {
 	const userAddr = "user"
 	pair := dex.Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
@@ -329,48 +291,6 @@ func Test_PairMapper(t *testing.T) {
 			assert.NoError(err, err)
 			assert.Equal(tc.expectedTx, tx, errMsg)
 		}
-	}
-}
-
-func Test_sortResult(t *testing.T) {
-
-	const userAddr = "userAddr"
-	pair := dex.Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
-	tcs := []struct {
-		target   el.MatchedResult
-		expected el.MatchedResult
-
-		errMsg string
-	}{
-		{
-
-			el.MatchedResult{
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "send"},
-				{Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr},
-				{Key: "amount", Value: "332157"},
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "swap"},
-				{Key: "sender", Value: userAddr}, {Key: "receiver", Value: userAddr},
-				{Key: "offer_asset", Value: pair.Assets[0]}, {Key: "ask_asset", Value: pair.Assets[1]},
-				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"},
-				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "302"},
-			},
-			el.MatchedResult{
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "send"},
-				{Key: "amount", Value: "332157"},
-				{Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr},
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "swap"},
-				{Key: "ask_asset", Value: pair.Assets[1]}, {Key: "commission_amount", Value: "302"},
-				{Key: "offer_amount", Value: "100000"}, {Key: "offer_asset", Value: pair.Assets[0]},
-				{Key: "receiver", Value: userAddr}, {Key: "return_amount", Value: "100583"},
-				{Key: "sender", Value: userAddr}, {Key: "spread_amount", Value: "2"},
-			},
-			"",
-		},
-	}
-
-	for _, tc := range tcs {
-		sortResult(tc.target)
-		assert.Equal(t, tc.target, tc.expected, tc.errMsg)
 	}
 }
 

--- a/parser/dex/mapper.go
+++ b/parser/dex/mapper.go
@@ -5,15 +5,13 @@ import (
 	"strings"
 
 	"github.com/dezswap/cosmwasm-etl/parser"
-	dex_common "github.com/dezswap/cosmwasm-etl/pkg/dex"
+	pdex "github.com/dezswap/cosmwasm-etl/pkg/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 
 	"github.com/pkg/errors"
 )
 
-type mapperMixin struct{}
-
-type factoryMapper struct{ mapperMixin }
+type factoryMapper struct{ pdex.MapperMixin }
 type transferMapper struct {
 	pairSet map[string]Pair
 }
@@ -22,19 +20,19 @@ type wasmCommonTransferMapper struct {
 	pairSet     map[string]Pair
 }
 
-type initialProvideMapper struct{ mapperMixin }
+type initialProvideMapper struct{ pdex.MapperMixin }
 
 func NewFactoryMapper() parser.Mapper[ParsedTx] {
-	return &factoryMapper{mapperMixin{}}
+	return &factoryMapper{pdex.MapperMixin{}}
 }
 
 // MatchedToParsedTx implements parser.Mapper.
 func (m *factoryMapper) MatchedToParsedTx(res eventlog.MatchedResult, optional ...interface{}) ([]*ParsedTx, error) {
-	if err := m.mapperMixin.checkResult(res, dex_common.CreatePairMatchedLen); err != nil {
+	if err := m.CheckResult(res, pdex.CreatePairMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "factoryMapper.MatchedToParsedTx")
 	}
 
-	assets := strings.Split(res[dex_common.FactoryPairIdx].Value, "-")
+	assets := strings.Split(res[pdex.FactoryPairIdx].Value, "-")
 	if len(assets) != 2 {
 		msg := fmt.Sprintf("expected assets length(%d)", 2)
 		return nil, errors.New(msg)
@@ -43,12 +41,12 @@ func (m *factoryMapper) MatchedToParsedTx(res eventlog.MatchedResult, optional .
 	return []*ParsedTx{{
 		Type:         CreatePair,
 		Sender:       "",
-		ContractAddr: res[dex_common.FactoryPairAddrIdx].Value,
+		ContractAddr: res[pdex.FactoryPairAddrIdx].Value,
 		Assets: [2]Asset{
 			{Addr: assets[0]},
 			{Addr: assets[1]},
 		},
-		LpAddr:   res[dex_common.FactoryLpAddrIdx].Value,
+		LpAddr:   res[pdex.FactoryLpAddrIdx].Value,
 		LpAmount: "",
 	}}, nil
 }
@@ -64,7 +62,7 @@ func (m *wasmCommonTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult,
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
 
-	sender, receiver := matchMap[dex_common.WasmTransferFromKey].Value, matchMap[dex_common.WasmTransferToKey].Value
+	sender, receiver := matchMap[pdex.WasmTransferFromKey].Value, matchMap[pdex.WasmTransferToKey].Value
 	fp, fromPair := m.pairSet[sender]
 	tp, toPair := m.pairSet[receiver]
 	if !fromPair && !toPair {
@@ -73,7 +71,7 @@ func (m *wasmCommonTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult,
 
 	var txs []*ParsedTx
 
-	amount := matchMap[dex_common.WasmTransferAmountKey].Value
+	amount := matchMap[pdex.WasmTransferAmountKey].Value
 	cw20Addr := matchMap[m.cw20AddrKey].Value
 	if fromPair {
 		txs = append(txs, m.wasmTransferToParsedTx(fp, cw20Addr, sender, amount, true))
@@ -124,7 +122,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
 
-	sender, receiver := matchMap[dex_common.TransferSenderKey].Value, matchMap[dex_common.TransferRecipientKey].Value
+	sender, receiver := matchMap[pdex.TransferSenderKey].Value, matchMap[pdex.TransferRecipientKey].Value
 	fp, fromPair := m.pairSet[sender]
 	tp, toPair := m.pairSet[receiver]
 
@@ -132,7 +130,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		return nil, nil
 	}
 
-	assetsStr := matchMap[dex_common.TransferAmountKey].Value
+	assetsStr := matchMap[pdex.TransferAmountKey].Value
 	txs := []*ParsedTx{}
 	if fromPair {
 		tx, err := m.transferToParsedTx(fp, sender, assetsStr, true)
@@ -190,12 +188,15 @@ func (m transferMapper) transferToParsedTx(pair Pair, from, assetsStr string, fr
 	}, nil
 }
 
-func NewInitialProvideMapper() parser.Mapper[ParsedTx] {
-	return &initialProvideMapper{mapperMixin{}}
+func NewInitialProvideMapper(postEventAttrLen ...int) parser.Mapper[ParsedTx] {
+	if len(postEventAttrLen) > 0 {
+		return &initialProvideMapper{MapperMixin: pdex.MapperMixin{PostEventAttrLen: postEventAttrLen[0]}}
+	}
+	return &initialProvideMapper{pdex.MapperMixin{}}
 }
 
 func (m *initialProvideMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...interface{}) ([]*ParsedTx, error) {
-	if err := m.checkResult(res, dex_common.PairInitialProvideMatchedLen); err != nil {
+	if err := m.CheckResult(res, pdex.PairInitialProvideMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "initialProvideMapper.MatchedToParsedTx")
 	}
 	matchMap, err := eventlog.ResultToItemMap(res)
@@ -206,24 +207,10 @@ func (m *initialProvideMapper) MatchedToParsedTx(res eventlog.MatchedResult, opt
 	return []*ParsedTx{{
 		Type:         InitialProvide,
 		Sender:       "",
-		ContractAddr: matchMap[dex_common.PairInitialProvideToKey].Value,
+		ContractAddr: matchMap[pdex.PairInitialProvideToKey].Value,
 		Assets:       [2]Asset{{}, {}},
-		LpAddr:       matchMap[dex_common.PairInitialProvideAddrKey].Value,
-		LpAmount:     matchMap[dex_common.PairInitialProvideAmountKey].Value,
+		LpAddr:       matchMap[pdex.PairInitialProvideAddrKey].Value,
+		LpAmount:     matchMap[pdex.PairInitialProvideAmountKey].Value,
 		Meta:         nil,
 	}}, nil
-}
-
-func (*mapperMixin) checkResult(res eventlog.MatchedResult, expectedLen ...int) error {
-	if len(expectedLen) > 0 && len(res) != expectedLen[0] {
-		msg := fmt.Sprintf("expected results length(%d)", expectedLen)
-		return errors.New(msg)
-	}
-	for i, r := range res {
-		if r.Value == "" {
-			msg := fmt.Sprintf("matched result(%d) must not be empty", i)
-			return errors.New(msg)
-		}
-	}
-	return nil
 }

--- a/parser/dex/mappers_test.go
+++ b/parser/dex/mappers_test.go
@@ -12,51 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_mapperMixin(t *testing.T) {
-	mapperMixin := mapperMixin{}
-
-	tcs := []struct {
-		matchedResults el.MatchedResult
-		expectedLen    int
-		errMsg         string
-	}{
-		{
-			el.MatchedResult{
-				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "amount", Value: "1000Asset1"},
-			},
-			3,
-			"",
-		},
-		{
-			el.MatchedResult{
-				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
-				{Key: "amount", Value: "1000Asset1"}, {Key: "WRONG_MATCHED_LENGTH", Value: "LENGTH"},
-			},
-			3,
-			"must return error when matched result length is not equal to expected",
-		},
-		{
-			el.MatchedResult{
-				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "amount", Value: ""},
-			},
-			3,
-			"empty value must return error",
-		},
-	}
-
-	for idx, tc := range tcs {
-		assert := assert.New(t)
-		errMsg := fmt.Sprintf("tc(%d)", idx)
-
-		err := mapperMixin.checkResult(tc.matchedResults, tc.expectedLen)
-		if tc.errMsg != "" {
-			assert.Error(err, errMsg, tc.errMsg)
-		} else {
-			assert.NoError(err, errMsg)
-		}
-	}
-}
-
 func Test_TransferMapper(t *testing.T) {
 	const userAddr = "user"
 	pair := Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
@@ -170,7 +125,7 @@ func Test_InitialProvideMapper(t *testing.T) {
 	}{
 		/// Initial Provide
 		{
-			&initialProvideMapper{mapperMixin{}},
+			&initialProvideMapper{dex.MapperMixin{}},
 			el.MatchedResult{
 				{Key: "_contract_address", Value: pair.LpAddr}, {Key: "action", Value: "mint"},
 				{Key: "amount", Value: "1000"}, {Key: "to", Value: pair.ContractAddr},
@@ -179,7 +134,7 @@ func Test_InitialProvideMapper(t *testing.T) {
 			"",
 		},
 		{
-			&initialProvideMapper{mapperMixin{}}, el.MatchedResult{
+			&initialProvideMapper{dex.MapperMixin{}}, el.MatchedResult{
 				{Key: "_contract_address", Value: pair.LpAddr}, {Key: "action", Value: "mint"},
 				{Key: "amount", Value: "1000"}, {Key: "to", Value: pair.ContractAddr}, {Key: "sender", Value: pair.ContractAddr},
 			},

--- a/parser/dex/starfleit/mappers_test.go
+++ b/parser/dex/starfleit/mappers_test.go
@@ -11,44 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_mapperMixin(t *testing.T) {
-	mapperMixin := mapperMixin{}
-
-	tcs := []struct {
-		matchedResults el.MatchedResult
-		expectedLen    int
-		errMsg         string
-	}{
-		{
-			el.MatchedResult{
-				{Key: "amount", Value: "1000Asset1"}, {Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
-			},
-			3,
-			"",
-		},
-		{
-			el.MatchedResult{
-				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
-				{Key: "amount", Value: "1000Asset1"}, {Key: "WRONG_MATCHED_LENGTH", Value: "LENGTH"},
-			},
-			3,
-			"must return error when matched result length is not equal to expected",
-		},
-	}
-
-	for idx, tc := range tcs {
-		assert := assert.New(t)
-		errMsg := fmt.Sprintf("tc(%d)", idx)
-
-		err := mapperMixin.checkResult(tc.matchedResults, tc.expectedLen)
-		if tc.errMsg != "" {
-			assert.Error(err, errMsg, tc.errMsg)
-		} else {
-			assert.NoError(err, errMsg)
-		}
-	}
-}
-
 func Test_TransferMapper(t *testing.T) {
 	const userAddr = "user"
 	pair := dex.Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
@@ -320,47 +282,5 @@ func Test_PairMapper(t *testing.T) {
 			assert.NoError(err, err)
 			assert.Equal(tc.expectedTx, tx, errMsg)
 		}
-	}
-}
-
-func Test_sortResult(t *testing.T) {
-
-	const userAddr = "userAddr"
-	pair := dex.Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
-	tcs := []struct {
-		target   el.MatchedResult
-		expected el.MatchedResult
-
-		errMsg string
-	}{
-		{
-
-			el.MatchedResult{
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "send"},
-				{Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr},
-				{Key: "amount", Value: "332157"},
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "swap"},
-				{Key: "sender", Value: userAddr}, {Key: "receiver", Value: userAddr},
-				{Key: "offer_asset", Value: pair.Assets[0]}, {Key: "ask_asset", Value: pair.Assets[1]},
-				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"},
-				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "302"},
-			},
-			el.MatchedResult{
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "send"},
-				{Key: "amount", Value: "332157"},
-				{Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr},
-				{Key: "_contract_address", Value: pair.ContractAddr}, {Key: "action", Value: "swap"},
-				{Key: "ask_asset", Value: pair.Assets[1]}, {Key: "commission_amount", Value: "302"},
-				{Key: "offer_amount", Value: "100000"}, {Key: "offer_asset", Value: pair.Assets[0]},
-				{Key: "receiver", Value: userAddr}, {Key: "return_amount", Value: "100583"},
-				{Key: "sender", Value: userAddr}, {Key: "spread_amount", Value: "2"},
-			},
-			"",
-		},
-	}
-
-	for _, tc := range tcs {
-		sortResult(tc.target)
-		assert.Equal(t, tc.target, tc.expected, tc.errMsg)
 	}
 }

--- a/parser/dex/terraswap/columbusv1/mappers.go
+++ b/parser/dex/terraswap/columbusv1/mappers.go
@@ -2,6 +2,7 @@ package columbusv1
 
 import (
 	"fmt"
+	pdex "github.com/dezswap/cosmwasm-etl/pkg/dex"
 
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
@@ -13,10 +14,8 @@ import (
 
 var _ parser.Mapper[dex.ParsedTx] = &pairMapper{}
 
-type mapperMixin struct{}
-
 type pairMapper struct {
-	mixin   mapperMixin
+	mixin   pdex.MapperMixin
 	pairSet map[string]dex.Pair
 }
 
@@ -46,7 +45,7 @@ func (m *pairMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...
 
 func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
 	var err error
-	if err = m.mixin.checkResult(res, cv1.PairSwapMatchedLen); err != nil {
+	if err = m.mixin.CheckResult(res, cv1.PairSwapMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "pairMapper.swapMatchedToParsedTx")
 	}
 
@@ -84,7 +83,7 @@ func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.
 }
 
 func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	if err := m.mixin.checkResult(res, cv1.PairProvideMatchedLen); err != nil {
+	if err := m.mixin.CheckResult(res, cv1.PairProvideMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "pairMapper.PairProvideMatchedLen")
 	}
 
@@ -107,7 +106,7 @@ func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair d
 }
 
 func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	if err := m.mixin.checkResult(res, cv1.PairWithdrawMatchedLen); err != nil {
+	if err := m.mixin.CheckResult(res, cv1.PairWithdrawMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "pairMapper.withdrawMatchedToParsedTx")
 	}
 
@@ -134,18 +133,4 @@ func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair 
 		},
 	}}, nil
 
-}
-
-func (*mapperMixin) checkResult(res eventlog.MatchedResult, expectedLen ...int) error {
-	if len(expectedLen) > 0 && len(res) != expectedLen[0] {
-		msg := fmt.Sprintf("expected results length(%d)", expectedLen)
-		return errors.New(msg)
-	}
-	for i, r := range res {
-		if r.Value == "" {
-			msg := fmt.Sprintf("matched result(%d) must not be empty", i)
-			return errors.New(msg)
-		}
-	}
-	return nil
 }

--- a/pkg/dex/dezswap/consts.go
+++ b/pkg/dex/dezswap/consts.go
@@ -8,6 +8,8 @@ const (
 const (
 	MainnetV2Height = 3166247
 	TestnetV2Height = 2975818
+
+	TestnetSdkV50Height = 12015741
 )
 
 var FactoryAddress = map[string]string{

--- a/pkg/dex/mapper.go
+++ b/pkg/dex/mapper.go
@@ -1,0 +1,52 @@
+package dex
+
+import (
+	"fmt"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
+	"github.com/pkg/errors"
+	"sort"
+)
+
+const msgIndexKey = "msg_index"
+
+type MapperMixin struct {
+	PostEventAttrLen int
+}
+
+func (m *MapperMixin) CheckResult(res eventlog.MatchedResult, expectedLen int) error {
+	if len(res) != expectedLen+m.PostEventAttrLen {
+		msg := fmt.Sprintf("expected results length(%d)", expectedLen)
+		return errors.New(msg)
+	}
+
+	for i, r := range res {
+		if r.Value == "" {
+			msg := fmt.Sprintf("matched result(%d) must not be empty", i)
+			return errors.New(msg)
+		}
+	}
+	return nil
+}
+
+// SortResult sorts the result by key split by "_contract_address"
+// @param res will be sorted
+func (*MapperMixin) SortResult(res eventlog.MatchedResult) {
+	const sortSplitter = "_contract_address"
+	sort := func(from, to int) {
+		target := res[from:to]
+		sort.Slice(target, func(i, j int) bool {
+			if target[i].Key == msgIndexKey {
+				return false
+			}
+			return target[i].Key < target[j].Key
+		})
+	}
+	prev := 0
+	for idx, v := range res {
+		if v.Key == sortSplitter {
+			sort(prev, idx)
+			prev = idx
+		}
+	}
+	sort(prev, len(res))
+}

--- a/pkg/dex/mapper_test.go
+++ b/pkg/dex/mapper_test.go
@@ -1,0 +1,230 @@
+package dex
+
+import (
+	"fmt"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func Test_CheckResult(t *testing.T) {
+	mapperMixin := MapperMixin{}
+
+	tcs := []struct {
+		matchedResults eventlog.MatchedResult
+		expectedLen    int
+		errMsg         string
+	}{
+		{
+			eventlog.MatchedResult{
+				{Key: "amount", Value: "1000Asset1"}, {Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
+			},
+			3,
+			"",
+		},
+		{
+			eventlog.MatchedResult{
+				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "amount", Value: "1000Asset1"},
+			},
+			3,
+			"",
+		},
+		{
+			eventlog.MatchedResult{
+				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
+				{Key: "amount", Value: "1000Asset1"}, {Key: "WRONG_MATCHED_LENGTH", Value: "LENGTH"},
+			},
+			3,
+			"must return error when matched result length is not equal to expected",
+		},
+		{
+			eventlog.MatchedResult{
+				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "amount", Value: ""},
+			},
+			3,
+			"empty value must return error",
+		},
+	}
+
+	assert := assert.New(t)
+	for idx, tc := range tcs {
+		errMsg := fmt.Sprintf("tc(%d)", idx)
+
+		err := mapperMixin.CheckResult(tc.matchedResults, tc.expectedLen)
+		if tc.errMsg != "" {
+			assert.Error(err, errMsg, tc.errMsg)
+		} else {
+			assert.NoError(err, errMsg)
+		}
+	}
+}
+
+func Test_CheckResult_WithPostAttrLen(t *testing.T) {
+	mapperMixin := MapperMixin{1}
+
+	tcs := []struct {
+		matchedResults eventlog.MatchedResult
+		expectedLen    int
+		errMsg         string
+	}{
+		{
+			eventlog.MatchedResult{
+				{Key: "amount", Value: "1000Asset1"}, {Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "msg_index", Value: "0"},
+			},
+			3,
+			"",
+		},
+		{
+			eventlog.MatchedResult{
+				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "amount", Value: "1000Asset1"}, {Key: "msg_index", Value: "0"},
+			},
+			3,
+			"",
+		},
+		{
+			eventlog.MatchedResult{
+				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"},
+				{Key: "amount", Value: "1000Asset1"}, {Key: "WRONG_MATCHED_LENGTH", Value: "LENGTH"}, {Key: "msg_index", Value: "0"},
+			},
+			3,
+			"must return error when matched result length is not equal to expected",
+		},
+		{
+			eventlog.MatchedResult{
+				{Key: "recipient", Value: "Pair"}, {Key: "sender", Value: "A"}, {Key: "amount", Value: ""}, {Key: "msg_index", Value: "0"},
+			},
+			3,
+			"empty value must return error",
+		},
+	}
+
+	assert := assert.New(t)
+	for idx, tc := range tcs {
+		errMsg := fmt.Sprintf("tc(%d)", idx)
+
+		err := mapperMixin.CheckResult(tc.matchedResults, tc.expectedLen)
+		if tc.errMsg != "" {
+			assert.Error(err, errMsg, tc.errMsg)
+		} else {
+			assert.NoError(err, errMsg)
+		}
+	}
+}
+
+func Test_sortResult(t *testing.T) {
+	const userAddr = "userAddr"
+
+	pairContractAddr := "Pair"
+	assets := []string{"Asset1", "Asset2"}
+	tcs := []struct {
+		target   eventlog.MatchedResult
+		expected eventlog.MatchedResult
+
+		errMsg string
+	}{
+		{
+			eventlog.MatchedResult{
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "send"},
+				{Key: "from", Value: userAddr},
+				{Key: "to", Value: pairContractAddr},
+				{Key: "amount", Value: "332157"},
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "swap"},
+				{Key: "sender", Value: userAddr},
+				{Key: "receiver", Value: userAddr},
+				{Key: "offer_asset", Value: assets[0]},
+				{Key: "ask_asset", Value: assets[1]},
+				{Key: "offer_amount", Value: "100000"},
+				{Key: "return_amount", Value: "100583"},
+				{Key: "spread_amount", Value: "2"},
+				{Key: "commission_amount", Value: "302"},
+			},
+			eventlog.MatchedResult{
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "send"},
+				{Key: "amount", Value: "332157"},
+				{Key: "from", Value: userAddr},
+				{Key: "to", Value: pairContractAddr},
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "swap"},
+				{Key: "ask_asset", Value: assets[1]},
+				{Key: "commission_amount", Value: "302"},
+				{Key: "offer_amount", Value: "100000"},
+				{Key: "offer_asset", Value: assets[0]},
+				{Key: "receiver", Value: userAddr},
+				{Key: "return_amount", Value: "100583"},
+				{Key: "sender", Value: userAddr},
+				{Key: "spread_amount", Value: "2"},
+			},
+			"",
+		},
+	}
+
+	mm := MapperMixin{}
+	for _, tc := range tcs {
+		mm.SortResult(tc.target)
+		assert.Equal(t, tc.target, tc.expected, tc.errMsg)
+	}
+}
+
+func Test_sortResult_WithMsgIndex(t *testing.T) {
+	const userAddr = "userAddr"
+
+	pairContractAddr := "Pair"
+	assets := []string{"Asset1", "Asset2"}
+	tcs := []struct {
+		target   eventlog.MatchedResult
+		expected eventlog.MatchedResult
+
+		errMsg string
+	}{
+		{
+			eventlog.MatchedResult{
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "send"},
+				{Key: "from", Value: userAddr},
+				{Key: "to", Value: pairContractAddr},
+				{Key: "amount", Value: "332157"},
+				{Key: "msg_index", Value: "2"},
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "swap"},
+				{Key: "sender", Value: userAddr},
+				{Key: "receiver", Value: userAddr},
+				{Key: "offer_asset", Value: assets[0]},
+				{Key: "ask_asset", Value: assets[1]},
+				{Key: "offer_amount", Value: "100000"},
+				{Key: "return_amount", Value: "100583"},
+				{Key: "spread_amount", Value: "2"},
+				{Key: "commission_amount", Value: "302"},
+				{Key: "msg_index", Value: "2"},
+			},
+			eventlog.MatchedResult{
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "send"},
+				{Key: "amount", Value: "332157"},
+				{Key: "from", Value: userAddr},
+				{Key: "to", Value: pairContractAddr},
+				{Key: "msg_index", Value: "2"},
+				{Key: "_contract_address", Value: pairContractAddr},
+				{Key: "action", Value: "swap"},
+				{Key: "ask_asset", Value: assets[1]},
+				{Key: "commission_amount", Value: "302"},
+				{Key: "offer_amount", Value: "100000"},
+				{Key: "offer_asset", Value: assets[0]},
+				{Key: "receiver", Value: userAddr},
+				{Key: "return_amount", Value: "100583"},
+				{Key: "sender", Value: userAddr},
+				{Key: "spread_amount", Value: "2"},
+				{Key: "msg_index", Value: "2"},
+			},
+			"",
+		},
+	}
+
+	mm := MapperMixin{}
+	for _, tc := range tcs {
+		mm.SortResult(tc.target)
+		assert.Equal(t, tc.target, tc.expected, tc.errMsg)
+	}
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Cosmos SDK v50 added `msg_index` attribute at the end of `wasm` event and parser fails the event's length validation due to not recognizing the new attribute.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
`mapperMixin` becomes a common struct in `pkg` and handles attribute slice's sort and validation. it has `postEventAttrLen` to check additional attributes from the previous standard length to validate. Also, `sortResult` function intentionally places certain additional(e.g. `msg_index`) key at the last intentionally to prevent indicating false value for designated attribute index.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?
