### PR TITLE
feat: register validation exception pairs automatically by flagging tax-deducted non-native assets

### DIFF
--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -105,6 +105,10 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 	return txDtos, nil
 }
 
+func (p *dezswapApp) IsValidationExceptionCandidate(contractAddress string) bool {
+	return false
+}
+
 func (p *dezswapApp) updateParsers(pairs map[string]dex.Pair, height uint64) error {
 	pairFilter := make(map[string]bool)
 	for k := range pairs {

--- a/parser/dex/interface.go
+++ b/parser/dex/interface.go
@@ -11,6 +11,7 @@ type DexParserApp interface {
 
 type TargetApp interface {
 	parser.TargetApp[ParsedTx]
+	IsValidationExceptionCandidate(contractAddress string) bool
 }
 
 type Repo interface {
@@ -18,6 +19,7 @@ type Repo interface {
 	PairRepo
 	ParsedPoolsInfo(from, to uint64) ([]PoolInfo, error)
 	ValidationExceptionList() ([]string, error)
+	InsertPairValidationException(chainID string, contractAddress string) error
 }
 
 type SourceDataStore interface {

--- a/parser/dex/mappers_test.go
+++ b/parser/dex/mappers_test.go
@@ -156,3 +156,28 @@ func Test_InitialProvideMapper(t *testing.T) {
 		}
 	}
 }
+
+// e.g. https://finder.terra-classic.hexxagon.io/mainnet/tx/def0a16fc181b19cde5b09f149130d0f980d23ef784583b7ad6c8bca4705a2b4
+func Test_WasmTransferMapper_FlaggedPairs(t *testing.T) {
+	const msgSender = "terra1tmrwqr9g6htfzdppd34w3nypavtha7exqxdrk6"
+	pair := Pair{
+		ContractAddr: "terra15ukfg2wy9xd4g8hd5nl2rdyn7arlwk4l9u6kalwmg0pew5pjlpgskydg2a",
+		LpAddr:       "terra17csvyqecvdt6mhvfyt2uu07lnseh6clmzus4v4zdyuqwy8y7hmwqxucz52",
+		Assets:       []string{"terra1zkhwtm4a559emekwj7z4vklzqupgjyad8ncpwvav38y5ef6g5tjse7ceus", "uluna"}}
+	pairSet := map[string]Pair{pair.ContractAddr: pair}
+	flagged := map[string]bool{}
+
+	mapper := NewWasmTransferMapper(dex.WasmTransferCw20AddrKey, pairSet, flagged)
+	res := el.MatchedResult{
+		{Key: "_contract_address", Value: pair.Assets[0]},
+		{Key: "action", Value: "transfer"},
+		{Key: "amount", Value: "90256368190315"},
+		{Key: "cw20_tax_amount", Value: "7220509455225"}, // tax flag key
+		{Key: "from", Value: pair.ContractAddr},
+		{Key: "to", Value: msgSender},
+	}
+
+	_, err := mapper.MatchedToParsedTx(res)
+	assert.NoError(t, err)
+	assert.True(t, flagged[pair.Assets[0]])
+}

--- a/parser/dex/mock.go
+++ b/parser/dex/mock.go
@@ -82,6 +82,11 @@ func (m *RepoMock) Insert(height uint64, txs []ParsedTx, arg ...interface{}) err
 	return args.Error(0)
 }
 
+func (m *RepoMock) InsertPairValidationException(chainID string, contractAddress string) error {
+	args := m.MethodCalled("InsertPairValidationException")
+	return args.Error(0)
+}
+
 // ParsedPoolInfo implements Repo.
 func (m *RepoMock) ParsedPoolsInfo(from, to uint64) ([]PoolInfo, error) {
 	args := m.MethodCalled("ParsedPoolsInfo", from, to)

--- a/parser/dex/repo/repository.go
+++ b/parser/dex/repo/repository.go
@@ -114,6 +114,17 @@ func (r *repoImpl) Insert(height uint64, txs []dex.ParsedTx, arg ...interface{})
 	})
 }
 
+func (r *repoImpl) InsertPairValidationException(chainID string, contractAddress string) error {
+	if err := r.db.Model(&schemas.PairValidationException{}).Create(schemas.PairValidationException{
+		ChainId:  chainID,
+		Contract: contractAddress,
+	}).Error; err != nil {
+		return errors.Wrap(err, "repo.InsertPairValidationException")
+	}
+
+	return nil
+}
+
 // ParsedPoolInfo implements p_dex.Repo.
 func (r *repoImpl) ParsedPoolsInfo(from, to uint64) ([]dex.PoolInfo, error) {
 	type poolInfo struct {

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -104,6 +104,10 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	return txDtos, nil
 }
 
+func (p *starfleitApp) IsValidationExceptionCandidate(contractAddress string) bool {
+	return false
+}
+
 func (p *starfleitApp) updateParsers(pairs map[string]dex.Pair, height uint64) error {
 	pairFilter := make(map[string]bool)
 	for k := range pairs {

--- a/parser/dex/terraswap/columbusv1/app_test.go
+++ b/parser/dex/terraswap/columbusv1/app_test.go
@@ -51,7 +51,7 @@ func Test_parseTxs(t *testing.T) {
 		createPairParser := dex.ParserMock{}
 		repo := dex.RepoMock{}
 		rawStore := dex.RawStoreMock{}
-		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}}
+		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}, make(map[string]bool)}
 
 		dexApp := dex.NewDexApp(&app, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{FactoryAddress: factoryAddrKey})
 		pairMap := map[string]dex.Pair{pair.ContractAddr: pair}

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -50,7 +50,7 @@ func Test_parseTxs(t *testing.T) {
 		createPairParser := dex.ParserMock{}
 		repo := dex.RepoMock{}
 		rawStore := dex.RawStoreMock{}
-		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}}
+		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}, make(map[string]bool)}
 
 		dexApp := dex.NewDexApp(&app, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{FactoryAddress: factoryAddr})
 		pairMap := map[string]dex.Pair{pair.ContractAddr: pair}

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -16,6 +16,8 @@ type terraswapApp struct {
 	dex.PairRepo
 	Parsers *dex.PairParsers
 	dex.DexMixin
+
+	flaggedAssets map[string]bool
 }
 
 var _ dex.TargetApp = &terraswapApp{}
@@ -34,7 +36,7 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 		Transfer:         nil,
 	}
 
-	return &terraswapApp{repo, &parsers, dex.DexMixin{}}, nil
+	return &terraswapApp{repo, &parsers, dex.DexMixin{}, make(map[string]bool)}, nil
 }
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
@@ -118,6 +120,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	return txDtos, nil
 }
 
+func (p *terraswapApp) IsValidationExceptionCandidate(contractAddress string) bool {
+	return p.flaggedAssets[contractAddress]
+}
+
 func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 	pairFilter := make(map[string]bool)
 	for k := range pairs {
@@ -139,7 +145,7 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.WasmTransfer = parser.NewParser[dex.ParsedTx](wasmTransferFinder, dex.NewWasmTransferMapper(pdex.WasmTransferCw20AddrKey, pairs))
+	p.Parsers.WasmTransfer = parser.NewParser[dex.ParsedTx](wasmTransferFinder, dex.NewWasmTransferMapper(pdex.WasmTransferCw20AddrKey, pairs, p.flaggedAssets))
 
 	transferRule, err := phoenix.CreateSortedTransferRuleFinder(nil)
 	if err != nil {

--- a/parser/dex/terraswap/phoenix/app_test.go
+++ b/parser/dex/terraswap/phoenix/app_test.go
@@ -50,7 +50,7 @@ func Test_parseTxs(t *testing.T) {
 		createPairParser := dex.ParserMock{}
 		repo := dex.RepoMock{}
 		rawStore := dex.RawStoreMock{}
-		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}}
+		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}, make(map[string]bool)}
 
 		dexApp := dex.NewDexApp(&app, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{FactoryAddress: factoryAddr})
 		pairMap := map[string]dex.Pair{pair.ContractAddr: pair}

--- a/pkg/dex/const.go
+++ b/pkg/dex/const.go
@@ -51,6 +51,8 @@ const (
 	WasmTransferAmountKey         = "amount"
 	WasmTransferFromKey           = "from"
 	WasmTransferToKey             = "to"
+
+	WasmTransferTaxFlagPatternKey = "tax"
 )
 
 const (


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some non-native tokens deduct tax on transfers, which can cause asset mismatches when validating dex pairs. Previously, these mismatches were handled manually.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Added a flag for tax-deducted non-native assets
- Automatically add a pair with asset mismatches as validation exceptions when such assets are involved

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
