### PR TITLE
fix: prevent panicking when no file exists but only env vars

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -71,6 +71,10 @@ jobs:
           role-session-name: cosmwasm-etl-deploy
           aws-region: ${{ inputs.region }}
 
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2.0.1
+
       - name: Download Task Definition
         id: download-task-definition
         working-directory: .
@@ -83,7 +87,7 @@ jobs:
         with:
           task-definition: ./${{ env.TARGET }}.json
           container-name: ${{ env.TARGET }}
-          image: ${{ steps.login-ecr-deps.outputs.registry }}/${{ env.ECR_REPOSITORY}}/${{ github.event.inputs.app_type }}:${{ steps.check-tag.outputs.tag }}
+          image: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY}}/${{ github.event.inputs.app_type }}:${{ steps.check-tag.outputs.tag }}
 
       - name: Deploy Amazon ECS task definition
         uses: aws-actions/amazon-ecs-deploy-task-definition@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    environment: CI
     services:
       cosmwasm-etl-db:
         image: postgres
@@ -38,7 +39,7 @@ jobs:
     - name: Tests
       shell: bash
       run: |
-        touch config.yaml
+        echo "${{ secrets.CONFIG }}" > config.yaml
         make test
 
     - name: Migration Tests

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -1,0 +1,39 @@
+package configs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func withTestBasepath(t *testing.T, dir string) func() {
+	t.Helper()
+	original := basepath
+	basepath = dir
+	return func() { basepath = original }
+}
+
+func Test_New_EnvOnly(t *testing.T) {
+	expectedEnv := "local"
+	expectedChainID := "testnet-1"
+
+	t.Setenv("APP_LOG_ENV", expectedEnv)
+	t.Setenv("APP_LOG_CHAINID", expectedChainID)
+
+	tmp := t.TempDir()
+	defer withTestBasepath(t, tmp)()
+
+	cfg := New()
+	require.Equal(t, expectedEnv, cfg.Log.Environment)
+	require.Equal(t, expectedChainID, cfg.Log.ChainId)
+}
+
+func Test_New_NoFile_NoEnv(t *testing.T) {
+	t.Setenv("APP_LOG_ENV", "")
+	t.Setenv("APP_LOG_CHAINID", "")
+
+	tmp := t.TempDir()
+	defer withTestBasepath(t, tmp)()
+
+	require.Panics(t, func() { _ = New() })
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The service panicked if no config file was present, even when environment variables were available.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Fixed config loading to allow running with env vars only (no file required)  
- Added CI step to log in and fetch ECR registry address

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
