### PR TITLE
fix: prevent sorting attribute partially

### DIFF
--- a/pkg/eventlog/util.go
+++ b/pkg/eventlog/util.go
@@ -23,7 +23,7 @@ func SortAttributes(attrs Attributes, filter map[string]bool) (*Attributes, erro
 	end := len(filter)
 	for end <= len(filtered) {
 		sort.Slice(filtered[idx:end], func(i, j int) bool {
-			return filtered[i].Key < attrs[j].Key
+			return filtered[idx:end][i].Key < attrs[j].Key
 		})
 		idx = end
 		end = idx + len(filter)

--- a/pkg/eventlog/util_test.go
+++ b/pkg/eventlog/util_test.go
@@ -1,0 +1,97 @@
+package eventlog
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestSortAttributes(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrs    Attributes
+		filter   map[string]bool
+		expected *Attributes
+	}{
+		{
+			name: "default tc",
+			attrs: Attributes{
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+				{Key: "amount", Value: "100uluna"},
+			},
+			filter: map[string]bool{
+				"amount":    true,
+				"recipient": true,
+				"sender":    true,
+			},
+			expected: &Attributes{
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+			},
+		},
+		{
+			name: "tc with keys to be excluded",
+			attrs: Attributes{
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "msg_index", Value: "1"},
+				{Key: "sender", Value: "terra1abcds"},
+				{Key: "token_id", Value: "ABCD"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "assets", Value: "0"},
+			},
+			filter: map[string]bool{
+				"amount":    true,
+				"recipient": true,
+				"sender":    true,
+			},
+			expected: &Attributes{
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+			},
+		},
+		{
+			name: "tc with multiple key sets",
+			attrs: Attributes{
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr2"},
+				{Key: "sender", Value: "terra1abcdr"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcds"},
+				{Key: "sender", Value: "terra1abcdr"},
+				{Key: "amount", Value: "1uluna"},
+			},
+			filter: map[string]bool{
+				"amount":    true,
+				"recipient": true,
+				"sender":    true,
+			},
+			expected: &Attributes{
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr2"},
+				{Key: "sender", Value: "terra1abcdr"},
+				{Key: "amount", Value: "1uluna"},
+				{Key: "recipient", Value: "terra1abcds"},
+				{Key: "sender", Value: "terra1abcdr"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := SortAttributes(tc.attrs, tc.filter)
+
+			assert.NoError(t, err)
+			assert.Len(t, *actual, len(*tc.expected))
+			for i := range *actual {
+				assert.Equal(t, (*tc.expected)[i], (*actual)[i])
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer: @psy2848048 

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
`less` function in `sort.Slice` indicates whole slice's index so that it compares same slice only.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
