### PR TITLE
fix: preserve tax transfers lost by RemoveDuplicatedTxs

### DIFF
--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -138,20 +138,23 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		burnTxs = append(burnTxs, burns...)
 	}
 
-	// Originally, tax_amount in wasm was used to deduct the tax(parser.dex.terraswap.columbusv2.pairMapper.swapMatchedToParsedTx).
-	// tax_payment log replaced tax_amount attribute for more detail, so it will be used to deduct here instead.
+	// tax_payment log replaced the legacy tax_amount wasm attribute for deducting tax from pairTxs.
+	// Tax transfers are extracted first so RemoveDuplicatedTxs consumes the result transfer
+	// (pair→user) rather than the tax transfer (pair→tax_collector).
 	// e.g. 2B99CFA6D1FB1029A28DCCABD753B5F43517B89CE31BF855235D47C16A7D2FB0
+	pairAddrs := p.getPairAddrs(pairTxs)
+	taxTransfers, transferTxs := p.extractTaxTransfers(transferTxs, taxTxs, pairAddrs)
 	if len(taxTxs) > 0 {
-		pairAddrs := p.getPairAddrs(pairTxs)
-		pairTransferTxs := p.getPairTransfers(pairAddrs, transferTxs)
-		pairTxs = p.deductTaxFromPairTxs(taxTxs, pairTransferTxs, pairTxs)
+		pairTxs = p.deductTaxFromPairTxs(taxTxs, p.getPairTransfers(pairAddrs, transferTxs), pairTxs)
 	}
 
 	for _, ptx := range pairTxs {
 		ptx.Sender = tx.Sender
 		txDtos = append(txDtos, *ptx)
 	}
-
+	for _, ttx := range taxTransfers {
+		txDtos = append(txDtos, *ttx)
+	}
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
 
@@ -249,6 +252,54 @@ func (p *terraswapApp) deductTaxFromPairTxs(taxTxs, pairTransferTxs, pairTxs []*
 	}
 
 	return pairTxs
+}
+
+// extractTaxTransfers splits transferTxs into two slices: transfers that
+// correspond to tax payments (matched 1:1 with taxTxs by asset address and
+// absolute amount) and the remaining transfers.
+// Only transfers whose Sender is a known pair address are candidates for tax
+// transfers, since tax transfers always originate from the pair (pair→tax_collector).
+func (p *terraswapApp) extractTaxTransfers(transferTxs, taxTxs []*dex.ParsedTx, pairAddrs []string) (taxTransfers, remaining []*dex.ParsedTx) {
+	if len(taxTxs) == 0 {
+		return nil, transferTxs
+	}
+	pairAddrSet := make(map[string]bool, len(pairAddrs))
+	for _, addr := range pairAddrs {
+		pairAddrSet[addr] = true
+	}
+	type taxKey struct{ addr, amount string }
+	taxCounts := make(map[taxKey]int, len(taxTxs))
+	for _, t := range taxTxs {
+		taxCounts[taxKey{t.Assets[0].Addr, t.Assets[0].Amount}]++
+	}
+	for _, tx := range transferTxs {
+		if !pairAddrSet[tx.Sender] {
+			remaining = append(remaining, tx)
+			continue
+		}
+		// tax transfers carry exactly one asset; if both slots are filled it is not a tax transfer
+		if tx.Assets[0].Amount != "" && tx.Assets[1].Amount != "" {
+			remaining = append(remaining, tx)
+			continue
+		}
+		asset := tx.Assets[0]
+		if asset.Amount == "" {
+			asset = tx.Assets[1]
+		}
+		// tax transfers are outflows from the pair (negative amount)
+		if len(asset.Amount) == 0 || asset.Amount[0] != '-' {
+			remaining = append(remaining, tx)
+			continue
+		}
+		k := taxKey{asset.Addr, asset.Amount[1:]}
+		if taxCounts[k] > 0 {
+			taxCounts[k]--
+			taxTransfers = append(taxTransfers, tx)
+		} else {
+			remaining = append(remaining, tx)
+		}
+	}
+	return taxTransfers, remaining
 }
 
 func (p *terraswapApp) IsValidationExceptionCandidate(contractAddress string) bool {

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -118,6 +118,79 @@ func Test_parseTxs(t *testing.T) {
 	}
 }
 
+func Test_extractTaxTransfers(t *testing.T) {
+	assert := assert.New(t)
+	app := &terraswapApp{}
+
+	const pairAddr = "PAIR_ADDR"
+	pairAddrs := []string{pairAddr}
+
+	taxTx := &dex.ParsedTx{
+		Type:   dex.TaxPayment,
+		Assets: [2]dex.Asset{{Addr: "uluna", Amount: "10"}, {}},
+	}
+
+	// tax transfer: pair → tax_collector, Sender = pair addr, amount -10
+	taxTransfer := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		Sender:       pairAddr,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: "uluna", Amount: "-10"}, {}},
+	}
+
+	// result transfer: pair → user, Sender = pair addr, amount -990
+	resultTransfer := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		Sender:       pairAddr,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: "uluna", Amount: "-990"}, {}},
+	}
+
+	// inflow transfer: user → pair, Sender = user (not pair addr)
+	unrelatedTransfer := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		Sender:       "user",
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: "uusd", Amount: "1000"}, {}},
+	}
+
+	// with no taxTxs, all transfers go to remaining
+	taxed, rem := app.extractTaxTransfers([]*dex.ParsedTx{taxTransfer, resultTransfer}, nil, pairAddrs)
+	assert.Nil(taxed, "no taxTxs: taxTransfers should be nil")
+	assert.Len(rem, 2, "no taxTxs: all transfers should remain")
+
+	// tax transfer is extracted; result and unrelated transfers remain
+	taxed, rem = app.extractTaxTransfers([]*dex.ParsedTx{taxTransfer, resultTransfer, unrelatedTransfer}, []*dex.ParsedTx{taxTx}, pairAddrs)
+	assert.Len(taxed, 1, "one tax transfer should be extracted")
+	assert.Equal(taxTransfer, taxed[0])
+	assert.Len(rem, 2, "result and unrelated transfers should remain")
+	assert.Equal(resultTransfer, rem[0])
+	assert.Equal(unrelatedTransfer, rem[1])
+
+	// inflow transfer with same amount as tax is not matched (Sender != pair addr)
+	inflowSameAmount := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		Sender:       "user",
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: "uluna", Amount: "10"}, {}},
+	}
+	taxed, rem = app.extractTaxTransfers([]*dex.ParsedTx{inflowSameAmount, taxTransfer}, []*dex.ParsedTx{taxTx}, pairAddrs)
+	assert.Len(taxed, 1, "only the outflow from pair should be extracted")
+	assert.Equal(taxTransfer, taxed[0])
+	assert.Len(rem, 1, "inflow with same amount should remain")
+	assert.Equal(inflowSameAmount, rem[0])
+
+	// two identical tax transfers, two taxTxs → both extracted
+	taxTx2 := &dex.ParsedTx{
+		Type:   dex.TaxPayment,
+		Assets: [2]dex.Asset{{Addr: "uluna", Amount: "10"}, {}},
+	}
+	taxed, rem = app.extractTaxTransfers([]*dex.ParsedTx{taxTransfer, taxTransfer, resultTransfer}, []*dex.ParsedTx{taxTx, taxTx2}, pairAddrs)
+	assert.Len(taxed, 2, "both tax transfers should be extracted")
+	assert.Len(rem, 1, "only result transfer should remain")
+	assert.Equal(resultTransfer, rem[0])
+}
+
 func Test_taxDeduction(t *testing.T) {
 	assert := assert.New(t)
 	app := &terraswapApp{}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
PR #113 updated `RemoveDuplicatedTxs` so that pair-send transfers are matched by asset address alone, ignoring the amount. This is safe for most chains where a pair can emit only one outgoing transfer per action for each asset.

The chain-level taxation system unique to Terra Classic causes the pair to emit two outgoing transfers per native-coin swap:
1. pair → tax_collector — small tax amount
3. pair → user — net swap output

Because both share the same asset address, pair sender, and outgoing direction(which is negative amount), `RemoveDuplicatedTxs` can consume the tax transfer accidently. This accidental cosumption triggers that the result transfer then passed through as an unmatched record, and the tax transfer was silently dropped from the output.

This issue is isolated to Columbus-5 — on other chains a pair send is only ever caused by a single pair action event.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Added `extractTaxTransfers`, which splits `transferTxs` into two buckets before `RemoveDuplicatedTxs` runs, using `taxTxs` as the key (matched by pair sender, outflow direction, asset address, and absolute amount):
- Tax transfers → appended directly to `txDtos` so they are preserved in the output
- Remaining transfers → passed to `RemoveDuplicatedTxs` as before, so the single popList entry is correctly consumed by the result transfer (pair → user)

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tax transfer extraction and processing in Terraswap transaction parsing, ensuring more accurate separation of tax-related transfers from standard transactions.

* **Tests**
  * Added comprehensive test coverage for tax transfer extraction logic, including edge cases and multiple scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/114)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->