### PR TITLE
feat: inject version in docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,10 @@ jobs:
               - 'go.sum'
 
       - name: Validate Dockerfile (syntax check)
-        run: |
-          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-          docker build --check --build-arg APP_PATH=parser/dex --build-arg GO_VERSION=$GO_VERSION .
+        run: docker build --check --build-arg APP_PATH=parser/dex .
 
       - name: Full build check (Dockerfile/go.mod changed)
         if: steps.changed.outputs.docker == 'true'
-        run: |
-          GO_VERSION=$(grep '^go ' go.mod | awk '{print $2}')
-          docker build --build-arg APP_PATH=parser/dex --build-arg GO_VERSION=$GO_VERSION .
+        env:
+          APP_PATH: parser/dex
+        run: make image

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           for app_type in collector parser-dex aggregator; do
             echo "Building for $app_type"
             APP_PATH=$(echo $app_type | tr '-' '/')
-            docker build --build-arg APP_PATH=$APP_PATH --no-cache -t ${{ env.PROJECT_ID }}/$app_type:${IMAGE_TAG} .
+            docker build --build-arg APP_PATH=$APP_PATH --build-arg VERSION=$(IMAGE_TAG) --no-cache -t ${{ env.PROJECT_ID }}/$app_type:${IMAGE_TAG} .
             docker save -o ${{ runner.temp }}/${{ env.PROJECT_ID }}-$app_type.tar ${{ env.PROJECT_ID }}/$app_type:${IMAGE_TAG}
           done
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
           for app_type in collector parser-dex aggregator; do
             echo "Building for $app_type"
             APP_PATH=$(echo $app_type | tr '-' '/')
-            docker build --build-arg APP_PATH=$APP_PATH --build-arg VERSION=$(IMAGE_TAG) --no-cache -t ${{ env.PROJECT_ID }}/$app_type:${IMAGE_TAG} .
+            docker build --build-arg APP_PATH=$APP_PATH --build-arg VERSION=${IMAGE_TAG} --no-cache -t ${{ env.PROJECT_ID }}/$app_type:${IMAGE_TAG} .
             docker save -o ${{ runner.temp }}/${{ env.PROJECT_ID }}-$app_type.tar ${{ env.PROJECT_ID }}/$app_type:${IMAGE_TAG}
           done
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ FROM ${BASE_IMAGE} AS build
 ARG LIBWASMVM_VERSION=v2.1.4
 # required argument: one of("aggregator", "collector", "parser/dex")
 ARG APP_PATH
+ARG VERSION
 
 WORKDIR /app
 
@@ -33,7 +34,8 @@ RUN cp /lib/libwasmvm_muslc.`uname -m`.a /lib/libwasmvm_muslc.a
 
 # Build the app
 RUN go build -mod=readonly -tags "netgo muslc" \
-            -ldflags "-X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,muslc' \
+            -ldflags "${VERSION:+-X main.version=${VERSION} }\
+            -X github.com/cosmos/cosmos-sdk/version.BuildTags='netgo,muslc' \
             -w -s -linkmode=external -extldflags '-Wl,-z,muldefs -static'" \
             -trimpath -o ./main ./cmd/${APP_PATH}
 

--- a/Makefile
+++ b/Makefile
@@ -106,9 +106,16 @@ prune-deps:
 	go mod tidy
 
 # Create the service docker image
+# Usage: make image APP_PATH=aggregator  (or collector, parser/dex, parser/checkpoint)
+IMAGE_VERSION := $(shell git describe --tags --always --dirty 2>/dev/null)
 .PHONY: image
 image:
-	docker build --force-rm -t dezswap/cosmwasm-etl .
+	docker build --force-rm \
+		--build-arg APP_PATH=$(APP_PATH) \
+		--build-arg VERSION=$(IMAGE_VERSION) \
+		-t cosmwasm-etl-$(subst /,-,$(APP_PATH)):$(if $(IMAGE_VERSION),$(IMAGE_VERSION),dev) \
+		-t cosmwasm-etl-$(subst /,-,$(APP_PATH)):latest \
+		.
 
 # Migrate database.
 .PHONY: parser-migrate-test parser-migrate-up parser-migrate-down parser-generate-migration \

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Requirements
 
-- [Go installation](https://golang.org/dl/) (preferably v1.24) and a [correctly configured path](https://golang.org/doc/install#install).
+- [Go installation](https://golang.org/dl/) (preferably v1.25) and a [correctly configured path](https://golang.org/doc/install#install).
 - A local [docker, docker-compose](https://docs.docker.com)
 - [Golangci-lint](https://github.com/golangci/golangci-lint) to improve code quality
 

--- a/cmd/aggregator/main.go
+++ b/cmd/aggregator/main.go
@@ -15,6 +15,8 @@ const (
 	app = "aggregator"
 )
 
+var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
+
 func main() {
 	c := configs.New()
 	logger := logging.New("aggregator", c.Log)
@@ -27,6 +29,8 @@ func main() {
 		})
 	}
 	defer catch(logger)
+
+	logger.WithField("version", version).Info("starting aggregator")
 
 	app := aggregator.New(c, logger)
 	if err := app.Run(); err != nil {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -20,6 +20,8 @@ const (
 	app                 = "collector"
 )
 
+var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
+
 func main() {
 	c := configs.New()
 	nodeConf := c.Collector.NodeConfig
@@ -38,6 +40,8 @@ func main() {
 	}
 
 	defer catch(logger)
+
+	logger.WithField("version", version).Info("starting collector")
 
 	grpc.SetLogConfig(c.Log)
 	serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)

--- a/cmd/parser/checkpoint/main.go
+++ b/cmd/parser/checkpoint/main.go
@@ -28,11 +28,14 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/columbusv2"
 	"github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/phoenix"
 	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/dezswap/cosmwasm-etl/pkg/terra/col4"
 	"github.com/dezswap/cosmwasm-etl/pkg/terra/cosmos45"
 	"github.com/dezswap/cosmwasm-etl/pkg/terra/rpc"
 	"github.com/pkg/errors"
 )
+
+var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
 
 func main() {
 	c := configs.New()
@@ -41,6 +44,9 @@ func main() {
 	var targetHeight uint64
 	flag.Uint64Var(&targetHeight, "height", 0, "target block height")
 	flag.Parse()
+
+	logger := logging.New("checkpoint", c.Log)
+	logger.WithField("version", version).Info("starting checkpoint")
 
 	if err := run(c, targetHeight); err != nil {
 		panic(err)

--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -37,6 +37,8 @@ const (
 	app = "parser"
 )
 
+var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
+
 func newHttpClient(c configs.HttpClientConfig) *http.Client {
 	return &http.Client{
 		Timeout: c.Timeout.Duration,
@@ -156,6 +158,8 @@ func main() {
 
 	grpc.SetLogConfig(c.Log)
 	logger := logging.New("parser", c.Log)
+	logger.WithField("version", version).Info("starting parser")
+
 	defer catch(logger)
 	if err := c.Parser.DexConfig.Validate(); err != nil {
 		panic(fmt.Errorf("dex config is nil: %w", err))


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Running services had no way to report which binary version was deployed.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Added a version package-level variable (defaulting to `dev`) to all four entry-point binaries: `aggregator`, `collector`, `parser/dex`, and `parser/checkpoint`
- Each binary now logs version at startup as a structured log field
- The `Dockerfile` wires it through via `-ldflags "-X main.version=${VERSION}"`
- Removed explicit `GO_VERSION` injection from CI so that version discrepancy should be exposed when exists
- Updated `README` Go version reference
<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
