### PR TITLE
feat: support LP burn type for all dex apps

### DIFF
--- a/db/migrations/parser/20260406161622_add_tx_type_burn.down.sql
+++ b/db/migrations/parser/20260406161622_add_tx_type_burn.down.sql
@@ -1,0 +1,7 @@
+UPDATE parsed_tx SET type = 'transfer' WHERE type = 'lp_burn';
+
+CREATE TYPE tx_type_old AS ENUM ('create_pair', 'swap', 'provide', 'withdraw', 'initial_provide', 'transfer');
+
+ALTER TABLE parsed_tx ALTER COLUMN type TYPE tx_type_old USING type::text::tx_type_old;
+DROP TYPE tx_type;
+ALTER TYPE tx_type_old RENAME TO tx_type;

--- a/db/migrations/parser/20260406161622_add_tx_type_burn.up.sql
+++ b/db/migrations/parser/20260406161622_add_tx_type_burn.up.sql
@@ -1,0 +1,1 @@
+ALTER TYPE tx_type ADD VALUE 'lp_burn';

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -268,10 +268,13 @@ func (app *dexApp) comparePair(actual PoolInfo, expected PoolInfo) error {
 func CollectLpBurnTxs(burnTxs []*ParsedTx, lpPairAddrs map[string]string) []ParsedTx {
 	lpBurnTxs := []ParsedTx{}
 	for _, t := range burnTxs {
-		if pairAddr, ok := lpPairAddrs[t.LpAddr]; ok {
-			t.ContractAddr = pairAddr
-			lpBurnTxs = append(lpBurnTxs, *t)
+		pairAddr, ok := lpPairAddrs[t.LpAddr]
+		if !ok || t.Sender == pairAddr { // filter out withdraw lp burn
+			continue
 		}
+
+		t.ContractAddr = pairAddr
+		lpBurnTxs = append(lpBurnTxs, *t)
 	}
 	return lpBurnTxs
 }

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -262,6 +262,20 @@ func (app *dexApp) comparePair(actual PoolInfo, expected PoolInfo) error {
 	return errors.New(strings.Join(diffs, "; "))
 }
 
+// CollectLpBurnTxs collects LP burn events and associates them with their pair contract.
+// LP tokens can be burned directly (outside of withdraw_liquidity), so we need to track
+// these burns separately and subtract the burned amount to keep pool calculations accurate.
+func CollectLpBurnTxs(burnTxs []*ParsedTx, lpPairAddrs map[string]string) []ParsedTx {
+	lpBurnTxs := []ParsedTx{}
+	for _, t := range burnTxs {
+		if pairAddr, ok := lpPairAddrs[t.LpAddr]; ok {
+			t.ContractAddr = pairAddr
+			lpBurnTxs = append(lpBurnTxs, *t)
+		}
+	}
+	return lpBurnTxs
+}
+
 func (mixin *DexMixin) HasProvide(pairTxs []*ParsedTx) bool {
 	for _, tx := range pairTxs {
 		if tx.Type == Provide {

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -165,3 +165,32 @@ var (
 	withdrawTx = ParsedTx{"", time.Time{}, Withdraw, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}, "Lp", "1000", "", nil}
 	transferTx = ParsedTx{"", time.Time{}, Transfer, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", nil}
 )
+
+func Test_collectLpBurnTxs(t *testing.T) {
+	lpPairAddrs := map[string]string{
+		"LpToken": "PairContract",
+	}
+
+	tcs := []struct {
+		burnTxs  []*ParsedTx
+		expected []ParsedTx
+		errMsg   string
+	}{
+		{
+			burnTxs:  []*ParsedTx{{LpAddr: "LpToken", LpAmount: "-1000"}},
+			expected: []ParsedTx{{LpAddr: "LpToken", ContractAddr: "PairContract", LpAmount: "-1000"}},
+			errMsg:   "known LP addr must be collected with pair contract addr assigned",
+		},
+		{
+			burnTxs:  []*ParsedTx{{LpAddr: "UnknownLpToken", LpAmount: "-1000"}},
+			expected: []ParsedTx{},
+			errMsg:   "unknown LP addr must be filtered out",
+		},
+	}
+
+	for _, tc := range tcs {
+		assert := assert.New(t)
+		result := CollectLpBurnTxs(tc.burnTxs, lpPairAddrs)
+		assert.Equal(tc.expected, result, tc.errMsg)
+	}
+}

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -186,6 +186,11 @@ func Test_collectLpBurnTxs(t *testing.T) {
 			expected: []ParsedTx{},
 			errMsg:   "unknown LP addr must be filtered out",
 		},
+		{
+			burnTxs:  []*ParsedTx{{LpAddr: "LpToken", Sender: "PairContract", LpAmount: "-1000"}},
+			expected: []ParsedTx{},
+			errMsg:   "burn from pair contract itself (withdraw lp burn) must be filtered out",
+		},
 	}
 
 	for _, tc := range tcs {

--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -119,24 +119,9 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTransferTxs)...)
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
-	txDtos = append(txDtos, p.collectLpBurnTxs(burnTxs)...)
+	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil
-}
-
-// collectLpBurnTxs collects LP burn events and associates them with their pair contract.
-// LP tokens can be burned directly (outside of withdraw_liquidity), so we need to track
-// these burns separately and subtract the burned amount to keep pool calculations accurate.
-func (p *dezswapApp) collectLpBurnTxs(burnTxs []*dex.ParsedTx) []dex.ParsedTx {
-	lpBurnTxs := []dex.ParsedTx{}
-	for _, t := range burnTxs {
-		if pairAddr, ok := p.lpPairAddrs[t.LpAddr]; ok {
-			t.ContractAddr = pairAddr
-			lpBurnTxs = append(lpBurnTxs, *t)
-		}
-	}
-
-	return lpBurnTxs
 }
 
 func (p *dezswapApp) IsValidationExceptionCandidate(contractAddress string) bool {

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -77,8 +77,8 @@ func Test_ParseTxs(t *testing.T) {
 		},
 		{
 			logStrs:  []string{withdrawLogStr},
-			expected: []dex.ParsedTx{withdrawTx, lpBurnTx},
-			desc:     "withdraw log produces withdraw tx and lp burn tx",
+			expected: []dex.ParsedTx{withdrawTx},
+			desc:     "withdraw log produces withdraw tx; lp burn from pair contract is filtered out",
 		},
 	}
 
@@ -110,35 +110,6 @@ func Test_IsValidationExceptionCandidate(t *testing.T) {
 	assert.False(t, app.IsValidationExceptionCandidate(""))
 }
 
-func Test_CollectLpBurnTxs(t *testing.T) {
-	tcs := []struct {
-		burnTxs  []*dex.ParsedTx
-		expected []dex.ParsedTx
-		desc     string
-	}{
-		{
-			burnTxs:  []*dex.ParsedTx{{LpAddr: lpAddr, LpAmount: "-1000"}},
-			expected: []dex.ParsedTx{{LpAddr: lpAddr, ContractAddr: pairAddr, LpAmount: "-1000"}},
-			desc:     "known LP addr → pair contract addr assigned",
-		},
-		{
-			burnTxs:  []*dex.ParsedTx{{LpAddr: "unknown_lp", LpAmount: "-1000"}},
-			expected: []dex.ParsedTx{},
-			desc:     "unknown LP addr → filtered out",
-		},
-		{
-			burnTxs:  []*dex.ParsedTx{},
-			expected: []dex.ParsedTx{},
-			desc:     "empty input → empty output",
-		},
-	}
-
-	lpPairAddrs := map[string]string{lpAddr: pairAddr}
-	for _, tc := range tcs {
-		assert.Equal(t, tc.expected, dex.CollectLpBurnTxs(tc.burnTxs, lpPairAddrs), tc.desc)
-	}
-}
-
 var (
 	swapTx = dex.ParsedTx{
 		Hash: txHash, Timestamp: time.Time{},
@@ -166,13 +137,6 @@ var (
 			{Addr: asset2, Amount: "-1097303402006688516"},
 		},
 		LpAddr: lpAddr, LpAmount: "1098669138945462355",
-	}
-	// burn event inside the withdraw log: LP tokens destroyed at the pair contract
-	lpBurnTx = dex.ParsedTx{
-		Hash: txHash, Timestamp: time.Time{},
-		Type: dex.LpBurn, Sender: pairAddr, ContractAddr: pairAddr,
-		Assets: [2]dex.Asset{{}, {}},
-		LpAddr: lpAddr, LpAmount: "-1098669138945462355",
 	}
 )
 

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -1,39 +1,308 @@
 package dezswap
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
+	"time"
 
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
-func Test_collectLpBurnTxs(t *testing.T) {
-	app := &dezswapApp{
-		lpPairAddrs: map[string]string{
-			"LpToken": "PairContract",
+const (
+	txSender = "sender"
+	txHash   = "hash"
+
+	// real addresses from logfinders_test.go in pkg/dex/dezswap
+	pairAddr = "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"
+	lpAddr   = "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"
+	asset1   = "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"
+	asset2   = "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"
+	chainId  = "cube_47-5"
+)
+
+var testPair = dex.Pair{ContractAddr: pairAddr, LpAddr: lpAddr, Assets: []string{asset1, asset2}}
+
+func Test_ParseTxs(t *testing.T) {
+	type testcase struct {
+		logStrs  []string
+		expected []dex.ParsedTx
+		desc     string
+	}
+
+	// height < TestnetV2Height(2975818) -> v1 mapper (no refund_assets in provide)
+	const height = uint64(100)
+
+	setUp := func() dex.DexParserApp {
+		createPairParser := dex.ParserMock{}
+		repo := dex.RepoMock{}
+		rawStore := dex.RawStoreMock{}
+
+		createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return([]*dex.ParsedTx{}, nil)
+
+		app := dezswapApp{
+			PairRepo:    &repo,
+			Parsers:     &dex.PairParsers{CreatePairParser: &createPairParser},
+			DexMixin:    dex.DexMixin{},
+			chainId:     chainId,
+			pairs:       map[string]dex.Pair{pairAddr: testPair},
+			lpPairAddrs: map[string]string{lpAddr: pairAddr},
+		}
+		dexApp := dex.NewDexApp(&app, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{})
+		return dexApp.(dex.DexParserApp)
+	}
+
+	tcs := []testcase{
+		{
+			logStrs:  nil,
+			expected: []dex.ParsedTx{},
+			desc:     "empty logs produce no txs",
+		},
+		{
+			logStrs:  []string{swapLogStr},
+			expected: []dex.ParsedTx{swapTx},
+			desc:     "swap log produces one swap tx",
+		},
+		{
+			logStrs:  []string{provideLogStr},
+			expected: []dex.ParsedTx{provideTx},
+			desc:     "provide log produces one provide tx; wasm transfers are deduplicated",
+		},
+		{
+			logStrs:  []string{withdrawLogStr},
+			expected: []dex.ParsedTx{withdrawTx, lpBurnTx},
+			desc:     "withdraw log produces withdraw tx and lp burn tx",
 		},
 	}
 
+	for idx, tc := range tcs {
+		assert := assert.New(t)
+		msg := fmt.Sprintf("tc(%d): %s", idx, tc.desc)
+
+		app := setUp()
+
+		logs := eventlog.LogResults{}
+		for _, s := range tc.logStrs {
+			var results eventlog.LogResults
+			if err := json.Unmarshal([]byte(s), &results); err != nil {
+				t.Fatal(err)
+			}
+			logs = append(logs, results...)
+		}
+
+		tx := parser.RawTx{Sender: txSender, Hash: txHash, LogResults: logs}
+		txs, err := app.ParseTxs(tx, height)
+		assert.NoError(err, msg)
+		assert.Equal(tc.expected, txs, msg)
+	}
+}
+
+func Test_IsValidationExceptionCandidate(t *testing.T) {
+	app := &dezswapApp{}
+	assert.False(t, app.IsValidationExceptionCandidate("any_address"))
+	assert.False(t, app.IsValidationExceptionCandidate(""))
+}
+
+func Test_CollectLpBurnTxs(t *testing.T) {
 	tcs := []struct {
 		burnTxs  []*dex.ParsedTx
 		expected []dex.ParsedTx
-		errMsg   string
+		desc     string
 	}{
 		{
-			burnTxs:  []*dex.ParsedTx{{LpAddr: "LpToken", LpAmount: "-1000"}},
-			expected: []dex.ParsedTx{{LpAddr: "LpToken", ContractAddr: "PairContract", LpAmount: "-1000"}},
-			errMsg:   "known LP addr must be collected with pair contract addr assigned",
+			burnTxs:  []*dex.ParsedTx{{LpAddr: lpAddr, LpAmount: "-1000"}},
+			expected: []dex.ParsedTx{{LpAddr: lpAddr, ContractAddr: pairAddr, LpAmount: "-1000"}},
+			desc:     "known LP addr → pair contract addr assigned",
 		},
 		{
-			burnTxs:  []*dex.ParsedTx{{LpAddr: "UnknownLpToken", LpAmount: "-1000"}},
+			burnTxs:  []*dex.ParsedTx{{LpAddr: "unknown_lp", LpAmount: "-1000"}},
 			expected: []dex.ParsedTx{},
-			errMsg:   "unknown LP addr must be filtered out",
+			desc:     "unknown LP addr → filtered out",
+		},
+		{
+			burnTxs:  []*dex.ParsedTx{},
+			expected: []dex.ParsedTx{},
+			desc:     "empty input → empty output",
 		},
 	}
 
+	lpPairAddrs := map[string]string{lpAddr: pairAddr}
 	for _, tc := range tcs {
-		assert := assert.New(t)
-		result := app.collectLpBurnTxs(tc.burnTxs)
-		assert.Equal(tc.expected, result, tc.errMsg)
+		assert.Equal(t, tc.expected, dex.CollectLpBurnTxs(tc.burnTxs, lpPairAddrs), tc.desc)
 	}
 }
+
+var (
+	swapTx = dex.ParsedTx{
+		Hash: txHash, Timestamp: time.Time{},
+		Type: dex.Swap, Sender: txSender, ContractAddr: pairAddr,
+		Assets: [2]dex.Asset{
+			{Addr: asset1, Amount: "-37175064560952362156"},
+			{Addr: asset2, Amount: "36691384354750000000"},
+		},
+		CommissionAmount: "111860776010889756",
+	}
+	provideTx = dex.ParsedTx{
+		Hash: txHash, Timestamp: time.Time{},
+		Type: dex.Provide, Sender: txSender, ContractAddr: pairAddr,
+		Assets: [2]dex.Asset{
+			{Addr: asset1, Amount: "1000000000000000000000"},
+			{Addr: asset2, Amount: "1000000000000000000000"},
+		},
+		LpAddr: lpAddr, LpAmount: "1000000000000000000000",
+	}
+	withdrawTx = dex.ParsedTx{
+		Hash: txHash, Timestamp: time.Time{},
+		Type: dex.Withdraw, Sender: txSender, ContractAddr: pairAddr,
+		Assets: [2]dex.Asset{
+			{Addr: asset1, Amount: "-1100109276349974322"},
+			{Addr: asset2, Amount: "-1097303402006688516"},
+		},
+		LpAddr: lpAddr, LpAmount: "1098669138945462355",
+	}
+	// burn event inside the withdraw log: LP tokens destroyed at the pair contract
+	lpBurnTx = dex.ParsedTx{
+		Hash: txHash, Timestamp: time.Time{},
+		Type: dex.LpBurn, Sender: pairAddr, ContractAddr: pairAddr,
+		Assets: [2]dex.Asset{{}, {}},
+		LpAddr: lpAddr, LpAmount: "-1098669138945462355",
+	}
+)
+
+// log strings are taken from pkg/dex/dezswap/logfinders_test.go
+const swapLogStr = `[
+    {
+        "type": "execute",
+        "attributes": [
+            {"key": "_contract_address", "value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "_contract_address", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "_contract_address", "value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"}
+        ]},
+    {
+        "type": "message",
+        "attributes": [
+            {"key": "action", "value": "/cosmwasm.wasm.v1.MsgExecuteContract"},
+            {"key": "module", "value": "wasm"},
+            {"key": "sender", "value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"}
+        ]},
+    {
+        "type": "wasm",
+        "attributes": [
+            {"key": "_contract_address", "value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "action", "value": "send"},
+            {"key": "from", "value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "to", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "amount", "value": "36691384354750000000"},
+            {"key": "_contract_address", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "action", "value": "swap"},
+            {"key": "ask_asset", "value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"},
+            {"key": "commission_amount", "value": "111860776010889756"},
+            {"key": "offer_amount", "value": "36691384354750000000"},
+            {"key": "offer_asset", "value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "receiver", "value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "return_amount", "value": "37175064560952362156"},
+            {"key": "sender", "value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "spread_amount", "value": "1360327158956032802"},
+            {"key": "_contract_address", "value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"},
+            {"key": "action", "value": "transfer"},
+            {"key": "amount", "value": "37175064560952362156"},
+            {"key": "from", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "to", "value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"}
+        ]}
+]`
+
+const provideLogStr = `[
+    {
+        "type": "execute",
+        "attributes": [
+            {"key": "_contract_address","value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "_contract_address","value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"},
+            {"key": "_contract_address","value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "_contract_address","value": "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"}]},
+    {
+        "type": "message",
+        "attributes": [
+            {"key": "action","value": "/cosmwasm.wasm.v1.MsgExecuteContract"},
+            {"key": "module","value": "wasm"},
+            {"key": "sender","value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"}]},
+    {
+        "type": "wasm",
+        "attributes": [
+            {"key": "_contract_address","value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "action","value": "provide_liquidity"},
+            {"key": "sender","value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "receiver","value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "assets","value": "1000000000000000000000xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm, 1000000000000000000000xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "share","value": "1000000000000000000000"},
+            {"key": "_contract_address","value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"},
+            {"key": "action","value": "transfer_from"},
+            {"key": "amount","value": "1000000000000000000000"},
+            {"key": "by","value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "from","value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "to","value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "_contract_address","value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "action","value": "transfer_from"},
+            {"key": "amount","value": "1000000000000000000000"},
+            {"key": "by","value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "from","value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"},
+            {"key": "to","value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "_contract_address","value": "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"},
+            {"key": "action","value": "mint"},
+            {"key": "amount","value": "1000000000000000000000"},
+            {"key": "to","value": "xpla190465x8qz4p7uxylrmwcn8rufkv30j655h6h7q"}]}
+]`
+
+const withdrawLogStr = `[
+    {
+        "type": "execute",
+        "attributes": [
+            {"key": "_contract_address", "value": "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"},
+            {"key": "_contract_address", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "_contract_address", "value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"},
+            {"key": "_contract_address", "value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "_contract_address", "value": "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"}
+        ]},
+    {
+        "type": "message",
+        "attributes": [
+            {"key": "action", "value": "/cosmwasm.wasm.v1.MsgExecuteContract"},
+            {"key": "module", "value": "wasm"},
+            {"key": "sender", "value": "xpla1s4gljj0ksjkhh5vsk3lvw2s9rpflyq6k7e575x"}
+        ]},
+    {
+        "type": "wasm",
+        "attributes": [
+            {"key": "_contract_address", "value": "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"},
+            {"key": "action", "value": "send"},
+            {"key": "from", "value": "xpla1s4gljj0ksjkhh5vsk3lvw2s9rpflyq6k7e575x"},
+            {"key": "to", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "amount", "value": "1098669138945462355"},
+            {"key": "_contract_address", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "action", "value": "withdraw_liquidity"},
+            {"key": "refund_assets", "value": "1100109276349974322xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm, 1097303402006688516xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "sender", "value": "xpla1s4gljj0ksjkhh5vsk3lvw2s9rpflyq6k7e575x"},
+            {"key": "withdrawn_share", "value": "1098669138945462355"},
+            {"key": "_contract_address", "value": "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm"},
+            {"key": "action", "value": "transfer"},
+            {"key": "amount", "value": "1100109276349974322"},
+            {"key": "from", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "to", "value": "xpla1s4gljj0ksjkhh5vsk3lvw2s9rpflyq6k7e575x"},
+            {"key": "_contract_address", "value": "xpla1v2ezcmgzmvwdtp9m0nyfy38p85dnkn0excnyy6dqylm65fhft0qsrzmktv"},
+            {"key": "action", "value": "transfer"},
+            {"key": "amount", "value": "1097303402006688516"},
+            {"key": "from", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"},
+            {"key": "to", "value": "xpla1s4gljj0ksjkhh5vsk3lvw2s9rpflyq6k7e575x"},
+            {"key": "_contract_address", "value": "xpla1aye7rggr2w0dgpwuwul0y6nyxau2k5jjrpmrxtkcvsd7nlx2nz0su357u5"},
+            {"key": "action", "value": "burn"},
+            {"key": "amount", "value": "1098669138945462355"},
+            {"key": "from", "value": "xpla1ng9mj65a5cunzvkdqctgsv3pewgrx2hvk9tnrww77v3tk2lp7c9qllk0xh"}
+        ]
+    }
+]`

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -18,7 +18,8 @@ type starfleitApp struct {
 	chainId string
 
 	// state
-	pairs map[string]dex.Pair
+	pairs       map[string]dex.Pair
+	lpPairAddrs map[string]string
 }
 
 var _ dex.TargetApp = &starfleitApp{}
@@ -42,14 +43,19 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig, ch
 		return nil, errors.Wrap(err, "starfleit.New")
 	}
 
-	return &starfleitApp{repo, parsers, dex.DexMixin{}, chainId, pairs}, nil
+	lpPairAddrs := make(map[string]string)
+	for _, p := range pairs {
+		lpPairAddrs[p.LpAddr] = p.ContractAddr
+	}
+
+	return &starfleitApp{repo, parsers, dex.DexMixin{}, chainId, pairs, lpPairAddrs}, nil
 }
 
 func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "parseTxs")
+		return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
 	}
 	for _, ctx := range createPairTxs {
 		p.pairs[ctx.ContractAddr] = dex.Pair{
@@ -57,21 +63,23 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			LpAddr:       ctx.LpAddr,
 			Assets:       []string{ctx.Assets[0].Addr, ctx.Assets[1].Addr},
 		}
+		p.lpPairAddrs[ctx.LpAddr] = ctx.ContractAddr
 		ctx.Sender = tx.Sender
 		txDtos = append(txDtos, *ctx)
 	}
 
 	if err := p.updateParsers(p.pairs, height); err != nil {
-		return nil, errors.Wrap(err, "parseTxs")
+		return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
 	}
 
 	pairTxs := []*dex.ParsedTx{}
 	wasmTxs := []*dex.ParsedTx{}
 	transferTxs := []*dex.ParsedTx{}
+	burnTxs := []*dex.ParsedTx{}
 	for _, raw := range tx.LogResults {
 		ptxs, err := p.Parsers.PairActionParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
 		}
 		pairTxs = append(pairTxs, ptxs...)
 
@@ -79,7 +87,7 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		if p.HasProvide(ptxs) {
 			ipTxs, err := p.Parsers.InitialProvide.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 			if err != nil {
-				return nil, errors.Wrap(err, "parseTxs")
+				return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
 			}
 			pairTxs = append(pairTxs, ipTxs...)
 		}
@@ -87,15 +95,21 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		// find transfer from user
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
 		}
 		transferTxs = append(transferTxs, transfers...)
+
+		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if err != nil {
+			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+		}
+		burnTxs = append(burnTxs, burns...)
 	}
 	for _, ptx := range pairTxs {
 		ptx.Sender = tx.Sender
@@ -103,6 +117,7 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	}
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil
 }
@@ -145,5 +160,15 @@ func (p *starfleitApp) updateParsers(pairs map[string]dex.Pair, height uint64) e
 		return errors.Wrap(err, "updateParsers")
 	}
 	p.Parsers.Transfer = parser.NewParser[dex.ParsedTx](transferRule, &transferMapper{pairSet: pairs})
+
+	// burn parser - to collect and parse LP burn event
+	{
+		burnRule, err := sf.CreateBurnRuleFinder()
+		if err != nil {
+			return errors.Wrap(err, "updateParser")
+		}
+		p.Parsers.BurnParser = parser.NewParser(burnRule, dex.NewBurnMapper())
+	}
+
 	return nil
 }

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -21,6 +21,7 @@ type terraswapApp struct {
 
 	// state
 	pairs         map[string]dex.Pair
+	lpPairAddrs   map[string]string
 	flaggedAssets map[string]bool
 }
 
@@ -51,7 +52,12 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 		return nil, errors.Wrap(err, "columbusv2.New")
 	}
 
-	return &terraswapApp{repo, &parsers, dex.DexMixin{}, pairs, make(map[string]bool)}, nil
+	lpPairAddrs := make(map[string]string)
+	for _, p := range pairs {
+		lpPairAddrs[p.LpAddr] = p.ContractAddr
+	}
+
+	return &terraswapApp{repo, &parsers, dex.DexMixin{}, pairs, lpPairAddrs, make(map[string]bool)}, nil
 }
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
@@ -67,6 +73,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			LpAddr:       ctx.LpAddr,
 			Assets:       []string{ctx.Assets[0].Addr, ctx.Assets[1].Addr},
 		}
+		p.lpPairAddrs[ctx.LpAddr] = ctx.ContractAddr
 		ctx.Sender = tx.Sender
 		txDtos = append(txDtos, *ctx)
 	}
@@ -79,6 +86,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	wasmTxs := []*dex.ParsedTx{}
 	taxTxs := []*dex.ParsedTx{}
 	transferTxs := []*dex.ParsedTx{}
+	burnTxs := []*dex.ParsedTx{}
 	for _, raw := range tx.LogResults {
 		if !pdex.ParsableRules[string(raw.Type)] {
 			continue
@@ -127,6 +135,12 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
 		}
 		transferTxs = append(transferTxs, transfers...)
+
+		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if err != nil {
+			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+		}
+		burnTxs = append(burnTxs, burns...)
 	}
 
 	// Originally, tax_amount in wasm was used to deduct the tax(parser.dex.terraswap.columbusv2.pairMapper.swapMatchedToParsedTx).
@@ -145,6 +159,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil
 }
@@ -275,6 +290,15 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 		return errors.Wrap(err, "updateParsers")
 	}
 	p.Parsers.Transfer = parser.NewParser(transferRule, dex.NewTransferMapper(pairs))
+
+	// burn parser - to collect and parse LP burn event
+	{
+		burnRule, err := columbusv2.CreateBurnRuleFinder()
+		if err != nil {
+			return errors.Wrap(err, "updateParser")
+		}
+		p.Parsers.BurnParser = parser.NewParser(burnRule, dex.NewBurnMapper())
+	}
 
 	return nil
 }

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -64,7 +64,7 @@ func Test_parseTxs(t *testing.T) {
 
 		taxPaymentParser := dex.ParserMock{}
 		taxPaymentParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return([]*dex.ParsedTx{}, nil)
-		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser, TaxPaymentParser: &taxPaymentParser}, dex.DexMixin{}, pairMap, make(map[string]bool)}
+		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser, TaxPaymentParser: &taxPaymentParser}, dex.DexMixin{}, pairMap, make(map[string]string), make(map[string]bool)}
 		dexApp := dex.NewDexApp(&app, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{FactoryAddress: factoryAddr})
 
 		createTxs = []*dex.ParsedTx{}

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -19,6 +19,7 @@ type terraswapApp struct {
 
 	// state
 	pairs         map[string]dex.Pair
+	lpPairAddrs   map[string]string
 	flaggedAssets map[string]bool
 }
 
@@ -43,7 +44,12 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 		return nil, errors.Wrap(err, "phoenix.New")
 	}
 
-	return &terraswapApp{repo, &parsers, dex.DexMixin{}, pairs, make(map[string]bool)}, nil
+	lpPairAddrs := make(map[string]string)
+	for _, p := range pairs {
+		lpPairAddrs[p.LpAddr] = p.ContractAddr
+	}
+
+	return &terraswapApp{repo, &parsers, dex.DexMixin{}, pairs, lpPairAddrs, make(map[string]bool)}, nil
 }
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
@@ -58,6 +64,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			LpAddr:       ctx.LpAddr,
 			Assets:       []string{ctx.Assets[0].Addr, ctx.Assets[1].Addr},
 		}
+		p.lpPairAddrs[ctx.LpAddr] = ctx.ContractAddr
 		ctx.Sender = tx.Sender
 		txDtos = append(txDtos, *ctx)
 	}
@@ -69,6 +76,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	pairTxs := []*dex.ParsedTx{}
 	wasmTxs := []*dex.ParsedTx{}
 	transferTxs := []*dex.ParsedTx{}
+	burnTxs := []*dex.ParsedTx{}
 	for _, raw := range tx.LogResults {
 		if !pdex.ParsableRules[string(raw.Type)] {
 			continue
@@ -110,6 +118,12 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
 		}
 		transferTxs = append(transferTxs, transfers...)
+
+		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if err != nil {
+			return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+		}
+		burnTxs = append(burnTxs, burns...)
 	}
 	for _, ptx := range pairTxs {
 		ptx.Sender = tx.Sender
@@ -118,6 +132,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil
 }
@@ -154,5 +169,15 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 		return errors.Wrap(err, "updateParsers")
 	}
 	p.Parsers.Transfer = parser.NewParser[dex.ParsedTx](transferRule, dex.NewTransferMapper(pairs))
+
+	// burn parser - to collect and parse LP burn event
+	{
+		burnRule, err := pdex.CreateBurnRuleFinder()
+		if err != nil {
+			return errors.Wrap(err, "updateParser")
+		}
+		p.Parsers.BurnParser = parser.NewParser(burnRule, dex.NewBurnMapper())
+	}
+
 	return nil
 }

--- a/parser/dex/terraswap/phoenix/app_test.go
+++ b/parser/dex/terraswap/phoenix/app_test.go
@@ -61,7 +61,7 @@ func Test_parseTxs(t *testing.T) {
 			pairMap[p.ContractAddr] = p
 		}
 
-		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}, pairMap, make(map[string]bool)}
+		app := terraswapApp{&repo, &dex.PairParsers{CreatePairParser: &createPairParser}, dex.DexMixin{}, pairMap, make(map[string]string), make(map[string]bool)}
 		dexApp := dex.NewDexApp(&app, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{FactoryAddress: factoryAddr})
 
 		createTxs = []*dex.ParsedTx{}

--- a/pkg/dex/starfleit/logfinders.go
+++ b/pkg/dex/starfleit/logfinders.go
@@ -1,6 +1,7 @@
 package starfleit
 
 import (
+	"github.com/dezswap/cosmwasm-etl/pkg/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 )
 
@@ -158,4 +159,17 @@ var initialProvideRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.
 	}},
 	eventlog.RuleItem{Key: "amount", Filter: nil},
 	eventlog.RuleItem{Key: "to", Filter: nil},
+}}
+
+func CreateBurnRuleFinder() (eventlog.LogFinder, error) {
+	return eventlog.NewLogFinder(burnRule)
+}
+
+var burnRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{
+	eventlog.RuleItem{Key: dex.BurnAddrKey, Filter: nil},
+	eventlog.RuleItem{Key: dex.BurnActionKey, Filter: func(v string) bool {
+		return v == "burn"
+	}},
+	eventlog.RuleItem{Key: dex.BurnFromKey, Filter: nil},
+	eventlog.RuleItem{Key: dex.BurnAmountKey, Filter: nil},
 }}

--- a/pkg/dex/terraswap/columbusv2/logfinders.go
+++ b/pkg/dex/terraswap/columbusv2/logfinders.go
@@ -88,3 +88,16 @@ var taxPaymentRule = eventlog.Rule{Type: eventlog.TaxPaymentType, Items: eventlo
 	eventlog.RuleItem{Key: "reverse_charge", Filter: nil},
 	eventlog.RuleItem{Key: "tax_amount", Filter: nil},
 }}
+
+func CreateBurnRuleFinder() (eventlog.LogFinder, error) {
+	return eventlog.NewLogFinder(burnRule)
+}
+
+var burnRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{
+	eventlog.RuleItem{Key: dex.BurnAddrKey, Filter: nil},
+	eventlog.RuleItem{Key: dex.BurnActionKey, Filter: func(v string) bool {
+		return v == "burn"
+	}},
+	eventlog.RuleItem{Key: dex.BurnFromKey, Filter: nil},
+	eventlog.RuleItem{Key: dex.BurnAmountKey, Filter: nil},
+}}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
LP Burn type event parsing was previously implemented for Dezswap in https://github.com/dezswap/cosmwasm-etl/pull/94, but has not yet been applied to other apps. In particular, Starfleit(ASI Alliance, fetchhub) and Terraswap(Terraclassic, columbus v2) have slight differences in attribute ordering, making the existing implementation incompatible as-is.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Added LP burn type parsers for each app and integrated them into the parsing stage
- Extracted the function `CollectLpBurnTxs` from Dezswap into a shared
- Implemented finder rules for Starfleit and Terraswap(columbusv2) to handle differences in attribute ordering

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
