### PR TITLE
refactor: add db indices for query optimization

### DIFF
--- a/db/migrations/aggregator/20260327160019_add_price_index.down.sql
+++ b/db/migrations/aggregator/20260327160019_add_price_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX price_token_id_tx_id_idx;

--- a/db/migrations/aggregator/20260327160019_add_price_index.up.sql
+++ b/db/migrations/aggregator/20260327160019_add_price_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX price_token_id_tx_id_idx ON price (token_id, tx_id);

--- a/db/migrations/parser/20260327160019_add_parsed_tx_indices.down.sql
+++ b/db/migrations/parser/20260327160019_add_parsed_tx_indices.down.sql
@@ -1,0 +1,6 @@
+DROP INDEX parsed_tx_type_timestamp_idx;
+
+DROP INDEX parsed_tx_contract_type_timestamp_idx;
+
+DROP INDEX parsed_tx_asset0_type_timestamp_idx;
+DROP INDEX parsed_tx_asset1_type_timestamp_idx;

--- a/db/migrations/parser/20260327160019_add_parsed_tx_indices.up.sql
+++ b/db/migrations/parser/20260327160019_add_parsed_tx_indices.up.sql
@@ -1,0 +1,6 @@
+CREATE INDEX parsed_tx_type_timestamp_idx ON parsed_tx (type, timestamp DESC);
+
+CREATE INDEX parsed_tx_contract_type_timestamp_idx ON parsed_tx (contract, type, timestamp DESC);
+
+CREATE INDEX parsed_tx_asset0_type_timestamp_idx ON parsed_tx (asset0, type, timestamp DESC);
+CREATE INDEX parsed_tx_asset1_type_timestamp_idx ON parsed_tx (asset1, type, timestamp DESC);


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dezswap dashboard API endpoints (`/txs`, `/txs?pool=`, `/txs?token=`) were slow due to sequential scans on `parsed_tx`, which is a large and frequently queried table. Queries commonly filter by type, contract, or asset columns with timestamp DESC ordering, making composite indexes on     
  these columns an effective fix. The price table also lacked an index for token-based lookups, causing unnecessary overhead in price-related queries.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Add composite indexes on `parsed_tx` to cover the primary query patterns used by the dashboard APIs — filtering by tx type, pool contract, and token assets with timestamp ordering. Also adds an index on `price(token_id, tx_id)` to speed up token price lookups.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
