### PR TITLE
fix: handle pair to user transfers whose amount differs due to token-…

### DIFF
--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -301,24 +301,65 @@ func (mixin *DexMixin) HasProvide(pairTxs []*ParsedTx) bool {
 	return false
 }
 
+type transferPopEntry struct {
+	pairAddr  string
+	assetAddr string
+	amount    string
+}
+
+// RemoveDuplicatedTxs removes transfer events already captured by pair action events.
+// By building popList from pairTxs (one per asset) and matching each transfer 1:1,
+// it prevents a single pair action from consuming more transfers than it produced.
 func (mixin *DexMixin) RemoveDuplicatedTxs(pairTxs []*ParsedTx, transferTxs []*ParsedTx) []ParsedTx {
-	txs := []ParsedTx{}
-	for idx, tx := range transferTxs {
-		duplicated := false
-		for i := 0; i < len(pairTxs) && !duplicated; i++ {
-			duplicated = mixin.isDuplicatedTx(pairTxs[i], tx)
+	popList := []transferPopEntry{}
+	for _, ptx := range pairTxs {
+		for _, asset := range ptx.Assets {
+			if asset.Amount != "" {
+				popList = append(popList, transferPopEntry{ptx.ContractAddr, asset.Addr, asset.Amount})
+			}
 		}
-		if !duplicated {
-			txs = append(txs, *transferTxs[idx])
+	}
+
+	consumed := make([]bool, len(transferTxs))
+	for i, tx := range transferTxs {
+		for j, entry := range popList {
+			if mixin.matchesPairTransferEntry(entry, tx) {
+				consumed[i] = true
+				popList = append(popList[:j], popList[j+1:]...)
+				break
+			}
+		}
+	}
+
+	txs := []ParsedTx{}
+	for i, tx := range transferTxs {
+		if !consumed[i] {
+			txs = append(txs, *tx)
 		}
 	}
 	return txs
 }
 
-// TODO: more specific logic
-func (mixin *DexMixin) isDuplicatedTx(ptx *ParsedTx, transfer *ParsedTx) bool {
-	isSameAssetAmount := func(a1, a2 Asset) bool {
-		return a1.Addr == a2.Addr && a1.Amount == a2.Amount
+// matchesPairTransferEntry reports whether tx corresponds to a transfer entry.
+func (mixin *DexMixin) matchesPairTransferEntry(entry transferPopEntry, transferTx *ParsedTx) bool {
+	if transferTx.ContractAddr != entry.pairAddr && transferTx.Sender != entry.pairAddr {
+		return false
 	}
-	return (ptx.ContractAddr == transfer.ContractAddr || ptx.ContractAddr == transfer.Sender) && (isSameAssetAmount(ptx.Assets[0], transfer.Assets[0]) || isSameAssetAmount(ptx.Assets[1], transfer.Assets[1]))
+
+	for _, asset := range transferTx.Assets {
+		if asset.Addr != entry.assetAddr || asset.Amount == "" {
+			continue
+		}
+
+		// For pair->user transfers (transferTx.Sender == entry.pairAddr), only the asset address is checked:
+		// unknown attributes from token contract may cause the received amount to differ from the pair's recorded amount.
+		// e.g. columbus-5 14829F480097AF38ECED3079ACD06BAA0AC0583E6BFCC85375A018617B13BBCB
+		// For user->pair transfers, the asset amount must match exactly (asset.Amount == entry.amount),
+		// to avoid consuming unrelated same-asset transfers within the same tx.
+		if transferTx.Sender == entry.pairAddr || asset.Amount == entry.amount {
+			return true
+		}
+	}
+
+	return false
 }

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -314,7 +314,7 @@ func (mixin *DexMixin) RemoveDuplicatedTxs(pairTxs []*ParsedTx, transferTxs []*P
 	popList := []transferPopEntry{}
 	for _, ptx := range pairTxs {
 		for _, asset := range ptx.Assets {
-			if asset.Amount != "" {
+			if asset.Amount != "" && asset.Amount != "0" {
 				popList = append(popList, transferPopEntry{ptx.ContractAddr, asset.Addr, asset.Amount})
 			}
 		}
@@ -342,7 +342,11 @@ func (mixin *DexMixin) RemoveDuplicatedTxs(pairTxs []*ParsedTx, transferTxs []*P
 
 // matchesPairTransferEntry reports whether tx corresponds to a transfer entry.
 func (mixin *DexMixin) matchesPairTransferEntry(entry transferPopEntry, transferTx *ParsedTx) bool {
-	if transferTx.ContractAddr != entry.pairAddr && transferTx.Sender != entry.pairAddr {
+	isPairSendTx := entry.pairAddr == transferTx.Sender
+	isPairReceiveTx := entry.pairAddr == transferTx.ContractAddr
+	isEntryOutflow := strings.HasPrefix(entry.amount, "-")
+
+	if (!isEntryOutflow && !isPairReceiveTx) || (isEntryOutflow && !isPairSendTx) {
 		return false
 	}
 
@@ -356,7 +360,7 @@ func (mixin *DexMixin) matchesPairTransferEntry(entry transferPopEntry, transfer
 		// e.g. columbus-5 14829F480097AF38ECED3079ACD06BAA0AC0583E6BFCC85375A018617B13BBCB
 		// For user->pair transfers, the asset amount must match exactly (asset.Amount == entry.amount),
 		// to avoid consuming unrelated same-asset transfers within the same tx.
-		if transferTx.Sender == entry.pairAddr || asset.Amount == entry.amount {
+		if isPairSendTx || asset.Amount == entry.amount {
 			return true
 		}
 	}

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -166,6 +166,94 @@ var (
 	transferTx = ParsedTx{"", time.Time{}, Transfer, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", nil}
 )
 
+func Test_matchesPairTransferEntry(t *testing.T) {
+	mixin := DexMixin{}
+	pairAddr := "PAIR_ADDR"
+
+	tcs := []struct {
+		entry    transferPopEntry
+		transfer ParsedTx
+		expected bool
+		explain  string
+	}{
+		{
+			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
+			transfer: ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}},
+			expected: true,
+			explain:  "user→pair transfer with exact amount must match",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "TokenB", "500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "490"}}},
+			expected: true,
+			explain:  "pair→user transfer with different amount (share_amount) must match (no amount check)",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
+			transfer: ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "999"}, {"TokenB", ""}}},
+			expected: false,
+			explain:  "user→pair transfer with mismatched amount must not match (unrelated transfer)",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
+			transfer: ParsedTx{ContractAddr: "OTHER_PAIR", Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}},
+			expected: false,
+			explain:  "different contract must not match",
+		},
+	}
+
+	for _, tc := range tcs {
+		result := mixin.matchesPairTransferEntry(tc.entry, &tc.transfer)
+		assert.Equal(t, tc.expected, result, tc.explain)
+	}
+}
+
+func Test_removeDuplicatedTxs(t *testing.T) {
+	mixin := DexMixin{}
+	pairAddr := "PAIR_ADDR"
+	pairTx := &ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", "500"}}}
+
+	tcs := []struct {
+		pairTxs     []*ParsedTx
+		transferTxs []*ParsedTx
+		expected    int
+		explain     string
+	}{
+		{
+			pairTxs:     []*ParsedTx{pairTx},
+			transferTxs: []*ParsedTx{{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}}},
+			expected:    0,
+			explain:     "user->pair transfer matching pair action must be removed",
+		},
+		{
+			pairTxs:     []*ParsedTx{pairTx},
+			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "490"}}}},
+			expected:    0,
+			explain:     "pair->user transfer with amount mismatch must be removed",
+		},
+		{
+			pairTxs: []*ParsedTx{pairTx},
+			transferTxs: []*ParsedTx{
+				{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}},
+				{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "500"}, {"TokenB", ""}}},
+			},
+			expected: 1,
+			explain:  "unrelated transfer to pair with different amount in same tx must be kept",
+		},
+		{
+			pairTxs:     []*ParsedTx{pairTx},
+			transferTxs: []*ParsedTx{{ContractAddr: "OTHER_PAIR", Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}}},
+			expected:    1,
+			explain:     "transfer to unrelated pair must be kept",
+		},
+	}
+
+	for _, tc := range tcs {
+		result := mixin.RemoveDuplicatedTxs(tc.pairTxs, tc.transferTxs)
+		assert.Len(t, result, tc.expected, tc.explain)
+	}
+}
+
 func Test_collectLpBurnTxs(t *testing.T) {
 	lpPairAddrs := map[string]string{
 		"LpToken": "PairContract",

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -183,10 +183,16 @@ func Test_matchesPairTransferEntry(t *testing.T) {
 			explain:  "user→pair transfer with exact amount must match",
 		},
 		{
-			entry:    transferPopEntry{pairAddr, "TokenB", "500"},
+			entry:    transferPopEntry{pairAddr, "TokenB", "-500"},
 			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "490"}}},
 			expected: true,
-			explain:  "pair→user transfer with different amount (share_amount) must match (no amount check)",
+			explain:  "pair→user transfer with different amount must match (no amount check)",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "TokenB", "500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "500"}}},
+			expected: false,
+			explain:  "pair→user transfer with positive sign must not match",
 		},
 		{
 			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
@@ -211,7 +217,7 @@ func Test_matchesPairTransferEntry(t *testing.T) {
 func Test_removeDuplicatedTxs(t *testing.T) {
 	mixin := DexMixin{}
 	pairAddr := "PAIR_ADDR"
-	pairTx := &ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", "500"}}}
+	pairTx := &ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", "-500"}}}
 
 	tcs := []struct {
 		pairTxs     []*ParsedTx
@@ -227,9 +233,9 @@ func Test_removeDuplicatedTxs(t *testing.T) {
 		},
 		{
 			pairTxs:     []*ParsedTx{pairTx},
-			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "490"}}}},
+			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "-490"}}}},
 			expected:    0,
-			explain:     "pair->user transfer with amount mismatch must be removed",
+			explain:     "pair->user transfer (negative entry amount) with amount mismatch must be removed",
 		},
 		{
 			pairTxs: []*ParsedTx{pairTx},
@@ -245,6 +251,15 @@ func Test_removeDuplicatedTxs(t *testing.T) {
 			transferTxs: []*ParsedTx{{ContractAddr: "OTHER_PAIR", Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}}},
 			expected:    1,
 			explain:     "transfer to unrelated pair must be kept",
+		},
+		{
+			pairTxs: []*ParsedTx{{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "0"}, {"TokenB", "0"}}}},
+			transferTxs: []*ParsedTx{
+				{Sender: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}},
+				{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "1000"}}},
+			},
+			expected: 2,
+			explain:  "withdraw where pair records 0 amount: transfer must not be consumed (actual movement recorded separately)",
 		},
 	}
 

--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -113,8 +113,7 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 		txDtos = append(txDtos, *ptx)
 	}
 
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTransferTxs)...)
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTransferTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -111,8 +111,7 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		ptx.Sender = tx.Sender
 		txDtos = append(txDtos, *ptx)
 	}
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil

--- a/parser/dex/terraswap/columbusv1/app.go
+++ b/parser/dex/terraswap/columbusv1/app.go
@@ -93,8 +93,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 		txDtos = append(txDtos, *ptx)
 	}
 
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 
 	return txDtos, nil
 }

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -152,8 +152,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		txDtos = append(txDtos, *ptx)
 	}
 
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -126,8 +126,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		txDtos = append(txDtos, *ptx)
 	}
 
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, wasmTxs)...)
-	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, transferTxs)...)
+	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
 	return txDtos, nil


### PR DESCRIPTION
## Background

Some CW20 token contracts internally redirect part of the transferred amount to another address during their transfer event.
e.g. columbus-5 `[12] wasm` in [14829F480097AF38ECED3079ACD06BAA0AC0583E6BFCC85375A018617B13BBCB](https://finder.terra.money/classic/tx/14829f480097af38eced3079acd06baa0ac0583e6bfcc85375a018617b13bbcb)

 This means a pair -> user transfer in the event log can carry a smaller amount than what the pair contract recorded. The old `isDuplicatedTx` required exact amount equality in every direction, so these transfers were never recognized as duplicates and leaked into the output as spurious `Transfer` records.

## Summary

- Replaced `isDuplicatedTx` with a `popList`-based `RemoveDuplicatedTxs` that applies two different matching rules:
  - **pair->user** (`tx.Sender == pairAddr`): match on asset address only — no amount check — to tolerate token contracts that silently redirect a portion of the transfer.
  - **user->pair** (`tx.ContractAddr == pairAddr`): require exact amount match to avoid consuming unrelated same-asset transfers within the same tx.
- Merged the previously separate `RemoveDuplicatedTxs` calls for `wasmTxs` and `transferTxs` into one call per DEX app so the `popList` is shared in a single pass.
- Added unit tests for `matchesPairTransferEntry` and `RemoveDuplicatedTxs` covering both rules and edge cases.

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?