### PR TITLE
ci: restructure workflows with tag-based publish and separation

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -35,10 +35,7 @@ env:
   # AWS
   ECR_REPOSITORY: cosmwasm-etl
   ECS_CLUSTER: cosmwasm-etl
-
-  GIT_COMMIT: ${{ github.sha }}
   TARGET: ${{ format('{0}-cosmwasm-etl-{1}', github.event.inputs.network, github.event.inputs.app_type) }}
-  CONFIG_NAME: ${{ format('{0}_{1}_CONFIG', github.event.inputs.network, github.event.inputs.app_type) }}
 
 permissions:
   id-token: write
@@ -48,55 +45,31 @@ jobs:
   deploy:
     name: build and deploy the app
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     environment: production
     steps:
-      - name: Shortten commit hash
-        run: |
-          echo "GIT_COMMIT=${GIT_COMMIT::7}" >> $GITHUB_ENV
-          # to Upper case
-          echo "CONFIG_NAME=$(echo "$CONFIG_NAME" | tr '-' '_' | tr '[:lower:]' '[:upper:]')" >> $GITHUB_ENV
-
       - name: checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
+
+      - name: Check if ref is a tag and extract version
+        id: check-tag
+        run: |
+          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+            GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
+            echo "tag=${GIT_TAG}" >> "$GITHUB_OUTPUT"
+            echo "run_next_job=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "This workflow must be triggered by a tag ref (refs/tags/*)."
+            echo "run_next_job=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
 
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ steps.check-tag.outputs.run_next_job == 'true' }}
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: cosmwasm-etl-deploy
           aws-region: ${{ inputs.region }}
-
-
-      - name: Login to Amazon ECR
-        id: login-ecr-deps
-        uses: aws-actions/amazon-ecr-login@v2.0.1
-
-      - name: Pull dependency image
-        id: pull
-        working-directory: .
-        run: |
-          docker pull  ${{ steps.login-ecr-deps.outputs.registry }}/$ECR_REPOSITORY:deps-${{env.GIT_COMMIT}}
-
-      - name: Build the app, tag and push image
-        id: build
-        working-directory: .
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr-deps.outputs.registry }}
-          CONFIG: ${{ secrets[env.CONFIG_NAME] }}
-        run: |
-          IMAGE_TAG=${{inputs.app_type}}-${{env.GIT_COMMIT}}
-          echo "${CONFIG}" > config.yaml
-
-          APP_PATH=$(echo ${{inputs.app_type}} | tr '-' '/')
-          docker build \
-            --build-arg BUILD_BASE_IMAGE="${{ steps.login-ecr-deps.outputs.registry }}/$ECR_REPOSITORY:deps-${{env.GIT_COMMIT}}" \
-            --build-arg APP_PATH=$APP_PATH \
-            --no-cache -t $ECR_REGISTRY/$ECR_REPOSITORY:${{env.TARGET}} -t $ECR_REGISTRY/$ECR_REPOSITORY:${IMAGE_TAG} .
-
-           docker image push -a $ECR_REGISTRY/$ECR_REPOSITORY
-
-           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV
 
       - name: Download Task Definition
         id: download-task-definition
@@ -110,7 +83,7 @@ jobs:
         with:
           task-definition: ./${{ env.TARGET }}.json
           container-name: ${{ env.TARGET }}
-          image: ${{ steps.login-ecr-deps.outputs.registry }}/${{ env.ECR_REPOSITORY}}:${{ env.TARGET }}
+          image: ${{ steps.login-ecr-deps.outputs.registry }}/${{ env.ECR_REPOSITORY}}/${{ github.event.inputs.app_type }}:${{ steps.check-tag.outputs.tag }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,10 @@ jobs:
           --health-retries 5
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
 
     - name: Set up Go
-      uses: actions/setup-go@v3
+      uses: actions/setup-go@v5
       with:
         go-version: 1.20.10
 
@@ -50,38 +50,3 @@ jobs:
 
     - name: Build all
       run: make build-all
-
-  deploy-deps-image:
-    environment: production
-    runs-on: ubuntu-latest
-    needs: tests
-    name: build deps image
-    if: success() && github.ref == 'refs/heads/main'
-    permissions:
-      id-token: write
-      contents: read
-
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
-          role-session-name: cosmwasm-etl-deps
-          aws-region: ${{ secrets.AWS_DEPS_REGION }}
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2.0.1
-
-      - name: Build, tag, and push image to Amazon ECR
-        id: build-deps-image
-        working-directory: .
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY: cosmwasm-etl
-        run: |
-          GIT_SHORT_COMMIT=`git rev-parse --short HEAD`
-          docker build --no-cache --target=deps -t $ECR_REGISTRY/$ECR_REPOSITORY:deps-${GIT_SHORT_COMMIT} .
-          docker image push -a $ECR_REGISTRY/$ECR_REPOSITORY

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  AWS_REGION: ${{ secrets.AWS_REGION }}
+  ECR_REPOSITORY: cosmwasm-etl
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  deploy:
+    name: build and deploy the app
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check if tag commit is on main branch
+        id: check_branch
+        run: |
+          branches_containing_tag=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
+          echo "Branches containing tag: $branches_containing_tag"
+
+          if echo "$branches_containing_tag" | grep -Eq "^(origin/)?ci/refactoring"; then
+            # get version from tag
+            GIT_TAG=$(echo "${{ github.ref }}" | sed 's|refs/tags/v||')
+            echo "tag=$GIT_TAG" >> $GITHUB_OUTPUT
+            echo "run_next_job=true" >> $GITHUB_OUTPUT
+          else
+            echo "The tag commit is NOT on main branch. Exiting."
+            echo "run_next_job=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        if: ${{ steps.check_branch.outputs.run_next_job == 'true' }}
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: cosmwasm-etl-deploy
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.0.1
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        working-directory: .
+        env:
+          IMAGE_TAG: ${{ steps.check_branch.outputs.tag }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        run: |
+          for app_type in collector parser-dex aggregator; do
+            echo "Building for $app_type"
+            APP_PATH=$(echo $app_type | tr '-' '/')
+            docker build \
+            --build-arg APP_PATH=$APP_PATH --no-cache \
+            -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}/$app_type:latest \
+            -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}/$app_type:${IMAGE_TAG} .
+            docker image push -a $ECR_REGISTRY/${{ env.ECR_REPOSITORY }}/$app_type
+          done


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The previous workflow included building and storing a base image(`deps`) in ECR, and then creating per-app images together with `config.yaml`. This approach may use additional storage usage in ECR, and redesigning the workflow offers a chance to improve image reuse across services.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Removed base image (`deps`) build step in `ci.yml` and per-app rebuild with `config.yaml` in `cd.yml`
- Added a new publish workflow to build and push per-app docker images based on tags
- Updated CD workflow to only update ECS task definitions with the selected tag version

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
