### PR TITLE
fix: reorder to follow filter key sequence per sub slice

### DIFF
--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -98,8 +98,8 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		if raw.Type == eventlog.TransferType {
 			// event log messages are not sorted well
 			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
-			filter := map[string]bool{
-				columbusv2.SortedTransferAmountKey: true, columbusv2.SortedTransferRecipientKey: true, columbusv2.SortedTransferSenderKey: true,
+			filter := []string{
+				columbusv2.SortedTransferAmountKey, columbusv2.SortedTransferRecipientKey, columbusv2.SortedTransferSenderKey,
 			}
 			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
 			if err != nil {

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -96,8 +96,8 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		if raw.Type == eventlog.TransferType {
 			// event log messages are not sorted well
 			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
-			filter := map[string]bool{
-				phoenix.SortedTransferAmountKey: true, phoenix.SortedTransferRecipientKey: true, phoenix.SortedTransferSenderKey: true,
+			filter := []string{
+				phoenix.SortedTransferAmountKey, phoenix.SortedTransferRecipientKey, phoenix.SortedTransferSenderKey,
 			}
 			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
 			if err != nil {

--- a/pkg/eventlog/util.go
+++ b/pkg/eventlog/util.go
@@ -7,14 +7,19 @@ import (
 	"github.com/pkg/errors"
 )
 
-func SortAttributes(attrs Attributes, filter map[string]bool) (*Attributes, error) {
+func SortAttributes(attrs Attributes, filter []string) (*Attributes, error) {
 	if len(filter) == 0 {
 		return nil, errors.New("filter must be provided")
 	}
 
+	order := make(map[string]int, len(filter))
+	for i, key := range filter {
+		order[key] = i
+	}
+
 	filtered := make(Attributes, 0, len(attrs))
 	for _, attr := range attrs {
-		if _, ok := filter[attr.Key]; ok {
+		if _, ok := order[attr.Key]; ok {
 			filtered = append(filtered, attr)
 		}
 	}
@@ -23,7 +28,7 @@ func SortAttributes(attrs Attributes, filter map[string]bool) (*Attributes, erro
 	end := len(filter)
 	for end <= len(filtered) {
 		sort.Slice(filtered[idx:end], func(i, j int) bool {
-			return filtered[idx:end][i].Key < attrs[j].Key
+			return order[filtered[idx:end][i].Key] < order[filtered[idx:end][j].Key]
 		})
 		idx = end
 		end = idx + len(filter)

--- a/pkg/eventlog/util_test.go
+++ b/pkg/eventlog/util_test.go
@@ -9,7 +9,7 @@ func TestSortAttributes(t *testing.T) {
 	tests := []struct {
 		name     string
 		attrs    Attributes
-		filter   map[string]bool
+		filter   []string
 		expected *Attributes
 	}{
 		{
@@ -19,10 +19,10 @@ func TestSortAttributes(t *testing.T) {
 				{Key: "sender", Value: "terra1abcds"},
 				{Key: "amount", Value: "100uluna"},
 			},
-			filter: map[string]bool{
-				"amount":    true,
-				"recipient": true,
-				"sender":    true,
+			filter: []string{
+				"amount",
+				"recipient",
+				"sender",
 			},
 			expected: &Attributes{
 				{Key: "amount", Value: "100uluna"},
@@ -40,10 +40,10 @@ func TestSortAttributes(t *testing.T) {
 				{Key: "amount", Value: "100uluna"},
 				{Key: "assets", Value: "0"},
 			},
-			filter: map[string]bool{
-				"amount":    true,
-				"recipient": true,
-				"sender":    true,
+			filter: []string{
+				"amount",
+				"recipient",
+				"sender",
 			},
 			expected: &Attributes{
 				{Key: "amount", Value: "100uluna"},
@@ -64,10 +64,41 @@ func TestSortAttributes(t *testing.T) {
 				{Key: "sender", Value: "terra1abcdr"},
 				{Key: "amount", Value: "1uluna"},
 			},
-			filter: map[string]bool{
-				"amount":    true,
-				"recipient": true,
-				"sender":    true,
+			filter: []string{
+				"amount",
+				"recipient",
+				"sender",
+			},
+			expected: &Attributes{
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr2"},
+				{Key: "sender", Value: "terra1abcdr"},
+				{Key: "amount", Value: "1uluna"},
+				{Key: "recipient", Value: "terra1abcds"},
+				{Key: "sender", Value: "terra1abcdr"},
+			},
+		},
+		{
+			// https://finder.terra-classic.hexxagon.io/mainnet/tx/4E80262C9F94E11900D903D03646D75397B92B505B0850DB1E034EFB506FF964
+			name: "tc with multiple key sets 2",
+			attrs: Attributes{
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "sender", Value: "terra1abcds"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr2"},
+				{Key: "sender", Value: "terra1abcdr"},
+				{Key: "recipient", Value: "terra1abcds"},
+				{Key: "sender", Value: "terra1abcdr"},
+				{Key: "amount", Value: "1uluna"},
+			},
+			filter: []string{
+				"amount",
+				"recipient",
+				"sender",
 			},
 			expected: &Attributes{
 				{Key: "amount", Value: "100uluna"},


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`SortAttributes` was using the wrong slice for comparison and relied on alphabetical ordering.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- ensure cyclic pattern matches filter order

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
