### PR TITLE
fix: prevent false alarm for no new height

### DIFF
--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	stdErr "errors"
+	"errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -13,8 +13,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/collector/datastore"
 	"github.com/dezswap/cosmwasm-etl/configs"
 	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
-	"github.com/pkg/errors"
-
 	pds "github.com/dezswap/cosmwasm-etl/parser/dex/dezswap"
 	"github.com/dezswap/cosmwasm-etl/parser/dex/repo"
 	"github.com/dezswap/cosmwasm-etl/parser/dex/srcstore"
@@ -128,7 +126,7 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 			terraswapQueryClient := dts_colv1.NewCol4Client(lcd)
 			rawDataStore = ts_srcstore.NewCol4Store(c.FactoryAddress, r, lcd, terraswapQueryClient)
 		default:
-			panic(errors.Errorf("invalid factory address: %s", c.FactoryAddress))
+			panic(fmt.Errorf("invalid factory address: %s", c.FactoryAddress))
 		}
 	} else {
 		rawDataStore = srcstore.New(readStore)
@@ -139,7 +137,7 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 	const BLOCK_SECONDS = 5 * time.Second
 	for errCount := uint(0); errCount <= c.ErrTolerance; {
 		if err := runner.Run(); err != nil {
-			if stdErr.Is(err, p_dex.ErrNoNewHeight) {
+			if errors.Is(err, p_dex.ErrNoNewHeight) {
 				logger.Infof("no new block yet: %s", err)
 			} else {
 				errCount++

--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	stdErr "errors"
 	"fmt"
 	"math"
 	"net/http"
@@ -138,8 +139,12 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 	const BLOCK_SECONDS = 5 * time.Second
 	for errCount := uint(0); errCount <= c.ErrTolerance; {
 		if err := runner.Run(); err != nil {
-			errCount++
-			logger.Errorf("errCount: %d, err: %s", errCount, err)
+			if stdErr.Is(err, p_dex.ErrNoNewHeight) {
+				logger.Infof("no new block yet: %s", err)
+			} else {
+				errCount++
+				logger.Errorf("errCount: %d, err: %s", errCount, err)
+			}
 		} else {
 			errCount = 0
 		}

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -1,6 +1,7 @@
 package dex
 
 import (
+	stdErr "errors"
 	"fmt"
 	"strings"
 
@@ -9,6 +10,11 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/pkg/errors"
 )
+
+// ErrNoNewHeight is returned when the remote node height has not advanced for
+// sameHeightTolerance consecutive checks. Callers should treat this as a
+// transient "wait for next block" condition, not a hard error.
+var ErrNoNewHeight = stdErr.New("no new height")
 
 type PairParsers struct {
 	CreatePairParser parser.Parser[ParsedTx]
@@ -160,8 +166,7 @@ func (app *dexApp) checkRemoteHeight(srcHeight uint64) error {
 	if srcHeight == app.lastSrcHeight {
 		app.sameHeightCount++
 		if app.sameHeightCount > app.sameHeightTolerance {
-			errMsg := fmt.Sprintf("remote node height(%d) remains the same for %d consecutive times", srcHeight, app.sameHeightCount)
-			return errors.New(errMsg)
+			return fmt.Errorf("remote node height(%d) remains the same for %d consecutive times: %w", srcHeight, app.sameHeightCount, ErrNoNewHeight)
 		}
 	} else {
 		app.sameHeightCount = 0

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -1,20 +1,19 @@
 package dex
 
 import (
-	stdErr "errors"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
-	"github.com/pkg/errors"
 )
 
 // ErrNoNewHeight is returned when the remote node height has not advanced for
 // sameHeightTolerance consecutive checks. Callers should treat this as a
 // transient "wait for next block" condition, not a hard error.
-var ErrNoNewHeight = stdErr.New("no new height")
+var ErrNoNewHeight = errors.New("no new height")
 
 type PairParsers struct {
 	CreatePairParser parser.Parser[ParsedTx]
@@ -63,12 +62,12 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 func (app *dexApp) Run() error {
 	localSynced, err := app.GetSyncedHeight()
 	if err != nil {
-		return errors.Wrap(err, "app.Run")
+		return fmt.Errorf("app.Run: %w", err)
 	}
 
 	srcHeight, err := app.GetSourceSyncedHeight()
 	if err != nil {
-		return errors.Wrap(err, "app.Run")
+		return fmt.Errorf("app.Run: %w", err)
 	}
 
 	if srcHeight < localSynced {
@@ -76,17 +75,17 @@ func (app *dexApp) Run() error {
 	}
 
 	if err := app.checkRemoteHeight(srcHeight); err != nil {
-		return errors.Wrap(err, "app.Run")
+		return fmt.Errorf("app.Run: %w", err)
 	}
 
 	// to avoid skipping validation error
 	if (localSynced % uint64(app.validationInterval)) == 0 {
 		poolInfos, err := app.GetPoolInfos((localSynced))
 		if err != nil {
-			return errors.Wrap(err, "app.Run")
+			return fmt.Errorf("app.Run: %w", err)
 		}
 		if err := app.validate(0, (localSynced), poolInfos); err != nil {
-			return errors.Wrap(err, "app.Run")
+			return fmt.Errorf("app.Run: %w", err)
 		}
 	}
 
@@ -98,14 +97,14 @@ func (app *dexApp) Run() error {
 				app.logger.Infof("remote node is indexing tx_results, skip")
 				return nil
 			}
-			return errors.Wrap(err, "app.Run")
+			return fmt.Errorf("app.Run: %w", err)
 		}
 
 		parsedTxs := []ParsedTx{}
 		for _, tx := range txs {
 			txs, err := app.ParseTxs(tx, cur)
 			if err != nil {
-				return errors.Wrap(err, "app.Run")
+				return fmt.Errorf("app.Run: %w", err)
 			}
 			parsedTxs = append(parsedTxs, txs...)
 		}
@@ -114,23 +113,23 @@ func (app *dexApp) Run() error {
 		if (cur % uint64(app.poolSnapshotInterval)) == 0 {
 			poolInfos, err = app.GetPoolInfos(cur)
 			if err != nil {
-				return errors.Wrap(err, "app.Run")
+				return fmt.Errorf("app.Run: %w", err)
 			}
 		}
 
 		if err := app.insert(cur-1, cur, parsedTxs, poolInfos); err != nil {
-			return errors.Wrap(err, "app.Run")
+			return fmt.Errorf("app.Run: %w", err)
 		}
 
 		if (cur % uint64(app.validationInterval)) == 0 {
 			if len(poolInfos) == 0 {
 				poolInfos, err = app.GetPoolInfos(cur)
 				if err != nil {
-					return errors.Wrap(err, "app.Run")
+					return fmt.Errorf("app.Run: %w", err)
 				}
 			}
 			if err := app.validate(0, cur, poolInfos); err != nil {
-				return errors.Wrap(err, "app.Run")
+				return fmt.Errorf("app.Run: %w", err)
 			}
 		}
 	}
@@ -155,7 +154,7 @@ func (app *dexApp) insert(srcHeight uint64, targetHeight uint64, txs []ParsedTx,
 
 	err := app.Insert(srcHeight, targetHeight, txs, pools, pairDtos)
 	if err != nil {
-		return errors.Wrap(err, "insert")
+		return fmt.Errorf("insert: %w", err)
 	}
 
 	return nil
@@ -185,7 +184,7 @@ func (app *dexApp) validate(from, to uint64, expected []PoolInfo) error {
 	// e.g.) expected pools can be difference between pool of height 1000 and 900
 	actual, err := app.ParsedPoolsInfo(from, to)
 	if err != nil {
-		return errors.Wrap(err, "dexApp.validate")
+		return fmt.Errorf("dexApp.validate: %w", err)
 	}
 
 	expectedPool := make(map[string]PoolInfo)
@@ -195,7 +194,7 @@ func (app *dexApp) validate(from, to uint64, expected []PoolInfo) error {
 
 	exceptions, err := app.ValidationExceptionList()
 	if err != nil {
-		return errors.Wrap(err, "dexApp.validate")
+		return fmt.Errorf("dexApp.validate: %w", err)
 	}
 	exceptionMap := make(map[string]bool)
 	for _, addr := range exceptions {
@@ -209,7 +208,7 @@ func (app *dexApp) validate(from, to uint64, expected []PoolInfo) error {
 		}
 		exp, ok := expectedPool[pool.ContractAddr]
 		if !ok {
-			return errors.New(fmt.Sprintf("unexpected pool(%s) found", pool.ContractAddr))
+			return fmt.Errorf("unexpected pool(%s) found", pool.ContractAddr)
 		}
 		if err := app.comparePair(pool, exp); err != nil {
 			return err
@@ -222,7 +221,7 @@ func (app *dexApp) validate(from, to uint64, expected []PoolInfo) error {
 		for _, pool := range expectedPool {
 			addrs = append(addrs, pool.ContractAddr)
 		}
-		return errors.New(fmt.Sprintf("expected pools(%s) not found", addrs))
+		return fmt.Errorf("expected pools(%s) not found", addrs)
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The parser currently uses an error return to trigger a sleep-and-retry when it reaches the latest block height. While functional, this error propagates without special handling and causes false-positive error alerts.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Introduced a dedicated “no new height” error
- Added handling to check this case before logging errors, and sleep instead
- Replaced `github.com/pkg/errors` to `errors`

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
