### PR TITLE
fix: remove redundant token_id attribute

### DIFF
--- a/pkg/eventlog/finder_test.go
+++ b/pkg/eventlog/finder_test.go
@@ -348,3 +348,52 @@ func TestFindFromAttr_WithMsgIndex(t *testing.T) {
 		}
 	}
 }
+
+func TestFindFromAttr_WithTokenId(t *testing.T) {
+	testCases := []struct {
+		attrs              Attributes
+		rule               RuleItems
+		ruleUntil          string
+		expectedResultLen  int
+		expectedMatchedLen int
+	}{
+		// transfer
+		{
+			Attributes{
+				{"_contract_address", "token_address"},
+				{"action", "transfer"},
+				{"token_id", "1357"},
+				{"amount", "1"},
+				{"from", "from_address"},
+				{"to", "to_address"},
+				{"_contract_address", "token_address"},
+				{"action", "transfer"},
+				{"token_id", "1357"},
+				{"amount", "1"},
+				{"from", "from_address"},
+				{"to", "to_address"},
+			},
+			RuleItems{
+				RuleItem{Key: "_contract_address", Filter: nil},
+				RuleItem{Key: "action", Filter: "transfer"},
+			},
+			"_contract_address",
+			2,
+			5,
+		},
+	}
+
+	for _, tc := range testCases {
+		rule, _ := NewRule("_", tc.rule, tc.ruleUntil)
+		finder, _ := NewLogFinder(rule)
+		results := finder.FindFromAttrs(tc.attrs)
+		assert.NotNil(t, results)
+		assert.Len(t, results, tc.expectedResultLen)
+		for _, r := range results {
+			assert.Len(t, r, tc.expectedMatchedLen)
+			for _, i := range r {
+				assert.NotEqual(t, "token_id", i.Key)
+			}
+		}
+	}
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
blocked by length check in `transferMapper.MatchedToParsedTx` due to `token_id` attribute

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
