### PR TITLE
feat: add token-level exception list

### DIFF
--- a/db/migrations/parser/20260414182230_token_parse_exception.down.sql
+++ b/db/migrations/parser/20260414182230_token_parse_exception.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP TABLE IF EXISTS "token_parse_exception";
+COMMIT;

--- a/db/migrations/parser/20260414182230_token_parse_exception.up.sql
+++ b/db/migrations/parser/20260414182230_token_parse_exception.up.sql
@@ -1,0 +1,8 @@
+BEGIN;
+CREATE TABLE "token_parse_exception" (
+  "id"       BIGSERIAL NOT NULL PRIMARY KEY,
+  "chain_id" VARCHAR   NOT NULL, CHECK("chain_id" <> ''),
+  "contract" VARCHAR   NOT NULL, CHECK("contract" <> ''),
+  CONSTRAINT token_parse_exception_unique UNIQUE ("chain_id", "contract")
+);
+COMMIT;

--- a/parser/checkpoint/builder_test.go
+++ b/parser/checkpoint/builder_test.go
@@ -1,12 +1,13 @@
 package checkpoint
 
 import (
-	"github.com/dezswap/cosmwasm-etl/parser"
-	"github.com/dezswap/cosmwasm-etl/parser/dex"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/stretchr/testify/assert"
 )
 
 // MockRepo implements pdex.Repo for testing
@@ -33,6 +34,10 @@ func (m *MockRepo) InsertPairValidationException(_ string, _ string) error {
 
 func (m *MockRepo) GetPairs() (map[string]dex.Pair, error) {
 	return nil, nil
+}
+
+func (m *MockRepo) GetTokenExceptions() (map[string]bool, error) {
+	return map[string]bool{}, nil
 }
 
 func (m *MockRepo) ValidationExceptionList() ([]string, error) {

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -60,6 +60,11 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 }
 
 func (app *dexApp) Run() error {
+	tokenExceptions, err := app.GetTokenExceptions()
+	if err != nil {
+		return fmt.Errorf("app.Run: %w", err)
+	}
+
 	localSynced, err := app.GetSyncedHeight()
 	if err != nil {
 		return fmt.Errorf("app.Run: %w", err)
@@ -97,6 +102,10 @@ func (app *dexApp) Run() error {
 				app.logger.Infof("remote node is indexing tx_results, skip")
 				return nil
 			}
+			return fmt.Errorf("app.Run: %w", err)
+		}
+
+		if err := app.UpdateParsers(tokenExceptions, cur); err != nil {
 			return fmt.Errorf("app.Run: %w", err)
 		}
 

--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -69,10 +69,6 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 		txDtos = append(txDtos, *ctx)
 	}
 
-	if err := p.updateParsers(p.pairs, height); err != nil {
-		return nil, errors.Wrap(err, "parseTxs")
-	}
-
 	pairTxs := []*dex.ParsedTx{}
 	wasmTransferTxs := []*dex.ParsedTx{}
 	transferTxs := []*dex.ParsedTx{}
@@ -128,9 +124,9 @@ func (p *dezswapApp) IsValidationExceptionCandidate(contractAddress string) bool
 	return false
 }
 
-func (p *dezswapApp) updateParsers(pairs map[string]dex.Pair, height uint64) error {
+func (p *dezswapApp) UpdateParsers(tokenExceptions map[string]bool, height uint64) error {
 	pairFilter := make(map[string]bool)
-	for k := range pairs {
+	for k := range p.pairs {
 		pairFilter[k] = true
 	}
 
@@ -141,7 +137,7 @@ func (p *dezswapApp) updateParsers(pairs map[string]dex.Pair, height uint64) err
 			return errors.Wrap(err, "updateParsers")
 		}
 
-		pairMapper, err := pairMapperBy(p.chainId, height, pairs)
+		pairMapper, err := pairMapperBy(p.chainId, height, p.pairs)
 		if err != nil {
 			return errors.Wrap(err, "updateParsers")
 		}
@@ -164,7 +160,13 @@ func (p *dezswapApp) updateParsers(pairs map[string]dex.Pair, height uint64) err
 			return errors.Wrap(err, "updateParsers")
 		}
 		p.Parsers.WasmTransfer = parser.NewParser(
-			wasmTransferFinder, &wasmTransferMapper{mixin: transferMapperMixin{pdex.MapperMixin{}}, pairSet: pairs})
+			wasmTransferFinder,
+			&wasmTransferMapper{
+				mixin:           transferMapperMixin{pdex.MapperMixin{}},
+				pairSet:         p.pairs,
+				tokenExceptions: tokenExceptions,
+			},
+		)
 	}
 
 	// transfer parser
@@ -173,7 +175,7 @@ func (p *dezswapApp) updateParsers(pairs map[string]dex.Pair, height uint64) err
 		if err != nil {
 			return errors.Wrap(err, "updateParsers")
 		}
-		p.Parsers.Transfer = parser.NewParser(transferRule, &transferMapper{pairSet: pairs})
+		p.Parsers.Transfer = parser.NewParser(transferRule, &transferMapper{pairSet: p.pairs})
 	}
 
 	// burn parser - to collect and parse LP burn event

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -98,6 +98,10 @@ func Test_ParseTxs(t *testing.T) {
 		}
 
 		tx := parser.RawTx{Sender: txSender, Hash: txHash, LogResults: logs}
+
+		err := app.UpdateParsers(make(map[string]bool), uint64(height))
+		assert.NoError(err)
+
 		txs, err := app.ParseTxs(tx, height)
 		assert.NoError(err, msg)
 		assert.Equal(tc.expected, txs, msg)

--- a/parser/dex/dezswap/mappers.go
+++ b/parser/dex/dezswap/mappers.go
@@ -26,8 +26,9 @@ type transferMapper struct {
 	pairSet map[string]dex.Pair
 }
 type wasmTransferMapper struct {
-	mixin   transferMapperMixin
-	pairSet map[string]dex.Pair
+	mixin           transferMapperMixin
+	pairSet         map[string]dex.Pair
+	tokenExceptions map[string]bool
 }
 
 // match implements mapper
@@ -58,6 +59,15 @@ func (m *createPairMapper) MatchedToParsedTx(res eventlog.MatchedResult, optiona
 // match implements mapper
 func (m *wasmTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...interface{}) ([]*dex.ParsedTx, error) {
 	m.mixin.SortResult(res)
+
+	var cw20Addr string
+	if len(res) > ds.WasmCommonTransferCw20AddrIdx {
+		cw20Addr = res[ds.WasmCommonTransferCw20AddrIdx].Value
+		if m.tokenExceptions[cw20Addr] {
+			return nil, nil
+		}
+	}
+
 	action := res[ds.WasmCommonTransferActionIdx]
 
 	switch action.Value {

--- a/parser/dex/interface.go
+++ b/parser/dex/interface.go
@@ -1,6 +1,8 @@
 package dex
 
-import "github.com/dezswap/cosmwasm-etl/parser"
+import (
+	"github.com/dezswap/cosmwasm-etl/parser"
+)
 
 type DexParserApp interface {
 	Run() error
@@ -12,6 +14,7 @@ type DexParserApp interface {
 type TargetApp interface {
 	parser.TargetApp[ParsedTx]
 	IsValidationExceptionCandidate(contractAddress string) bool
+	UpdateParsers(tokenExceptions map[string]bool, height uint64) error
 }
 
 type Repo interface {

--- a/parser/dex/mapper.go
+++ b/parser/dex/mapper.go
@@ -16,9 +16,10 @@ type transferMapper struct {
 	pairSet map[string]Pair
 }
 type wasmCommonTransferMapper struct {
-	cw20AddrKey  string
-	pairSet      map[string]Pair
-	flaggedPairs map[string]bool
+	cw20AddrKey     string
+	pairSet         map[string]Pair
+	flaggedPairs    map[string]bool
+	tokenExceptions map[string]bool
 }
 
 type initialProvideMapper struct{ pdex.MapperMixin }
@@ -56,18 +57,22 @@ func (m *factoryMapper) MatchedToParsedTx(res eventlog.MatchedResult, optional .
 	}}, nil
 }
 
-func NewWasmTransferMapper(cw20AddrKey string, pairSet map[string]Pair, flaggedPairs map[string]bool) parser.Mapper[ParsedTx] {
-	return &wasmCommonTransferMapper{cw20AddrKey, pairSet, flaggedPairs}
+func NewWasmTransferMapper(cw20AddrKey string, pairSet map[string]Pair, flaggedPairs map[string]bool, tokenExceptions map[string]bool) parser.Mapper[ParsedTx] {
+	return &wasmCommonTransferMapper{cw20AddrKey, pairSet, flaggedPairs, tokenExceptions}
 }
 
 // match implements mapper
 func (m *wasmCommonTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...interface{}) ([]*ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
-	if err != nil {
-		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
+	cw20Addr := firstValueInResult(res, m.cw20AddrKey)
+	if m.tokenExceptions[cw20Addr] {
+		return nil, nil
 	}
 
-	cw20Addr := matchMap[m.cw20AddrKey].Value
+	matchMap, err := eventlog.ResultToItemMap(res)
+	if err != nil {
+		return nil, fmt.Errorf("transferMapper.MatchedToParsedTx: %w (cw20=%s)", err, cw20Addr)
+	}
+
 	for _, r := range res {
 		if strings.Contains(strings.ToLower(r.Key), pdex.WasmTransferTaxFlagPatternKey) {
 			m.flaggedPairs[cw20Addr] = true
@@ -97,6 +102,15 @@ func (m *wasmCommonTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult,
 	}
 
 	return txs, nil
+}
+
+func firstValueInResult(res eventlog.MatchedResult, key string) string {
+	for _, item := range res {
+		if item.Key == key {
+			return item.Value
+		}
+	}
+	return ""
 }
 
 func (m *wasmCommonTransferMapper) wasmTransferToParsedTx(pair Pair, cw20Addr, from, amount string, fromPair bool) *ParsedTx {

--- a/parser/dex/mappers_test.go
+++ b/parser/dex/mappers_test.go
@@ -170,7 +170,7 @@ func Test_WasmTransferMapper_FlaggedPairs(t *testing.T) {
 	pairSet := map[string]Pair{pair.ContractAddr: pair}
 	flagged := map[string]bool{}
 
-	mapper := NewWasmTransferMapper(dex.WasmTransferCw20AddrKey, pairSet, flagged)
+	mapper := NewWasmTransferMapper(dex.WasmTransferCw20AddrKey, pairSet, flagged, nil)
 	res := el.MatchedResult{
 		{Key: "_contract_address", Value: pair.Assets[0]},
 		{Key: "action", Value: "transfer"},
@@ -195,7 +195,7 @@ func Test_WasmTransferMapper_IrregularFormat(t *testing.T) {
 	pairSet := map[string]Pair{pair.ContractAddr: pair}
 	flagged := map[string]bool{}
 
-	mapper := NewWasmTransferMapper(dex.WasmTransferCw20AddrKey, pairSet, flagged)
+	mapper := NewWasmTransferMapper(dex.WasmTransferCw20AddrKey, pairSet, flagged, nil)
 	res := el.MatchedResult{
 		{Key: "_contract_address", Value: pair.Assets[0]},
 		{Key: "action", Value: "transfer"},

--- a/parser/dex/mock.go
+++ b/parser/dex/mock.go
@@ -55,6 +55,12 @@ func (m *RepoMock) GetPairs() (map[string]Pair, error) {
 	return args.Get(0).(map[string]Pair), args.Error(1)
 }
 
+// GetTokenExceptions implements Repo
+func (m *RepoMock) GetTokenExceptions() (map[string]bool, error) {
+	args := m.MethodCalled("GetTokenExceptions")
+	return args.Get(0).(map[string]bool), args.Error(1)
+}
+
 // GetSyncedHeight implements Repo
 func (m *RepoMock) GetSyncedHeight() (uint64, error) {
 	args := m.MethodCalled("GetSyncedHeight")

--- a/parser/dex/repo/repository.go
+++ b/parser/dex/repo/repository.go
@@ -160,6 +160,20 @@ func (r *repoImpl) ParsedPoolsInfo(from, to uint64) ([]dex.PoolInfo, error) {
 	return results, nil
 }
 
+// GetTokenExceptions implements dex.PairRepo.
+func (r *repoImpl) GetTokenExceptions() (map[string]bool, error) {
+	var rows []schemas.TokenParseException
+	result := r.db.Where("chain_id = ?", r.chainId).Find(&rows)
+	if result.Error != nil {
+		return nil, errors.Wrap(result.Error, "repo.GetTokenExceptions")
+	}
+	m := make(map[string]bool, len(rows))
+	for _, row := range rows {
+		m[row.Contract] = true
+	}
+	return m, nil
+}
+
 // ValidationExceptionList implements dex.Repo.
 func (r *repoImpl) ValidationExceptionList() ([]string, error) {
 	exceptions := []string{}

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -68,10 +68,6 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		txDtos = append(txDtos, *ctx)
 	}
 
-	if err := p.updateParsers(p.pairs, height); err != nil {
-		return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
-	}
-
 	pairTxs := []*dex.ParsedTx{}
 	wasmTxs := []*dex.ParsedTx{}
 	transferTxs := []*dex.ParsedTx{}
@@ -126,9 +122,9 @@ func (p *starfleitApp) IsValidationExceptionCandidate(contractAddress string) bo
 	return false
 }
 
-func (p *starfleitApp) updateParsers(pairs map[string]dex.Pair, height uint64) error {
+func (p *starfleitApp) UpdateParsers(tokenExceptions map[string]bool, height uint64) error {
 	pairFilter := make(map[string]bool)
-	for k := range pairs {
+	for k := range p.pairs {
 		pairFilter[k] = true
 	}
 
@@ -137,7 +133,7 @@ func (p *starfleitApp) updateParsers(pairs map[string]dex.Pair, height uint64) e
 		return errors.Wrap(err, "updateParsers")
 	}
 
-	pairMapper, err := pairMapperBy(p.chainId, height, pairs)
+	pairMapper, err := pairMapperBy(p.chainId, height, p.pairs)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
@@ -153,13 +149,19 @@ func (p *starfleitApp) updateParsers(pairs map[string]dex.Pair, height uint64) e
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.WasmTransfer = parser.NewParser[dex.ParsedTx](wasmTransferFinder, &wasmTransferMapper{pairSet: pairs})
+	p.Parsers.WasmTransfer = parser.NewParser[dex.ParsedTx](
+		wasmTransferFinder,
+		&wasmTransferMapper{
+			pairSet:         p.pairs,
+			tokenExceptions: tokenExceptions,
+		},
+	)
 
 	transferRule, err := sf.CreateTransferRuleFinder()
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.Transfer = parser.NewParser[dex.ParsedTx](transferRule, &transferMapper{pairSet: pairs})
+	p.Parsers.Transfer = parser.NewParser[dex.ParsedTx](transferRule, &transferMapper{pairSet: p.pairs})
 
 	// burn parser - to collect and parse LP burn event
 	{

--- a/parser/dex/starfleit/mappers.go
+++ b/parser/dex/starfleit/mappers.go
@@ -27,8 +27,9 @@ type transferMapper struct {
 	pairSet map[string]dex.Pair
 }
 type wasmTransferMapper struct {
-	mixin   transferMapperMixin
-	pairSet map[string]dex.Pair
+	mixin           transferMapperMixin
+	pairSet         map[string]dex.Pair
+	tokenExceptions map[string]bool
 }
 
 // match implements mapper
@@ -59,6 +60,15 @@ func (m *createPairMapper) MatchedToParsedTx(res eventlog.MatchedResult, optiona
 // match implements mapper
 func (m *wasmTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...interface{}) ([]*dex.ParsedTx, error) {
 	m.mixin.SortResult(res)
+
+	var cw20Addr string
+	if len(res) > sf.WasmCommonTransferCw20AddrIdx {
+		cw20Addr = res[sf.WasmCommonTransferCw20AddrIdx].Value
+		if m.tokenExceptions[cw20Addr] {
+			return nil, nil
+		}
+	}
+
 	action := res[sf.WasmCommonTransferActionIdx]
 
 	switch action.Value {

--- a/parser/dex/terraswap/columbusv1/app.go
+++ b/parser/dex/terraswap/columbusv1/app.go
@@ -63,10 +63,6 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 		txDtos = append(txDtos, *ctx)
 	}
 
-	if err := p.updateParsers(p.pairs); err != nil {
-		return nil, errors.Wrap(err, "parseTxs")
-	}
-
 	pairTxs := []*p_dex.ParsedTx{}
 	wasmTxs := []*p_dex.ParsedTx{}
 	transferTxs := []*p_dex.ParsedTx{}
@@ -107,9 +103,9 @@ func (p *terraswapApp) IsValidationExceptionCandidate(contractAddress string) bo
 	return p.flaggedAssets[contractAddress]
 }
 
-func (p *terraswapApp) updateParsers(pairs map[string]p_dex.Pair) error {
+func (p *terraswapApp) UpdateParsers(tokenExceptions map[string]bool, height uint64) error {
 	pairFilter := make(map[string]bool)
-	for k := range pairs {
+	for k := range p.pairs {
 		pairFilter[k] = true
 	}
 
@@ -117,18 +113,26 @@ func (p *terraswapApp) updateParsers(pairs map[string]p_dex.Pair) error {
 	if err != nil {
 		return errors.Wrap(err, "createParsers")
 	}
-	p.Parsers.PairActionParser = parser.NewParser[p_dex.ParsedTx](pairFinder, &pairMapper{pairSet: pairs})
+	p.Parsers.PairActionParser = parser.NewParser[p_dex.ParsedTx](pairFinder, &pairMapper{pairSet: p.pairs})
 
 	wasmTransferFinder, err := cv1.CreateWasmCommonTransferRuleFinder(pairFilter)
 	if err != nil {
 		return errors.Wrap(err, "createParsers")
 	}
-	p.Parsers.WasmTransfer = parser.NewParser[p_dex.ParsedTx](wasmTransferFinder, p_dex.NewWasmTransferMapper(dex.WasmTransferLegacyCw20AddrKey, pairs, p.flaggedAssets))
+	p.Parsers.WasmTransfer = parser.NewParser[p_dex.ParsedTx](
+		wasmTransferFinder,
+		p_dex.NewWasmTransferMapper(
+			dex.WasmTransferLegacyCw20AddrKey,
+			p.pairs,
+			p.flaggedAssets,
+			tokenExceptions,
+		),
+	)
 
 	transferRule, err := cv1.CreateTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "createParsers")
 	}
-	p.Parsers.Transfer = parser.NewParser[p_dex.ParsedTx](transferRule, p_dex.NewTransferMapper(pairs))
+	p.Parsers.Transfer = parser.NewParser[p_dex.ParsedTx](transferRule, p_dex.NewTransferMapper(p.pairs))
 	return nil
 }

--- a/parser/dex/terraswap/columbusv1/app_test.go
+++ b/parser/dex/terraswap/columbusv1/app_test.go
@@ -101,6 +101,9 @@ func Test_parseTxs(t *testing.T) {
 		msg := fmt.Sprintf("tc(%d): %s", idx, tc.errMsg)
 		app := setUp(tc)
 
+		err := app.UpdateParsers(make(map[string]bool), uint64(height))
+		assert.NoError(err)
+
 		txs, err := app.ParseTxs(tx, uint64(height))
 		if tc.errMsg != "" {
 			assert.Error(err, msg, err)

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -61,7 +61,6 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 }
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
-
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
@@ -76,10 +75,6 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		p.lpPairAddrs[ctx.LpAddr] = ctx.ContractAddr
 		ctx.Sender = tx.Sender
 		txDtos = append(txDtos, *ctx)
-	}
-
-	if err := p.updateParsers(p.pairs); err != nil {
-		return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
 	}
 
 	pairTxs := []*dex.ParsedTx{}
@@ -261,9 +256,9 @@ func (p *terraswapApp) IsValidationExceptionCandidate(contractAddress string) bo
 	return p.flaggedAssets[contractAddress]
 }
 
-func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
+func (p *terraswapApp) UpdateParsers(tokenExceptions map[string]bool, height uint64) error {
 	pairFilter := make(map[string]bool)
-	for k := range pairs {
+	for k := range p.pairs {
 		pairFilter[k] = true
 	}
 
@@ -271,7 +266,7 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.PairActionParser = parser.NewParser(pairFinder, &pairMapper{pairSet: pairs})
+	p.Parsers.PairActionParser = parser.NewParser(pairFinder, &pairMapper{pairSet: p.pairs})
 
 	initialProvideFinder, err := pdex.CreatePairInitialProvideRuleFinder(pairFilter)
 	if err != nil {
@@ -283,13 +278,21 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.WasmTransfer = parser.NewParser(wasmTransferFinder, dex.NewWasmTransferMapper(pdex.WasmTransferCw20AddrKey, pairs, p.flaggedAssets))
+	p.Parsers.WasmTransfer = parser.NewParser(
+		wasmTransferFinder,
+		dex.NewWasmTransferMapper(
+			pdex.WasmTransferCw20AddrKey,
+			p.pairs,
+			p.flaggedAssets,
+			tokenExceptions,
+		),
+	)
 
 	transferRule, err := columbusv2.CreateSortedTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.Transfer = parser.NewParser(transferRule, dex.NewTransferMapper(pairs))
+	p.Parsers.Transfer = parser.NewParser(transferRule, dex.NewTransferMapper(p.pairs))
 
 	// burn parser - to collect and parse LP burn event
 	{

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -102,6 +102,9 @@ func Test_parseTxs(t *testing.T) {
 		msg := fmt.Sprintf("tc(%d): %s", idx, tc.errMsg)
 		app := setUp(tc)
 
+		err := app.UpdateParsers(make(map[string]bool), uint64(height))
+		assert.NoError(err)
+
 		txs, err := app.ParseTxs(tx, uint64(height))
 		if tc.errMsg != "" {
 			assert.Error(err, msg, err)

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -69,10 +69,6 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		txDtos = append(txDtos, *ctx)
 	}
 
-	if err := p.updateParsers(p.pairs); err != nil {
-		return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
-	}
-
 	pairTxs := []*dex.ParsedTx{}
 	wasmTxs := []*dex.ParsedTx{}
 	transferTxs := []*dex.ParsedTx{}
@@ -141,9 +137,9 @@ func (p *terraswapApp) IsValidationExceptionCandidate(contractAddress string) bo
 	return p.flaggedAssets[contractAddress]
 }
 
-func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
+func (p *terraswapApp) UpdateParsers(tokenExceptions map[string]bool, height uint64) error {
 	pairFilter := make(map[string]bool)
-	for k := range pairs {
+	for k := range p.pairs {
 		pairFilter[k] = true
 	}
 
@@ -151,7 +147,7 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.PairActionParser = parser.NewParser[dex.ParsedTx](pairFinder, &pairMapper{pairSet: pairs})
+	p.Parsers.PairActionParser = parser.NewParser[dex.ParsedTx](pairFinder, &pairMapper{pairSet: p.pairs})
 	initialProvideFinder, err := pdex.CreatePairInitialProvideRuleFinder(pairFilter)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
@@ -162,13 +158,21 @@ func (p *terraswapApp) updateParsers(pairs map[string]dex.Pair) error {
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.WasmTransfer = parser.NewParser[dex.ParsedTx](wasmTransferFinder, dex.NewWasmTransferMapper(pdex.WasmTransferCw20AddrKey, pairs, p.flaggedAssets))
+	p.Parsers.WasmTransfer = parser.NewParser[dex.ParsedTx](
+		wasmTransferFinder,
+		dex.NewWasmTransferMapper(
+			pdex.WasmTransferCw20AddrKey,
+			p.pairs,
+			p.flaggedAssets,
+			tokenExceptions,
+		),
+	)
 
 	transferRule, err := phoenix.CreateSortedTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}
-	p.Parsers.Transfer = parser.NewParser[dex.ParsedTx](transferRule, dex.NewTransferMapper(pairs))
+	p.Parsers.Transfer = parser.NewParser[dex.ParsedTx](transferRule, dex.NewTransferMapper(p.pairs))
 
 	// burn parser - to collect and parse LP burn event
 	{

--- a/parser/dex/terraswap/phoenix/app_test.go
+++ b/parser/dex/terraswap/phoenix/app_test.go
@@ -99,6 +99,9 @@ func Test_parseTxs(t *testing.T) {
 		msg := fmt.Sprintf("tc(%d): %s", idx, tc.errMsg)
 		app := setUp(tc)
 
+		err := app.UpdateParsers(make(map[string]bool), uint64(height))
+		assert.NoError(err)
+
 		txs, err := app.ParseTxs(tx, uint64(height))
 		if tc.errMsg != "" {
 			assert.Error(err, msg, err)

--- a/parser/interface.go
+++ b/parser/interface.go
@@ -14,6 +14,7 @@ type TargetApp[T any] interface {
 type Repo[T any] interface {
 	Insert(srcHeight uint64, targetHeight uint64, txs []T, arg ...interface{}) error
 	GetSyncedHeight() (uint64, error)
+	GetTokenExceptions() (map[string]bool, error)
 }
 
 type SourceDataStore interface {

--- a/pkg/db/schemas/parser.models.go
+++ b/pkg/db/schemas/parser.models.go
@@ -56,3 +56,8 @@ type PairValidationException struct {
 	ChainId  string `json:"chainId"`
 	Contract string `json:"contract"`
 }
+
+type TokenParseException struct {
+	ChainId  string `json:"chainId"`
+	Contract string `json:"contract"`
+}

--- a/pkg/db/schemas/parser.models.gorm.go
+++ b/pkg/db/schemas/parser.models.gorm.go
@@ -22,6 +22,9 @@ func (SyncedHeight) TableName() string {
 func (PairValidationException) TableName() string {
 	return "pair_validation_exception"
 }
+func (TokenParseException) TableName() string {
+	return "token_parse_exception"
+}
 
 func (Meta) GormDataType() string {
 	return "json"


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The parser currently relies on a pair-based exception list to skip problematic transactions. However, since pairs are deterministically created by factories, most parsing failures are not caused by the pair itself but by malformed or unsupported tokens within those pairs.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Introduced a token-based exception mechanism to skip parsing for transactions involving problematic tokens instead of pairs
- Loaded the token exception list from DB on parser initialization (and reload on service restart)
- Refactored `updateParser` -> `UpdateParser` to make it externally callable
- Changed parser update timing from per-transaction to per-block height, reducing redundant updates
- Kept the existing pair exception list for now, as fully migrating requires reviewing tokens for all existing pairs

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
