### PR TITLE
ci: add Codecov coverage reporting and move build before tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   tests:
@@ -38,22 +39,27 @@ jobs:
 
     - name: Run Golang linter
       uses: golangci/golangci-lint-action@v8
+    
+    - name: Build all
+      run: make build-all
 
     - name: Tests
       shell: bash
       run: |
         echo "${{ secrets.CONFIG }}" > config.yaml
-        make test
+        go test -short -coverprofile=coverage.out -covermode=atomic ./...
 
+    - name: Upload to Codecov
+      uses: codecov/codecov-action@v6
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: ./coverage.out
+    
     - name: Migration Tests
       run: |
         make parser-migrate-up
         make parser-migrate-test
         make parser-migrate-down
-      # Add if more needed
-
-    - name: Build all
-      run: make build-all
 
   docker-check:
     runs-on: ubuntu-latest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: 43%
+        threshold: 1%
+    patch:
+      default:
+        target: 30%


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CI pipeline lacked test coverage reporting, making it difficult to track coverage trends over time. Additionally, the build step ran after tests, which meant compilation errors wouldn't surface until after the test suite executed.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Add Codecov integration: generate a coverage profile (`coverage.out`) during tests and upload it via `codecov/codecov-action@v6`
- Add `codecov.yml` with coverage targets (43% project, 30% patch, 1% threshold)
- Move Build all step before Tests so build failures are caught earlier in the pipeline

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?
