### PR TITLE
refactor: avoid fetching from DB on every parse

### DIFF
--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -17,6 +17,8 @@ type terraswapApp struct {
 	Parsers *dex.PairParsers
 	dex.DexMixin
 
+	// state
+	pairs         map[string]dex.Pair
 	flaggedAssets map[string]bool
 }
 
@@ -36,22 +38,22 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 		Transfer:         nil,
 	}
 
-	return &terraswapApp{repo, &parsers, dex.DexMixin{}, make(map[string]bool)}, nil
+	pairs, err := repo.GetPairs()
+	if err != nil {
+		return nil, errors.Wrap(err, "phoenix.New")
+	}
+
+	return &terraswapApp{repo, &parsers, dex.DexMixin{}, pairs, make(map[string]bool)}, nil
 }
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
-	pairs, err := p.GetPairs()
-	if err != nil {
-		return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
-	}
-
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
 	}
 	for _, ctx := range createPairTxs {
-		pairs[ctx.ContractAddr] = dex.Pair{
+		p.pairs[ctx.ContractAddr] = dex.Pair{
 			ContractAddr: ctx.ContractAddr,
 			LpAddr:       ctx.LpAddr,
 			Assets:       []string{ctx.Assets[0].Addr, ctx.Assets[1].Addr},
@@ -60,7 +62,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		txDtos = append(txDtos, *ctx)
 	}
 
-	if err := p.updateParsers(pairs); err != nil {
+	if err := p.updateParsers(p.pairs); err != nil {
 		return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
 	}
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, the parser fetched the full pair list from the DB for every tx. Since pair rows never change once created, this resulted in unnecessary repeated queries and performance overhead.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Cache the pair list in memory instead of querying the DB for each block
- Update the cached list only when a tx adds a new pair

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
