### PR TITLE
fix: require exact amount for native/IBC token pair->user transfers

### DIFF
--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -355,12 +355,14 @@ func (mixin *DexMixin) matchesPairTransferEntry(entry transferPopEntry, transfer
 			continue
 		}
 
-		// For pair->user transfers (transferTx.Sender == entry.pairAddr), only the asset address is checked:
-		// unknown attributes from token contract may cause the received amount to differ from the pair's recorded amount.
+		// For pair->user transfers (transferTx.Sender == entry.pairAddr), CW20 token contracts
+		// may charge fees/taxes causing the received amount to differ from the pair's recorded amount.
 		// e.g. columbus-5 14829F480097AF38ECED3079ACD06BAA0AC0583E6BFCC85375A018617B13BBCB
+		// Native tokens (e.g., axpla, uusd, uluna) always transfer exact amounts via the bank module,
+		// so require an exact match even for pair->user transfers.
 		// For user->pair transfers, the asset amount must match exactly (asset.Amount == entry.amount),
 		// to avoid consuming unrelated same-asset transfers within the same tx.
-		if isPairSendTx || asset.Amount == entry.amount {
+		if (isPairSendTx && isCw20TokenAddress(entry.assetAddr)) || asset.Amount == entry.amount {
 			return true
 		}
 	}

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -166,6 +166,9 @@ var (
 	transferTx = ParsedTx{"", time.Time{}, Transfer, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", nil}
 )
 
+// Test_matchesPairTransferEntry verifies that transfers are matched to pair entries
+// correctly: user->pair requires exact amount; pair->user skips the amount check
+// for CW20 tokens (tax may apply) but requires exact amount for native and IBC tokens.
 func Test_matchesPairTransferEntry(t *testing.T) {
 	mixin := DexMixin{}
 	pairAddr := "PAIR_ADDR"
@@ -176,29 +179,55 @@ func Test_matchesPairTransferEntry(t *testing.T) {
 		expected bool
 		explain  string
 	}{
+		// user -> pair
 		{
 			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
 			transfer: ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"TokenB", ""}}},
 			expected: true,
-			explain:  "user→pair transfer with exact amount must match",
-		},
-		{
-			entry:    transferPopEntry{pairAddr, "TokenB", "-500"},
-			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "490"}}},
-			expected: true,
-			explain:  "pair→user transfer with different amount must match (no amount check)",
-		},
-		{
-			entry:    transferPopEntry{pairAddr, "TokenB", "500"},
-			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "500"}}},
-			expected: false,
-			explain:  "pair→user transfer with positive sign must not match",
+			explain:  "user->pair transfer with exact amount must match",
 		},
 		{
 			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
 			transfer: ParsedTx{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "999"}, {"TokenB", ""}}},
 			expected: false,
-			explain:  "user→pair transfer with mismatched amount must not match (unrelated transfer)",
+			explain:  "user->pair transfer with mismatched amount must not match (unrelated transfer)",
+		},
+		// pair -> user
+		{
+			entry:    transferPopEntry{pairAddr, "terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s", "-500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s", "490"}}},
+			expected: true,
+			explain:  "pair->user transfer of CW20 token with different amount must match (no amount check)",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "uusd", "-500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"uusd", "-500"}, {}}},
+			expected: true,
+			explain:  "pair->user transfer of native token with exact amount must match",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "uusd", "-500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"uusd", "-490"}, {}}},
+			expected: false,
+			explain:  "pair->user transfer of native token with different amount must not match",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4", "-500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4", "-500"}, {}}},
+			expected: true,
+			explain:  "pair->user transfer of IBC token with exact amount must match",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4", "-500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4", "-490"}, {}}},
+			expected: false,
+			explain:  "pair->user transfer of IBC token with different amount must not match",
+		},
+		{
+			entry:    transferPopEntry{pairAddr, "TokenB", "500"},
+			transfer: ParsedTx{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "500"}}},
+			expected: false,
+			explain:  "pair->user transfer with positive sign must not match",
 		},
 		{
 			entry:    transferPopEntry{pairAddr, "TokenA", "1000"},
@@ -214,6 +243,8 @@ func Test_matchesPairTransferEntry(t *testing.T) {
 	}
 }
 
+// Test_removeDuplicatedTxs verifies that transfer txs already captured by pair
+// action events are removed, while unrelated transfers in the same tx are kept.
 func Test_removeDuplicatedTxs(t *testing.T) {
 	mixin := DexMixin{}
 	pairAddr := "PAIR_ADDR"
@@ -232,10 +263,22 @@ func Test_removeDuplicatedTxs(t *testing.T) {
 			explain:     "user->pair transfer matching pair action must be removed",
 		},
 		{
-			pairTxs:     []*ParsedTx{pairTx},
-			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"TokenB", "-490"}}}},
+			pairTxs:     []*ParsedTx{{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s", "-500"}}}},
+			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s", "-490"}}}},
 			expected:    0,
-			explain:     "pair->user transfer (negative entry amount) with amount mismatch must be removed",
+			explain:     "pair->user transfer of CW20 token with amount mismatch must be removed",
+		},
+		{
+			pairTxs:     []*ParsedTx{{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"uusd", "-500"}}}},
+			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"uusd", "-500"}}}},
+			expected:    0,
+			explain:     "pair->user transfer of native token with exact amount must be removed",
+		},
+		{
+			pairTxs:     []*ParsedTx{{ContractAddr: pairAddr, Assets: [2]Asset{{"TokenA", "1000"}, {"uusd", "-500"}}}},
+			transferTxs: []*ParsedTx{{Sender: pairAddr, Assets: [2]Asset{{"TokenA", ""}, {"uusd", "-490"}}}},
+			expected:    1,
+			explain:     "pair->user transfer of native token with amount mismatch must be kept (native transfers are exact)",
 		},
 		{
 			pairTxs: []*ParsedTx{pairTx},

--- a/parser/dex/util.go
+++ b/parser/dex/util.go
@@ -77,3 +77,10 @@ func ToBigInt(n string) (*big.Int, error) {
 
 	return bi, nil
 }
+
+// isCw20TokenAddress reports whether addr is a CW20 token contract address.
+// CW20 contracts have long bech32 addresses (> 20 chars), while native token
+// denoms (e.g., axpla, uusd, uluna) are short and IBC denoms start with "ibc/".
+func isCw20TokenAddress(addr string) bool {
+	return !strings.HasPrefix(addr, "ibc/") && len(addr) > 20
+}

--- a/parser/dex/utils_test.go
+++ b/parser/dex/utils_test.go
@@ -122,3 +122,26 @@ func TestToBigInt(t *testing.T) {
 		})
 	}
 }
+
+// Test_isCw20TokenAddress verifies that native denoms and IBC tokens are not
+// treated as CW20 contracts, while bech32 contract addresses are.
+func Test_isCw20TokenAddress(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{"native uluna", "uluna", false},
+		{"native uusd", "uusd", false},
+		{"native axpla", "axpla", false},
+		{"ibc denom", "ibc/B3504E092456BA618CC28AC671A71FB08C6CA0FD0BE7C8A5B5A3E2DD933CC9E4", false},
+		{"terra CW20 contract", "terra1sepfj7s0aeg5967uxnfk4thzlerrsktkpelm5s", true},
+		{"xpla CW20 contract", "xpla1w6hv0suf8dmpq8kxd8a6yy9fnmntlh7hh9kl37qmax7kyzfd047qnnp0mm", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isCw20TokenAddress(tt.addr))
+		})
+	}
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
In `matchesPairTransferEntry`, pair→user transfers skipped the amount check entirely to accommodate CW20 token contracts that may charge fees/taxes, causing the received amount to differ from the pair's recorded amount. However, this exemption was incorrectly applied to native tokens (e.g., axpla, uusd, uluna) and IBC tokens, which transfer through the bank module and always deliver exact amounts. This could cause unrelated same-asset transfers within the same tx to be incorrectly consumed.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Introduce `isCw20TokenAddress` in `util.go` to distinguish CW20 contract addresses (long bech32, > 20 chars) from native token denoms and IBC tokens (`ibc/` prefix)
- Update `matchesPairTransferEntry` to skip the amount check on pair→user transfers only when the asset is a CW20 token; native and IBC tokens now require an exact amount match
- Add `Test_isCw20TokenAddress` covering native denoms, IBC denoms, and CW20 contract addresses
- Add test cases for `matchesPairTransferEntry` and `RemoveDuplicatedTxs` covering the new native/IBC exact-match behavior; fix previously broken cases that used short placeholder strings as CW20 addresses

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved transaction deduplication accuracy by more precisely matching transfer records. Native tokens now require exact amount matching, while CW20 tokens account for potential fees or taxes that may alter received amounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/119)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->