### PR TITLE
fix: track msg index for tax transfer matching

### DIFF
--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -159,11 +159,11 @@ func Test_validate(t *testing.T) {
 }
 
 var (
-	createTx   = ParsedTx{"", time.Time{}, CreatePair, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	swapTx     = ParsedTx{"", time.Time{}, Swap, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", nil}
-	provideTx  = ParsedTx{"", time.Time{}, Provide, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	withdrawTx = ParsedTx{"", time.Time{}, Withdraw, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}, "Lp", "1000", "", nil}
-	transferTx = ParsedTx{"", time.Time{}, Transfer, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", nil}
+	createTx   = ParsedTx{"", time.Time{}, CreatePair, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	swapTx     = ParsedTx{"", time.Time{}, Swap, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", 0, nil}
+	provideTx  = ParsedTx{"", time.Time{}, Provide, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	withdrawTx = ParsedTx{"", time.Time{}, Withdraw, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}, "Lp", "1000", "", 0, nil}
+	transferTx = ParsedTx{"", time.Time{}, Transfer, "sender", "PAIR_ADDR", [2]Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", 0, nil}
 )
 
 // Test_matchesPairTransferEntry verifies that transfers are matched to pair entries

--- a/parser/dex/dto.go
+++ b/parser/dex/dto.go
@@ -37,6 +37,7 @@ type ParsedTx struct {
 	LpAddr           string   `json:"lpAddr"`
 	LpAmount         string   `json:"lpAmount" faker:"amountString"`
 	CommissionAmount string   `json:"commissionAmount" faker:"amountString"`
+	MsgIndex         int      `json:"msg_index"`
 
 	Meta map[string]interface{} `json:"meta" faker:"meta"`
 }
@@ -77,6 +78,9 @@ func (defaultVal ParsedTx) Override(tx ParsedTx) (ParsedTx, error) {
 	}
 	if tx.CommissionAmount != "" {
 		defaultVal.CommissionAmount = tx.CommissionAmount
+	}
+	if tx.MsgIndex > 0 {
+		defaultVal.MsgIndex = tx.MsgIndex
 	}
 	if tx.Meta != nil {
 		if defaultVal.Meta == nil {

--- a/parser/dex/mapper.go
+++ b/parser/dex/mapper.go
@@ -54,6 +54,7 @@ func (m *factoryMapper) MatchedToParsedTx(res eventlog.MatchedResult, optional .
 		},
 		LpAddr:   res[pdex.FactoryLpAddrIdx].Value,
 		LpAmount: "",
+		MsgIndex: eventlog.MsgIndex(res),
 	}}, nil
 }
 
@@ -163,14 +164,14 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 	assetsStr := matchMap[pdex.TransferAmountKey].Value
 	txs := []*ParsedTx{}
 	if fromPair {
-		tx, err := m.transferToParsedTx(fp, sender, assetsStr, true)
+		tx, err := m.transferToParsedTx(fp, sender, assetsStr, true, eventlog.MsgIndex(res))
 		if err != nil {
 			return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 		}
 		txs = append(txs, tx)
 	}
 	if toPair {
-		tx, err := m.transferToParsedTx(tp, sender, assetsStr, false)
+		tx, err := m.transferToParsedTx(tp, sender, assetsStr, false, eventlog.MsgIndex(res))
 		if err != nil {
 			return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 		}
@@ -183,7 +184,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 	return txs, nil
 }
 
-func (m transferMapper) transferToParsedTx(pair Pair, from, assetsStr string, fromPair bool) (*ParsedTx, error) {
+func (m transferMapper) transferToParsedTx(pair Pair, from, assetsStr string, fromPair bool, msgIndex int) (*ParsedTx, error) {
 	assets := [2]Asset{
 		{Addr: pair.Assets[0]},
 		{Addr: pair.Assets[1]},
@@ -214,6 +215,7 @@ func (m transferMapper) transferToParsedTx(pair Pair, from, assetsStr string, fr
 		Assets:       assets,
 		LpAddr:       "",
 		LpAmount:     "",
+		MsgIndex:     msgIndex,
 		Meta:         meta,
 	}, nil
 }
@@ -261,9 +263,10 @@ func (m *taxPaymentMapper) MatchedToParsedTx(res eventlog.MatchedResult, optiona
 	}
 
 	return []*ParsedTx{{
-		Type:   TaxPayment,
-		Sender: "",
-		Assets: [2]Asset{asset, {}},
+		Type:     TaxPayment,
+		Sender:   "",
+		Assets:   [2]Asset{asset, {}},
+		MsgIndex: eventlog.MsgIndex(res),
 	}}, nil
 }
 

--- a/parser/dex/mappers_test.go
+++ b/parser/dex/mappers_test.go
@@ -27,7 +27,7 @@ func Test_TransferMapper(t *testing.T) {
 			el.MatchedResult{
 				{Key: "recipient", Value: pair.ContractAddr}, {Key: "sender", Value: userAddr}, {Key: "amount", Value: "1000Asset1"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], ""}}, "", "", "", make(map[string]interface{})}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], ""}}, "", "", "", 0, make(map[string]interface{})}},
 			"",
 		},
 		{
@@ -35,7 +35,7 @@ func Test_TransferMapper(t *testing.T) {
 			el.MatchedResult{
 				{Key: "recipient", Value: pair.ContractAddr}, {Key: "sender", Value: userAddr}, {Key: "amount", Value: "1000Asset1,2000Asset2"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "2000"}}, "", "", "", make(map[string]interface{})}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "2000"}}, "", "", "", 0, make(map[string]interface{})}},
 			"",
 		},
 		{
@@ -43,7 +43,7 @@ func Test_TransferMapper(t *testing.T) {
 			el.MatchedResult{
 				{Key: "recipient", Value: pair.ContractAddr}, {Key: "sender", Value: userAddr}, {Key: "amount", Value: "123456789012345678901234567890123456Asset2"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], "123456789012345678901234567890123456"}}, "", "", "", make(map[string]interface{})}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], "123456789012345678901234567890123456"}}, "", "", "", 0, make(map[string]interface{})}},
 			"",
 		},
 		{
@@ -59,7 +59,7 @@ func Test_TransferMapper(t *testing.T) {
 			el.MatchedResult{
 				{Key: "recipient", Value: pair.ContractAddr}, {Key: "sender", Value: userAddr}, {Key: "amount", Value: "1000WrongAsset1"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], ""}}, "", "", "", map[string]interface{}{"WrongAsset1": "1000"}}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], ""}}, "", "", "", 0, map[string]interface{}{"WrongAsset1": "1000"}}},
 			"",
 		},
 		// / wasm transfer
@@ -68,7 +68,7 @@ func Test_TransferMapper(t *testing.T) {
 			el.MatchedResult{
 				{Key: "_contract_address", Value: pair.Assets[0]}, {Key: "action", Value: "transfer"}, {Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr}, {Key: "amount", Value: "1000"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], ""}}, "", "", "", make(map[string]interface{})}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], ""}}, "", "", "", 0, make(map[string]interface{})}},
 			"",
 		},
 		{
@@ -78,7 +78,7 @@ func Test_TransferMapper(t *testing.T) {
 				{Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr},
 				{Key: "amount", Value: "123456789012345678901234567890123456"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], "123456789012345678901234567890123456"}}, "", "", "", make(map[string]interface{})}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], "123456789012345678901234567890123456"}}, "", "", "", 0, make(map[string]interface{})}},
 			"",
 		},
 		{
@@ -96,7 +96,7 @@ func Test_TransferMapper(t *testing.T) {
 				{Key: "_contract_address", Value: "WRONG_CW_20"}, {Key: "action", Value: "transfer"},
 				{Key: "from", Value: userAddr}, {Key: "to", Value: pair.ContractAddr}, {Key: "amount", Value: "1000"},
 			},
-			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], ""}}, "", "", "", map[string]interface{}{"WRONG_CW_20": "1000"}}},
+			[]*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], ""}}, "", "", "", 0, map[string]interface{}{"WRONG_CW_20": "1000"}}},
 			"",
 		},
 	}
@@ -132,7 +132,7 @@ func Test_InitialProvideMapper(t *testing.T) {
 				{Key: "amount", Value: "1000"},
 				{Key: "to", Value: pair.ContractAddr},
 			},
-			[]*ParsedTx{{"", time.Time{}, InitialProvide, "", pair.ContractAddr, [2]Asset{}, pair.LpAddr, "1000", "", nil}},
+			[]*ParsedTx{{"", time.Time{}, InitialProvide, "", pair.ContractAddr, [2]Asset{}, pair.LpAddr, "1000", "", 0, nil}},
 			"",
 		},
 		{
@@ -157,6 +157,57 @@ func Test_InitialProvideMapper(t *testing.T) {
 			assert.NoError(err, err)
 			assert.Equal(tc.expectedTx, tx, errMsg)
 		}
+	}
+}
+
+func Test_MappersPropagateMsgIndex(t *testing.T) {
+	const msgIndex = 2
+	pair := Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
+
+	tcs := []struct {
+		name           string
+		mapper         parser.Mapper[ParsedTx]
+		matchedResults el.MatchedResult
+	}{
+		{
+			name:   "factory",
+			mapper: NewFactoryMapper(),
+			matchedResults: el.MatchedResult{
+				{Key: "_contract_address", Value: "Factory", MsgIndex: msgIndex},
+				{Key: "action", Value: "create_pair", MsgIndex: msgIndex},
+				{Key: "pair", Value: "Asset1-Asset2", MsgIndex: msgIndex},
+				{Key: "_contract_address", Value: pair.ContractAddr, MsgIndex: msgIndex},
+				{Key: "liquidity_token_addr", Value: pair.LpAddr, MsgIndex: msgIndex},
+			},
+		},
+		{
+			name:   "transfer",
+			mapper: NewTransferMapper(map[string]Pair{pair.ContractAddr: pair}),
+			matchedResults: el.MatchedResult{
+				{Key: "amount", Value: "1000Asset1", MsgIndex: msgIndex},
+				{Key: "recipient", Value: pair.ContractAddr, MsgIndex: msgIndex},
+				{Key: "sender", Value: "user", MsgIndex: msgIndex},
+			},
+		},
+		{
+			name:   "tax payment",
+			mapper: NewTaxPaymentMapper(),
+			matchedResults: el.MatchedResult{
+				{Key: "reverse_charge", Value: "Asset1", MsgIndex: msgIndex},
+				{Key: "tax_amount", Value: "1000Asset1", MsgIndex: msgIndex},
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			txs, err := tc.mapper.MatchedToParsedTx(tc.matchedResults)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, txs)
+			for _, tx := range txs {
+				assert.Equal(t, msgIndex, tx.MsgIndex)
+			}
+		})
 	}
 }
 

--- a/parser/dex/parser_test.go
+++ b/parser/dex/parser_test.go
@@ -36,7 +36,7 @@ func Test_parser(t *testing.T) {
 			mapper.On("matchedToParsedTx", mock.Anything, mock.Anything).Return([]*ParsedTx{{}}, errors.New(t.mapperError))
 		}
 	}
-	parsedTx := &ParsedTx{"hash", time.Time{}, Provide, "sender", "ContractAddr", [2]Asset{{"Asset0", "100"}, {"Asset1", "100"}}, "Lp", "1000", "", make(map[string]interface{})}
+	parsedTx := &ParsedTx{"hash", time.Time{}, Provide, "sender", "ContractAddr", [2]Asset{{"Asset0", "100"}, {"Asset1", "100"}}, "Lp", "1000", "", 0, make(map[string]interface{})}
 
 	tcs := []testCase{
 		{[]*ParsedTx{}, eventlog.MatchedResults{}, []*ParsedTx{{}}, ""},

--- a/parser/dex/srcstore/terraswap/base_datastore.go
+++ b/parser/dex/srcstore/terraswap/base_datastore.go
@@ -157,8 +157,9 @@ func groupLogAttrByType(logs logResults) map[eventlog.LogType]eventlog.Attribute
 			attributes := eventlog.Attributes{}
 			for _, attr := range event.Attributes {
 				attributes = append(attributes, eventlog.Attribute{
-					Key:   attr.Key,
-					Value: attr.Value,
+					Key:      attr.Key,
+					Value:    attr.Value,
+					MsgIndex: log.MsgIndex,
 				})
 			}
 			logType := event.Type

--- a/parser/dex/srcstore/terraswap/base_datastore_test.go
+++ b/parser/dex/srcstore/terraswap/base_datastore_test.go
@@ -86,6 +86,7 @@ func Test_convertLogToRawTx_InvalidFormat(t *testing.T) {
 func Test_groupLogAttrByType(t *testing.T) {
 	logs := logResults{
 		{
+			MsgIndex: 3,
 			Events: eventlog.LogResults{
 				{
 					Type:       "wasm",
@@ -98,6 +99,7 @@ func Test_groupLogAttrByType(t *testing.T) {
 			},
 		},
 		{
+			MsgIndex: 4,
 			Events: eventlog.LogResults{
 				{
 					Type:       "wasm",
@@ -108,8 +110,11 @@ func Test_groupLogAttrByType(t *testing.T) {
 	}
 	result := groupLogAttrByType(logs)
 	assert.Len(t, result, 2)
-	assert.Equal(t, eventlog.Attributes{{Key: "k2", Value: "v2"}}, result["transfer"])
-	assert.ElementsMatch(t, []eventlog.Attribute{{Key: "k1", Value: "v1"}, {Key: "k3", Value: "v3"}}, result["wasm"])
+	assert.Equal(t, eventlog.Attributes{{Key: "k2", Value: "v2", MsgIndex: 3}}, result["transfer"])
+	assert.ElementsMatch(t, []eventlog.Attribute{
+		{Key: "k1", Value: "v1", MsgIndex: 3},
+		{Key: "k3", Value: "v3", MsgIndex: 4},
+	}, result["wasm"])
 }
 
 func Test_groupLogAttrByType_Empty(t *testing.T) {

--- a/parser/dex/terraswap/columbusv1/app_test.go
+++ b/parser/dex/terraswap/columbusv1/app_test.go
@@ -127,12 +127,12 @@ func rawLogs(logStr string) eventlog.LogResults {
 
 var (
 	pair           = dex.Pair{ContractAddr: "PAIR_ADDR", Assets: []string{"Asset0", "Asset1"}, LpAddr: "Lp"}
-	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", map[string]interface{}{"tax_amount": dex.Asset{pair.Assets[1], "0"}}}
-	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", map[string]interface{}{"withdraw_assets": []dex.Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}}}
-	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", make(map[string]interface{})}
-	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", make(map[string]interface{})}
+	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", 0, map[string]interface{}{"tax_amount": dex.Asset{pair.Assets[1], "0"}}}
+	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", 0, map[string]interface{}{"withdraw_assets": []dex.Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}}}
+	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", 0, make(map[string]interface{})}
+	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", 0, make(map[string]interface{})}
 )
 
 const (

--- a/parser/dex/terraswap/columbusv1/mappers.go
+++ b/parser/dex/terraswap/columbusv1/mappers.go
@@ -2,6 +2,7 @@ package columbusv1
 
 import (
 	"fmt"
+
 	pdex "github.com/dezswap/cosmwasm-etl/pkg/dex"
 
 	"github.com/dezswap/cosmwasm-etl/parser"

--- a/parser/dex/terraswap/columbusv1/mappers_test.go
+++ b/parser/dex/terraswap/columbusv1/mappers_test.go
@@ -31,7 +31,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "tax_amount", Value: "0"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "302"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "100000"}, {pair.Assets[1], "-100583"}}, "", "", "302", map[string]interface{}{"tax_amount": dex.Asset{pair.Assets[1], "0"}}}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "100000"}, {pair.Assets[1], "-100583"}}, "", "", "302", 0, map[string]interface{}{"tax_amount": dex.Asset{pair.Assets[1], "0"}}}},
 			"",
 		},
 		{
@@ -44,7 +44,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "tax_amount", Value: "583"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "300"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100000"}, {pair.Assets[1], "100000"}}, "", "", "300", map[string]interface{}{"tax_amount": dex.Asset{pair.Assets[0], "583"}}}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100000"}, {pair.Assets[1], "100000"}}, "", "", "300", 0, map[string]interface{}{"tax_amount": dex.Asset{pair.Assets[0], "583"}}}},
 			"",
 		},
 		{
@@ -64,7 +64,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "assets", Value: fmt.Sprintf("%s%s, %s%s", "1000", pair.Assets[0], "10000", pair.Assets[1])},
 				{Key: "share", Value: "998735"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "10000"}}, pair.LpAddr, "998735", "", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "10000"}}, pair.LpAddr, "998735", "", 0, nil}},
 			"",
 		},
 		{
@@ -87,7 +87,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "withdrawn_share", Value: "12418119"},
 				{Key: "refund_assets", Value: fmt.Sprintf("%s%s, %s%s", "24999998", pair.Assets[0], "24939789", pair.Assets[1])},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Withdraw, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "0"}, {pair.Assets[1], "0"}}, pair.LpAddr, "12418119", "", map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}}}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Withdraw, "", pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "0"}, {pair.Assets[1], "0"}}, pair.LpAddr, "12418119", "", 0, map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}}}},
 			"",
 		},
 		{

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -198,6 +198,7 @@ func (p *terraswapApp) deductTaxFromPairTxs(taxTxs, pairTransferTxs, pairTxs []*
 		addr      string
 		assetIdx  int
 		absAmount int64
+		msgIdx    int
 	}
 	pairTxIdx := make(map[pairKey]int)
 	for i, t := range pairTxs {
@@ -209,15 +210,21 @@ func (p *terraswapApp) deductTaxFromPairTxs(taxTxs, pairTransferTxs, pairTxs []*
 			if amount < 0 {
 				amount = -amount
 			}
-			pairTxIdx[pairKey{t.ContractAddr, j, amount}] = i
+			pairTxIdx[pairKey{t.ContractAddr, j, amount, t.MsgIndex}] = i
 		}
 	}
 
-	// queue tax amounts by asset addr (consumed one by one)
-	taxQueue := make(map[string][]int64)
+	type taxKey struct {
+		addr   string
+		msgIdx int
+	}
+
+	// queue tax amounts by asset addr and message index (consumed one by one)
+	taxQueue := make(map[taxKey][]int64)
 	for _, t := range taxTxs {
 		amount, _ := strconv.ParseInt(t.Assets[0].Amount, 10, 64)
-		taxQueue[t.Assets[0].Addr] = append(taxQueue[t.Assets[0].Addr], amount)
+		k := taxKey{t.Assets[0].Addr, t.MsgIndex}
+		taxQueue[k] = append(taxQueue[k], amount)
 	}
 
 	for _, tx := range pairTransferTxs {
@@ -230,7 +237,8 @@ func (p *terraswapApp) deductTaxFromPairTxs(taxTxs, pairTransferTxs, pairTxs []*
 			netAsset, assetIdx = tx.Assets[1], 1
 		}
 
-		taxes := taxQueue[netAsset.Addr]
+		taxQueueKey := taxKey{netAsset.Addr, tx.MsgIndex}
+		taxes := taxQueue[taxQueueKey]
 		if len(taxes) == 0 {
 			continue
 		}
@@ -241,11 +249,11 @@ func (p *terraswapApp) deductTaxFromPairTxs(taxTxs, pairTransferTxs, pairTxs []*
 		}
 
 		for j, taxAmount := range taxes {
-			key := pairKey{tx.ContractAddr, assetIdx, netAmount + taxAmount} // gross = net + tax
+			key := pairKey{tx.ContractAddr, assetIdx, netAmount + taxAmount, tx.MsgIndex} // gross = net + tax
 			if i, ok := pairTxIdx[key]; ok {
 				pairTxs[i].Assets[assetIdx].Amount = netAsset.Amount
 				delete(pairTxIdx, key)
-				taxQueue[netAsset.Addr] = append(taxes[:j], taxes[j+1:]...)
+				taxQueue[taxQueueKey] = append(taxes[:j], taxes[j+1:]...)
 				break
 			}
 		}
@@ -267,10 +275,13 @@ func (p *terraswapApp) extractTaxTransfers(transferTxs, taxTxs []*dex.ParsedTx, 
 	for _, addr := range pairAddrs {
 		pairAddrSet[addr] = true
 	}
-	type taxKey struct{ addr, amount string }
+	type taxKey struct {
+		addr, amount string
+		msgIdx       int
+	}
 	taxCounts := make(map[taxKey]int, len(taxTxs))
 	for _, t := range taxTxs {
-		taxCounts[taxKey{t.Assets[0].Addr, t.Assets[0].Amount}]++
+		taxCounts[taxKey{t.Assets[0].Addr, t.Assets[0].Amount, t.MsgIndex}]++
 	}
 	for _, tx := range transferTxs {
 		if !pairAddrSet[tx.Sender] {
@@ -291,7 +302,7 @@ func (p *terraswapApp) extractTaxTransfers(transferTxs, taxTxs []*dex.ParsedTx, 
 			remaining = append(remaining, tx)
 			continue
 		}
-		k := taxKey{asset.Addr, asset.Amount[1:]}
+		k := taxKey{asset.Addr, asset.Amount[1:], tx.MsgIndex}
 		if taxCounts[k] > 0 {
 			taxCounts[k]--
 			taxTransfers = append(taxTransfers, tx)

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
 	dts "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap"
+	cv2 "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/columbusv2"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/faker"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
@@ -189,6 +190,32 @@ func Test_extractTaxTransfers(t *testing.T) {
 	assert.Len(taxed, 2, "both tax transfers should be extracted")
 	assert.Len(rem, 1, "only result transfer should remain")
 	assert.Equal(resultTransfer, rem[0])
+
+	// same asset and amount in different messages must not match across MsgIndex
+	taxTxMsg1 := &dex.ParsedTx{
+		Type:     dex.TaxPayment,
+		Assets:   [2]dex.Asset{{Addr: "uluna", Amount: "10"}, {}},
+		MsgIndex: 1,
+	}
+	taxTransferMsg0 := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		Sender:       pairAddr,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: "uluna", Amount: "-10"}, {}},
+		MsgIndex:     0,
+	}
+	taxTransferMsg1 := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		Sender:       pairAddr,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: "uluna", Amount: "-10"}, {}},
+		MsgIndex:     1,
+	}
+	taxed, rem = app.extractTaxTransfers([]*dex.ParsedTx{taxTransferMsg0, taxTransferMsg1}, []*dex.ParsedTx{taxTxMsg1}, pairAddrs)
+	assert.Len(taxed, 1, "only the matching MsgIndex tax transfer should be extracted")
+	assert.Equal(taxTransferMsg1, taxed[0])
+	assert.Len(rem, 1, "same asset and amount with different MsgIndex should remain")
+	assert.Equal(taxTransferMsg0, rem[0])
 }
 
 func Test_taxDeduction(t *testing.T) {
@@ -220,6 +247,73 @@ func Test_taxDeduction(t *testing.T) {
 	assert.Equal("-990", result[0].Assets[1].Amount, "Asset1 outflow: net -990 applied from pairTransferTx")
 }
 
+func Test_taxDeduction_MatchesMsgIndex(t *testing.T) {
+	assert := assert.New(t)
+	app := &terraswapApp{}
+
+	pairTxMsg0 := &dex.ParsedTx{
+		Type:         dex.Swap,
+		ContractAddr: "PAIR_ADDR",
+		Assets:       [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}},
+		MsgIndex:     0,
+	}
+	pairTxMsg1 := &dex.ParsedTx{
+		Type:         dex.Swap,
+		ContractAddr: "PAIR_ADDR",
+		Assets:       [2]dex.Asset{{"Asset0", "2000"}, {"Asset1", "-1000"}},
+		MsgIndex:     1,
+	}
+	taxTxMsg1 := &dex.ParsedTx{
+		Type:     dex.TaxPayment,
+		Assets:   [2]dex.Asset{{Addr: "Asset1", Amount: "10"}, {}},
+		MsgIndex: 1,
+	}
+	pairTransferTxMsg1 := &dex.ParsedTx{
+		Type:         dex.Transfer,
+		ContractAddr: "PAIR_ADDR",
+		Assets:       [2]dex.Asset{{Addr: "Asset0", Amount: ""}, {Addr: "Asset1", Amount: "-990"}},
+		MsgIndex:     1,
+	}
+
+	result := app.deductTaxFromPairTxs(
+		[]*dex.ParsedTx{taxTxMsg1},
+		[]*dex.ParsedTx{pairTransferTxMsg1},
+		[]*dex.ParsedTx{pairTxMsg0, pairTxMsg1},
+	)
+	assert.Equal("-1000", result[0].Assets[1].Amount, "msg 0 pair tx must not consume msg 1 tax")
+	assert.Equal("-990", result[1].Assets[1].Amount, "msg 1 pair tx should consume msg 1 tax")
+}
+
+func Test_pairMapper_PropagatesMsgIndex(t *testing.T) {
+	assert := assert.New(t)
+
+	pairSet := map[string]dex.Pair{
+		pair.ContractAddr: pair,
+	}
+	finder, err := cv2.CreatePairCommonRulesFinder(map[string]bool{pair.ContractAddr: true})
+	assert.NoError(err)
+
+	parser := parser.NewParser(finder, &pairMapper{pairSet: pairSet})
+	txs, err := parser.Parse(eventlog.LogResults{{
+		Type: eventlog.WasmType,
+		Attributes: eventlog.Attributes{
+			{Key: "_contract_address", Value: pair.ContractAddr, MsgIndex: 1},
+			{Key: "action", Value: string(cv2.SwapAction), MsgIndex: 1},
+			{Key: "sender", Value: sender, MsgIndex: 1},
+			{Key: "receiver", Value: "receiver", MsgIndex: 1},
+			{Key: "offer_asset", Value: pair.Assets[0], MsgIndex: 1},
+			{Key: "ask_asset", Value: pair.Assets[1], MsgIndex: 1},
+			{Key: "offer_amount", Value: "1000", MsgIndex: 1},
+			{Key: "return_amount", Value: "1000", MsgIndex: 1},
+			{Key: "spread_amount", Value: "10", MsgIndex: 1},
+			{Key: "commission_amount", Value: "1", MsgIndex: 1},
+		},
+	}}, dex.ParsedTx{Hash: hash, Timestamp: time.Time{}})
+	assert.NoError(err)
+	assert.Len(txs, 1)
+	assert.Equal(1, txs[0].MsgIndex)
+}
+
 func rawLogs(logStr string) eventlog.LogResults {
 	logs := eventlog.LogResults{}
 	if err := json.Unmarshal([]byte(logStr), &logs); err != nil {
@@ -230,12 +324,12 @@ func rawLogs(logStr string) eventlog.LogResults {
 
 var (
 	pair           = dex.Pair{ContractAddr: "PAIR_ADDR", Assets: []string{"Asset0", "Asset1"}, LpAddr: "Lp"}
-	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", nil}
-	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-1000"}, {pair.Assets[1], "-1000"}}}}
-	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", make(map[string]interface{})}
-	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", make(map[string]interface{})}
+	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", 0, nil}
+	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", 0, map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-1000"}, {pair.Assets[1], "-1000"}}}}
+	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", 0, make(map[string]interface{})}
+	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", 0, make(map[string]interface{})}
 )
 
 const (

--- a/parser/dex/terraswap/columbusv2/mappers.go
+++ b/parser/dex/terraswap/columbusv2/mappers.go
@@ -75,6 +75,7 @@ func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.
 		Sender:           matchMap[pdex.PairSwapSenderKey].Value,
 		Assets:           assets,
 		CommissionAmount: matchMap[pdex.PairSwapCommissionAmountKey].Value,
+		MsgIndex:         eventlog.MsgIndex(res),
 		Meta:             nil,
 	}}, nil
 }
@@ -118,6 +119,7 @@ func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair d
 		Assets:       [2]dex.Asset(assets),
 		LpAddr:       pair.LpAddr,
 		LpAmount:     matchMap[columbusv2.PairProvideShareKey].Value,
+		MsgIndex:     eventlog.MsgIndex(res),
 	}}, nil
 }
 
@@ -146,6 +148,7 @@ func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair 
 		Assets:       [2]dex.Asset{{Addr: assets[0].Addr, Amount: "0"}, {Addr: assets[1].Addr, Amount: "0"}},
 		LpAddr:       pair.LpAddr,
 		LpAmount:     matchMap[columbusv2.PairWithdrawWithdrawShareKey].Value,
+		MsgIndex:     eventlog.MsgIndex(res),
 		Meta: map[string]interface{}{
 			"withdraw_assets": assets,
 		},

--- a/parser/dex/terraswap/columbusv2/mappers_test.go
+++ b/parser/dex/terraswap/columbusv2/mappers_test.go
@@ -34,7 +34,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "302"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "100000"}, {pair.Assets[1], "-100583"}}, "", "", "302", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "100000"}, {pair.Assets[1], "-100583"}}, "", "", "302", 0, nil}},
 			"",
 		},
 		{
@@ -46,7 +46,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "300"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100583"}, {pair.Assets[1], "100000"}}, "", "", "300", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100583"}, {pair.Assets[1], "100000"}}, "", "", "300", 0, nil}},
 			"",
 		},
 		{
@@ -58,7 +58,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"}, {Key: "tax_amount", Value: "583"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "300"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100000"}, {pair.Assets[1], "100000"}}, "", "", "300", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100000"}, {pair.Assets[1], "100000"}}, "", "", "300", 0, nil}},
 			"",
 		},
 		{
@@ -79,7 +79,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "assets", Value: fmt.Sprintf("%s%s, %s%s", "1000", pair.Assets[0], "10000", pair.Assets[1])},
 				{Key: "share", Value: "998735"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "10000"}}, pair.LpAddr, "998735", "", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "10000"}}, pair.LpAddr, "998735", "", 0, nil}},
 			"",
 		},
 		{
@@ -90,7 +90,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "assets", Value: fmt.Sprintf("%s%s, %s%s", "1000", pair.Assets[0], "10000", pair.Assets[1])},
 				{Key: "share", Value: "998735"}, {Key: columbusv2.PairProvideRefundAssetKey, Value: fmt.Sprintf("%s%s, %s%s", "100", pair.Assets[0], "100", pair.Assets[1])},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "900"}, {pair.Assets[1], "9900"}}, pair.LpAddr, "998735", "", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "900"}, {pair.Assets[1], "9900"}}, pair.LpAddr, "998735", "", 0, nil}},
 			"",
 		},
 		{
@@ -114,7 +114,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "withdrawn_share", Value: "12418119"},
 				{Key: "refund_assets", Value: fmt.Sprintf("%s%s, %s%s", "24999998", pair.Assets[0], "24939789", pair.Assets[1])},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Withdraw, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "0"}, {pair.Assets[1], "0"}}, pair.LpAddr, "12418119", "", map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}}}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Withdraw, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "0"}, {pair.Assets[1], "0"}}, pair.LpAddr, "12418119", "", 0, map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}}}},
 			"",
 		},
 		{

--- a/parser/dex/terraswap/phoenix/app_test.go
+++ b/parser/dex/terraswap/phoenix/app_test.go
@@ -125,12 +125,12 @@ func rawLogs(logStr string) eventlog.LogResults {
 
 var (
 	pair           = dex.Pair{ContractAddr: "PAIR_ADDR", Assets: []string{"Asset0", "Asset1"}, LpAddr: "Lp"}
-	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", nil}
-	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", nil}
-	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}, "Lp", "1000", "", nil}
-	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", make(map[string]interface{})}
-	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", make(map[string]interface{})}
+	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", 0, nil}
+	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "-1000"}, {"Asset1", "-1000"}}, "Lp", "1000", "", 0, nil}
+	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", 0, make(map[string]interface{})}
+	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", 0, make(map[string]interface{})}
 )
 
 const (

--- a/parser/dex/terraswap/phoenix/mappers_test.go
+++ b/parser/dex/terraswap/phoenix/mappers_test.go
@@ -34,7 +34,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "302"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "100000"}, {pair.Assets[1], "-100583"}}, "", "", "302", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "100000"}, {pair.Assets[1], "-100583"}}, "", "", "302", 0, nil}},
 			"",
 		},
 		{
@@ -46,7 +46,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "offer_amount", Value: "100000"}, {Key: "return_amount", Value: "100583"},
 				{Key: "spread_amount", Value: "2"}, {Key: "commission_amount", Value: "300"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100583"}, {pair.Assets[1], "100000"}}, "", "", "300", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Swap, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-100583"}, {pair.Assets[1], "100000"}}, "", "", "300", 0, nil}},
 			"",
 		},
 		{
@@ -67,7 +67,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "assets", Value: fmt.Sprintf("%s%s, %s%s", "1000", pair.Assets[0], "10000", pair.Assets[1])},
 				{Key: "share", Value: "998735"},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "10000"}}, pair.LpAddr, "998735", "", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], "10000"}}, pair.LpAddr, "998735", "", 0, nil}},
 			"",
 		},
 		{
@@ -78,7 +78,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "assets", Value: fmt.Sprintf("%s%s, %s%s", "1000", pair.Assets[0], "10000", pair.Assets[1])},
 				{Key: "share", Value: "998735"}, {Key: phoenix.PairProvideRefundAssetKey, Value: fmt.Sprintf("%s%s, %s%s", "100", pair.Assets[0], "100", pair.Assets[1])},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "900"}, {pair.Assets[1], "9900"}}, pair.LpAddr, "998735", "", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Provide, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "900"}, {pair.Assets[1], "9900"}}, pair.LpAddr, "998735", "", 0, nil}},
 			"",
 		},
 		{
@@ -102,7 +102,7 @@ func Test_PairMapper(t *testing.T) {
 				{Key: "withdrawn_share", Value: "12418119"},
 				{Key: "refund_assets", Value: fmt.Sprintf("%s%s, %s%s", "24999998", pair.Assets[0], "24939789", pair.Assets[1])},
 			},
-			[]*dex.ParsedTx{{"", time.Time{}, dex.Withdraw, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}, pair.LpAddr, "12418119", "", nil}},
+			[]*dex.ParsedTx{{"", time.Time{}, dex.Withdraw, userAddr, pair.ContractAddr, [2]dex.Asset{{pair.Assets[0], "-24999998"}, {pair.Assets[1], "-24939789"}}, pair.LpAddr, "12418119", "", 0, nil}},
 			"",
 		},
 		{

--- a/pkg/eventlog/finder.go
+++ b/pkg/eventlog/finder.go
@@ -74,15 +74,17 @@ func (f *logfinderImpl) findMatchingSubseq(attrIdx int, attrs Attributes) (Match
 	matchedResult := make(MatchedResult, 0)
 
 	i := 0
+	msgIndex := -1
 	for ; i < ruleItemsSize; i++ {
 		if shouldSkipKey(attrs[attrIdx+i].Key) && (attrIdx+ruleItemsSize) < attrsSize {
 			attrIdx++
 		}
-		if !f.rule.Items[i].Match(attrs[attrIdx+i]) {
+		if !f.rule.Items[i].Match(attrs[attrIdx+i]) || (msgIndex != -1 && attrs[attrIdx+i].MsgIndex != msgIndex) {
 			break
 		}
 
-		matchedResult = append(matchedResult, MatchedItem{attrs[attrIdx+i].Key, attrs[attrIdx+i].Value})
+		msgIndex = attrs[attrIdx+i].MsgIndex
+		matchedResult = append(matchedResult, MatchedItem{attrs[attrIdx+i].Key, attrs[attrIdx+i].Value, msgIndex})
 	}
 
 	return matchedResult, attrIdx + i
@@ -96,7 +98,7 @@ func (f *logfinderImpl) appendUntil(attrIdx int, matchedResult MatchedResult, at
 		for ; attrIdx < attrsSize && attrs[attrIdx].Key != f.rule.Until; attrIdx++ {
 			key := attrs[attrIdx].Key
 			if !shouldSkipKey(key) {
-				matchedResult = append(matchedResult, MatchedItem{key, attrs[attrIdx].Value})
+				matchedResult = append(matchedResult, MatchedItem{key, attrs[attrIdx].Value, attrs[attrIdx].MsgIndex})
 			}
 		}
 	}

--- a/pkg/eventlog/finder_test.go
+++ b/pkg/eventlog/finder_test.go
@@ -18,11 +18,11 @@ func TestFindFromLogs(t *testing.T) {
 			LogResults{
 				LogResult{
 					WasmType,
-					Attributes{{"contract", "a"}, {"contract", "b"}, {"contract", "c"}, {"contract", "d"}},
+					Attributes{{Key: "contract", Value: "a"}, {Key: "contract", Value: "b"}, {Key: "contract", Value: "c"}, {Key: "contract", Value: "d"}},
 				},
 				LogResult{
 					WasmType,
-					Attributes{{"contract", "a"}, {"contract", "b"}, {"contract", "c"}, {"contract", "d"}},
+					Attributes{{Key: "contract", Value: "a"}, {Key: "contract", Value: "b"}, {Key: "contract", Value: "c"}, {Key: "contract", Value: "d"}},
 				},
 			},
 			RuleItems{RuleItem{"contract", func(v string) bool {
@@ -38,7 +38,7 @@ func TestFindFromLogs(t *testing.T) {
 			LogResults{
 				LogResult{
 					WasmType,
-					Attributes{{"a", "Value is not important"}, {"a", "TEST"}, {"a", ""}},
+					Attributes{{Key: "a", Value: "Value is not important"}, {Key: "a", Value: "TEST"}, {Key: "a", Value: ""}},
 				},
 			},
 			RuleItems{RuleItem{Key: "a", Filter: nil}},
@@ -50,12 +50,12 @@ func TestFindFromLogs(t *testing.T) {
 			LogResults{
 				LogResult{
 					WasmType,
-					Attributes{{"a", "a"}, {"b", "b"}, {"c", "c"}},
+					Attributes{{Key: "a", Value: "a"}, {Key: "b", Value: "b"}, {Key: "c", Value: "c"}},
 				},
 			},
 			RuleItems{
 				{Key: "a", Filter: nil},
-				{"b", "b"},
+				{Key: "b", Filter: "b"},
 				{"c", func(c string) bool { return c == "c" }},
 			},
 			"",
@@ -66,12 +66,12 @@ func TestFindFromLogs(t *testing.T) {
 			LogResults{
 				LogResult{
 					WasmType,
-					Attributes{{"a", "a"}, {"b", "b"}, {"c", "c"}, {"a", "a"}, {"b", "b"}, {"c", "c"}, {"a", "a"}, {"b", "b"}, {"c", "c"}},
+					Attributes{{Key: "a", Value: "a"}, {Key: "b", Value: "b"}, {Key: "c", Value: "c"}, {Key: "a", Value: "a"}, {Key: "b", Value: "b"}, {Key: "c", Value: "c"}, {Key: "a", Value: "a"}, {Key: "b", Value: "b"}, {Key: "c", Value: "c"}},
 				},
 			},
 			RuleItems{
 				{Key: "a", Filter: nil},
-				{"b", "b"},
+				{Key: "b", Filter: "b"},
 				{"c", func(c string) bool { return false }},
 			},
 			"",
@@ -100,10 +100,10 @@ func TestFindFromAttr(t *testing.T) {
 	}{
 		{
 			Attributes{
-				{"contract", "a"},
-				{"contract", "b"},
-				{"contract", "c"},
-				{"contract", "d"},
+				{Key: "contract", Value: "a"},
+				{Key: "contract", Value: "b"},
+				{Key: "contract", Value: "c"},
+				{Key: "contract", Value: "d"},
 			},
 			RuleItems{RuleItem{"contract", func(v string) bool {
 				filterMap := map[string]bool{"a": true, "b": true, "c": true}
@@ -116,9 +116,9 @@ func TestFindFromAttr(t *testing.T) {
 		},
 		{
 			Attributes{
-				{"a", "Value is not important"},
-				{"a", "TEST"},
-				{"a", ""},
+				{Key: "a", Value: "Value is not important"},
+				{Key: "a", Value: "TEST"},
+				{Key: "a", Value: ""},
 			},
 			RuleItems{RuleItem{Key: "a", Filter: nil}},
 			"",
@@ -127,13 +127,13 @@ func TestFindFromAttr(t *testing.T) {
 		},
 		{
 			Attributes{
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
 			},
 			RuleItems{
 				{Key: "a", Filter: nil},
-				{"b", "b"},
+				{Key: "b", Filter: "b"},
 				{"c", func(c string) bool { return c == "c" }},
 			},
 			"",
@@ -142,19 +142,19 @@ func TestFindFromAttr(t *testing.T) {
 		},
 		{
 			Attributes{
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
 			},
 			RuleItems{
 				{Key: "a", Filter: nil},
-				{"b", "b"},
+				{Key: "b", Filter: "b"},
 				{"c", func(c string) bool { return false }},
 			},
 			"",
@@ -163,15 +163,15 @@ func TestFindFromAttr(t *testing.T) {
 		},
 		{
 			Attributes{
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
 			},
 			RuleItems{
 				{Key: "a", Filter: nil},
@@ -182,15 +182,15 @@ func TestFindFromAttr(t *testing.T) {
 		},
 		{
 			Attributes{
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
-				{"a", "a"},
-				{"b", "b"},
-				{"c", "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
+				{Key: "a", Value: "a"},
+				{Key: "b", Value: "b"},
+				{Key: "c", Value: "c"},
 			},
 			RuleItems{
 				{Key: "a", Filter: nil},
@@ -221,17 +221,17 @@ func TestFindFromAttr_WithMsgIndex(t *testing.T) {
 		// create_pair
 		{
 			Attributes{
-				{"_contract_address", "factory_address"},
-				{"action", "create_pair"},
-				{"pair", "asset1_address-asset2_address"},
-				{"msg_index", "0"},
-				{"_contract_address", "pair_address"},
-				{"liquidity_token_addr", "lp_token_address"},
-				{"msg_index", "0"},
-				{"_contract_address", "factory_address"},
-				{"pair_contract_addr", "pair_address"},
-				{"liquidity_token_addr", "lp_token_address"},
-				{"msg_index", "0"},
+				{Key: "_contract_address", Value: "factory_address"},
+				{Key: "action", Value: "create_pair"},
+				{Key: "pair", Value: "asset1_address-asset2_address"},
+				{Key: "msg_index", Value: "0"},
+				{Key: "_contract_address", Value: "pair_address"},
+				{Key: "liquidity_token_addr", Value: "lp_token_address"},
+				{Key: "msg_index", Value: "0"},
+				{Key: "_contract_address", Value: "factory_address"},
+				{Key: "pair_contract_addr", Value: "pair_address"},
+				{Key: "liquidity_token_addr", Value: "lp_token_address"},
+				{Key: "msg_index", Value: "0"},
 			},
 			RuleItems{
 				RuleItem{Key: "_contract_address", Filter: nil},
@@ -246,13 +246,13 @@ func TestFindFromAttr_WithMsgIndex(t *testing.T) {
 		},
 		{
 			Attributes{
-				{"_contract_address", "factory_address"},
-				{"action", "create_pair"},
-				{"pair", "asset1_address-asset2_address"},
-				{"msg_index", "0"},
-				{"_contract_address", "pair_address"},
-				{"liquidity_token_addr", "lp_token_address"},
-				{"msg_index", "0"},
+				{Key: "_contract_address", Value: "factory_address"},
+				{Key: "action", Value: "create_pair"},
+				{Key: "pair", Value: "asset1_address-asset2_address"},
+				{Key: "msg_index", Value: "0"},
+				{Key: "_contract_address", Value: "pair_address"},
+				{Key: "liquidity_token_addr", Value: "lp_token_address"},
+				{Key: "msg_index", Value: "0"},
 			},
 			RuleItems{
 				RuleItem{Key: "_contract_address", Filter: nil},
@@ -268,23 +268,23 @@ func TestFindFromAttr_WithMsgIndex(t *testing.T) {
 		// swap
 		{
 			Attributes{
-				{"_contract_address", "pair_address"},
-				{"action", "swap"},
-				{"sender", "sender_address"},
-				{"receiver", "receiver_address"},
-				{"offer_asset", "asset1_address"},
-				{"ask_asset", "asset2_address"},
-				{"offer_amount", "1000000"},
-				{"return_amount", "1000"},
-				{"spread_amount", "1"},
-				{"commission_amount", "3"},
-				{"msg_index", "0"},
-				{"_contract_address", "asset2_address"},
-				{"action", "transfer"},
-				{"amount", "1000"},
-				{"from", "pair_address"},
-				{"to", "sender_address"},
-				{"msg_index", "0"},
+				{Key: "_contract_address", Value: "pair_address"},
+				{Key: "action", Value: "swap"},
+				{Key: "sender", Value: "sender_address"},
+				{Key: "receiver", Value: "receiver_address"},
+				{Key: "offer_asset", Value: "asset1_address"},
+				{Key: "ask_asset", Value: "asset2_address"},
+				{Key: "offer_amount", Value: "1000000"},
+				{Key: "return_amount", Value: "1000"},
+				{Key: "spread_amount", Value: "1"},
+				{Key: "commission_amount", Value: "3"},
+				{Key: "msg_index", Value: "0"},
+				{Key: "_contract_address", Value: "asset2_address"},
+				{Key: "action", Value: "transfer"},
+				{Key: "amount", Value: "1000"},
+				{Key: "from", Value: "pair_address"},
+				{Key: "to", Value: "sender_address"},
+				{Key: "msg_index", Value: "0"},
 			},
 			RuleItems{
 				RuleItem{Key: "_contract_address", Filter: nil},
@@ -297,32 +297,32 @@ func TestFindFromAttr_WithMsgIndex(t *testing.T) {
 		// provide
 		{
 			Attributes{
-				{"_contract_address", "asset2_address"},
-				{"action", "increase_allowance"},
-				{"owner", "provider_address"},
-				{"spender", "pair_address"},
-				{"amount", "1000000"},
-				{"msg_index", "0"},
-				{"_contract_address", "pair_address"},
-				{"action", "provide_liquidity"},
-				{"sender", "provider_address"},
-				{"receiver", "provider_address"},
-				{"assets", "1000000asset1, 1000000asset2"},
-				{"share", "1000000"},
-				{"refund_assets", "0asset1, 0asset2"},
-				{"msg_index", "1"},
-				{"_contract_address", "asset2_address"},
-				{"action", "transfer_from"},
-				{"amount", "1000000"},
-				{"by", "pair_address"},
-				{"from", "provider_address"},
-				{"to", "pair_address"},
-				{"msg_index", "1"},
-				{"_contract_address", "lp_token_address"},
-				{"action", "mint"},
-				{"amount", "1000000"},
-				{"to", "provider_address"},
-				{"msg_index", "1"},
+				{Key: "_contract_address", Value: "asset2_address"},
+				{Key: "action", Value: "increase_allowance"},
+				{Key: "owner", Value: "provider_address"},
+				{Key: "spender", Value: "pair_address"},
+				{Key: "amount", Value: "1000000"},
+				{Key: "msg_index", Value: "0"},
+				{Key: "_contract_address", Value: "pair_address"},
+				{Key: "action", Value: "provide_liquidity"},
+				{Key: "sender", Value: "provider_address"},
+				{Key: "receiver", Value: "provider_address"},
+				{Key: "assets", Value: "1000000asset1, 1000000asset2"},
+				{Key: "share", Value: "1000000"},
+				{Key: "refund_assets", Value: "0asset1, 0asset2"},
+				{Key: "msg_index", Value: "1"},
+				{Key: "_contract_address", Value: "asset2_address"},
+				{Key: "action", Value: "transfer_from"},
+				{Key: "amount", Value: "1000000"},
+				{Key: "by", Value: "pair_address"},
+				{Key: "from", Value: "provider_address"},
+				{Key: "to", Value: "pair_address"},
+				{Key: "msg_index", Value: "1"},
+				{Key: "_contract_address", Value: "lp_token_address"},
+				{Key: "action", Value: "mint"},
+				{Key: "amount", Value: "1000000"},
+				{Key: "to", Value: "provider_address"},
+				{Key: "msg_index", Value: "1"},
 			},
 			RuleItems{
 				RuleItem{Key: "_contract_address", Filter: nil},
@@ -349,6 +349,53 @@ func TestFindFromAttr_WithMsgIndex(t *testing.T) {
 	}
 }
 
+func TestFindFromAttr_SeparatesResultsByMsgIndex(t *testing.T) {
+	attrs := Attributes{
+		{Key: "_contract_address", Value: "pair_address", MsgIndex: 0},
+		{Key: "action", Value: "swap", MsgIndex: 0},
+		{Key: "sender", Value: "sender0", MsgIndex: 0},
+		{Key: "_contract_address", Value: "pair_address", MsgIndex: 1},
+		{Key: "action", Value: "swap", MsgIndex: 1},
+		{Key: "sender", Value: "sender1", MsgIndex: 1},
+	}
+	rule := Rule{
+		Type: WasmType,
+		Items: RuleItems{
+			{Key: "_contract_address", Filter: "pair_address"},
+			{Key: "action", Filter: "swap"},
+		},
+		Until: "_contract_address",
+	}
+	finder, err := NewLogFinder(rule)
+	assert.NoError(t, err)
+
+	results := finder.FindFromAttrs(attrs)
+	assert.Len(t, results, 2)
+	assert.Equal(t, 0, MsgIndex(results[0]))
+	assert.Equal(t, 1, MsgIndex(results[1]))
+	assert.Equal(t, "sender0", results[0][2].Value)
+	assert.Equal(t, "sender1", results[1][2].Value)
+}
+
+func TestFindFromAttr_DoesNotMatchRuleAcrossMsgIndex(t *testing.T) {
+	attrs := Attributes{
+		{Key: "_contract_address", Value: "pair_address", MsgIndex: 0},
+		{Key: "action", Value: "swap", MsgIndex: 1},
+	}
+	rule := Rule{
+		Type: WasmType,
+		Items: RuleItems{
+			{Key: "_contract_address", Filter: "pair_address"},
+			{Key: "action", Filter: "swap"},
+		},
+	}
+	finder, err := NewLogFinder(rule)
+	assert.NoError(t, err)
+
+	results := finder.FindFromAttrs(attrs)
+	assert.Empty(t, results)
+}
+
 func TestFindFromAttr_WithTokenId(t *testing.T) {
 	testCases := []struct {
 		attrs              Attributes
@@ -360,18 +407,18 @@ func TestFindFromAttr_WithTokenId(t *testing.T) {
 		// transfer
 		{
 			Attributes{
-				{"_contract_address", "token_address"},
-				{"action", "transfer"},
-				{"token_id", "1357"},
-				{"amount", "1"},
-				{"from", "from_address"},
-				{"to", "to_address"},
-				{"_contract_address", "token_address"},
-				{"action", "transfer"},
-				{"token_id", "1357"},
-				{"amount", "1"},
-				{"from", "from_address"},
-				{"to", "to_address"},
+				{Key: "_contract_address", Value: "token_address"},
+				{Key: "action", Value: "transfer"},
+				{Key: "token_id", Value: "1357"},
+				{Key: "amount", Value: "1"},
+				{Key: "from", Value: "from_address"},
+				{Key: "to", Value: "to_address"},
+				{Key: "_contract_address", Value: "token_address"},
+				{Key: "action", Value: "transfer"},
+				{Key: "token_id", Value: "1357"},
+				{Key: "amount", Value: "1"},
+				{Key: "from", Value: "from_address"},
+				{Key: "to", Value: "to_address"},
 			},
 			RuleItems{
 				RuleItem{Key: "_contract_address", Filter: nil},

--- a/pkg/eventlog/types.go
+++ b/pkg/eventlog/types.go
@@ -16,8 +16,9 @@ const (
 )
 
 type Attribute struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	MsgIndex int    `json:"msg_index,omitempty"`
 }
 type Attributes []Attribute
 
@@ -28,8 +29,16 @@ type LogResult struct {
 type LogResults []LogResult
 
 type MatchedItem struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key      string `json:"key"`
+	Value    string `json:"value"`
+	MsgIndex int    `json:"msg_index,omitempty"`
 }
 type MatchedResult []MatchedItem
 type MatchedResults []MatchedResult
+
+func MsgIndex(res MatchedResult) int {
+	if len(res) == 0 {
+		return 0
+	}
+	return res[0].MsgIndex
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Columbus v2 tax handling can misclassify or deduct tax transfers incorrectly when a single transaction contains multiple messages with the same asset and amount. Matching only by asset and amount is not enough because event logs from different `msg_index` values can look identical.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This PR tracks `msg_index` through event log parsing and DEX parsed tx mapping, then uses it when matching Columbus v2 tax payments and transfer events.

Changes include:
- Add `MsgIndex` to event attributes, matched items, and parsed DEX tx DTOs.
- Propagate `MsgIndex` from raw TerraSwap event logs into parsed tx outputs.
- Match Columbus v2 tax transfers and tax deductions by asset, amount, and `MsgIndex`.
- Add regression tests for same-asset/same-amount tax transfers across different messages.
- Update affected parser tests for the new parsed tx field.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message-index propagation to parsed transactions and event attributes for precise message-level tracing.

* **Bug Fixes**
  * Resolved incorrect cross-message tax/event matching by including message index in matching and deduction logic.

* **Tests**
  * Updated many expectations and added tests to ensure msg-index propagation and that matching/deduction only occur within the same message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->