### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "**" ]
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/dezswap/cosmwasm-etl/security/code-scanning/2](https://github.com/dezswap/cosmwasm-etl/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root (best single change), so all jobs inherit restricted token access unless explicitly overridden later. For this workflow, `contents: read` is the minimal and appropriate baseline and should preserve current behavior (`checkout` and read-only metadata access).

**File to change:** `.github/workflows/ci.yml`  
**Change location:** after the `on:` trigger block (before `jobs:`).  
**Needed additions:** YAML key:
```yml
permissions:
  contents: read
```
No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
