### PR TITLE
ci: add automated release workflow with git-cliff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,35 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  changelog:
+    permissions:
+      contents: write
+      pull-requests: read
+    name: Generate changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: --latest --strip all
+        env:
+          OUTPUT: CHANGELOG.md
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          body_path: CHANGELOG.md
+          tag_name: ${{ github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         id: git-cliff
         with:
           config: cliff.toml
-          args: --latest --strip all
+          args: --current --strip all
         env:
           OUTPUT: CHANGELOG.md
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,74 @@
+# Contributing to CosmWasm ETL
+
+## Branching
+
+- Base all changes off `main`.
+- Use descriptive branch names: `feat/short-description`, `fix/short-description`.
+
+## Commit Messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/). Each commit message must have a type prefix:
+
+| Prefix | When to use |
+|---|---|
+| `feat:` | New feature |
+| `fix:` | Bug fix |
+| `refactor:` | Code change that is not a feature or fix |
+| `perf:` | Performance improvement |
+| `docs:` | Documentation only |
+| `test:` | Adding or updating tests |
+| `chore:` | Maintenance (deps, tooling, config) |
+| `ci:` | CI/CD changes |
+
+`docs:`, `test:`, `chore:`, `ci:`, and `build:` commits are excluded from the changelog automatically.
+
+## Pull Requests
+
+1. Keep PRs focused — one concern per PR.
+2. Fill in the PR template — background, summary, and checklist.
+3. All CI checks (lint, test, build) must pass before merging.
+
+## Development Setup
+
+```bash
+git clone https://github.com/dezswap/cosmwasm-etl.git
+cd cosmwasm-etl
+
+# Copy the example config and fill in your values
+cp example.config.yaml config.yaml
+vim config.yaml
+
+# Start the app and local PostgreSQL via docker-compose
+export APP_TYPE=collector  # one of: aggregator / collector / parser
+make up
+
+# Apply DB migrations
+make parser-migrate-up
+make aggregator-migrate-up
+make collector-migrate-up
+```
+
+## Code Quality
+
+```bash
+make fmt        # format
+make lint       # golangci-lint
+make test       # unit tests (-short)
+make cover      # tests with coverage
+```
+
+All CI checks must pass locally before opening a PR.
+
+## Database Migrations
+
+Migrations are timestamped SQL files under `db/migrations/<app>/`. Every schema change must include both an `.up.sql` and a `.down.sql`.
+
+```bash
+make parser-generate-migration   # create a new migration pair
+make parser-migrate-up           # apply migrations
+make parser-migrate-test         # run migration integration tests (-tags=mig,faker)
+```
+
+## Reporting Bugs & Feature Requests
+
+Please use the [GitHub issue tracker](https://github.com/dezswap/cosmwasm-etl/issues).

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Requirements
 
-- [Go installation](https://golang.org/dl/) (preferably v1.18) and a [correctly configured path](https://golang.org/doc/install#install).
+- [Go installation](https://golang.org/dl/) (preferably v1.24) and a [correctly configured path](https://golang.org/doc/install#install).
 - A local [docker, docker-compose](https://docs.docker.com)
 - [Golangci-lint](https://github.com/golangci/golangci-lint) to improve code quality
 
@@ -50,6 +50,8 @@ make cover      # Check coverage for all packages
 ## Packages
 
 ## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ### Bug Reports & Feature Requests
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,68 @@
+[changelog]
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | upper_first }} \
+  ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/dezswap/cosmwasm-etl/commit/{{ commit.id }}))\
+  {% if commit.remote.pr_number %}[#{{ commit.remote.pr_number }}](https://github.com/dezswap/cosmwasm-etl/pull/{{ commit.remote.pr_number }}){% endif %}\
+{% endfor %}
+{% endfor %}\n
+"""
+footer = """
+{% for release in releases %}\
+{% if release.version %}\
+{% if release.previous.version %}\
+[{{ release.version | trim_start_matches(pat="v") }}]: \
+  https://github.com/dezswap/cosmwasm-etl/compare/{{ release.previous.version }}...{{ release.version }}
+{% else %}\
+[{{ release.version | trim_start_matches(pat="v") }}]: \
+  https://github.com/dezswap/cosmwasm-etl/releases/tag/{{ release.version }}
+{% endif %}\
+{% else %}\
+[Unreleased]: https://github.com/dezswap/cosmwasm-etl/compare/{{ release.previous.version }}...HEAD
+{% endif %}\
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+
+commit_parsers = [
+  { message = "^feat", group = "Added" },
+  { message = "^fix", group = "Fixed" },
+  { message = "^refactor", group = "Changed" },
+  { message = "^perf", group = "Changed" },
+  { message = "^revert", group = "Fixed" },
+  { message = "^docs", skip = true },
+  { message = "^chore", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^test", skip = true },
+  { message = "^build", skip = true },
+]
+
+filter_commits = true
+tag_pattern = "v[0-9].*"
+skip_tags = ""
+ignore_tags = ""
+topo_order = false
+sort_commits = "oldest"
+
+[remote.github]
+owner = "dezswap"
+repo = "cosmwasm-etl"

--- a/cmd/parser/checkpoint/README.md
+++ b/cmd/parser/checkpoint/README.md
@@ -1,0 +1,31 @@
+# Checkpoint
+
+A CLI tool that creates snapshots of pool states at a specific block height.
+
+## Overview
+
+Checkpoint reads DEX pool states at a given block height and saves them to the database. It serves as a reference point when the parser needs to start synchronization from a specific block.
+
+### Flow
+
+1. Input target block height
+2. Validate heights (DB checkpoint < target height ≤ node synced height)
+3. Query pool states at the target height
+4. Save checkpoint to database
+
+## Usage
+
+```bash
+go run ./cmd/parser/checkpoint -height <block_height>
+```
+
+### Example
+
+```bash
+# Create checkpoint at block height 1000000
+go run ./cmd/parser/checkpoint -height=1000000
+```
+
+## Configuration
+
+Uses the parser section from `config.yaml`.


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There was no automated process to generate release notes or create GitHub Releases when a new version tag is pushed. Release notes had to be written manually, which is error-prone and inconsistent.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Adds a `release.yml` GitHub Actions workflow that triggers on `v*` tag pushes.
- Uses `git-cliff` (`cliff.toml`) to auto-generate a changelog from conventional commits (`feat`, `fix`, `refactor`, `perf`, `revert`; skips `docs`, `chore`, `ci`, `test`, `build`).
- Passes the generated changelog as the release body to `softprops/action-gh-release`, creating the GitHub Release automatically.
- Adds and updates contributor documentation.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
