### PR TITLE
feat(parser): persist and recover validation cursor

### DIFF
--- a/db/migrations/parser/2026051412172500_add_first_invalid_height.down.sql
+++ b/db/migrations/parser/2026051412172500_add_first_invalid_height.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE synced_height DROP COLUMN IF EXISTS validation_height;

--- a/db/migrations/parser/2026051412172500_add_first_invalid_height.up.sql
+++ b/db/migrations/parser/2026051412172500_add_first_invalid_height.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE synced_height ADD COLUMN IF NOT EXISTS validation_height BIGINT NULL DEFAULT NULL;
+COMMENT ON COLUMN synced_height.validation_height IS 'Next parser validation cursor. NULL means no validation is pending; a positive value means validate that height next and advance only after success.';

--- a/parser/checkpoint/builder_test.go
+++ b/parser/checkpoint/builder_test.go
@@ -44,6 +44,18 @@ func (m *MockRepo) ValidationExceptionList() ([]string, error) {
 	return nil, nil
 }
 
+func (m *MockRepo) GetValidationHeight() (uint64, error) {
+	return 0, nil
+}
+
+func (m *MockRepo) SetValidationHeight(_ uint64) error {
+	return nil
+}
+
+func (m *MockRepo) ClearValidationHeight() error {
+	return nil
+}
+
 // MockSourceDataStore implements pdex.SourceDataStore for testing
 type MockSourceDataStore struct {
 	syncedHeight uint64

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
@@ -39,6 +40,11 @@ type dexApp struct {
 	sameHeightTolerance uint
 	lastSrcHeight       uint64
 	sameHeightCount     uint
+
+	validationWorkerOnce         sync.Once
+	validationMu                 sync.Mutex
+	validationSignal             chan struct{}
+	latestValidationSyncedHeight uint64
 }
 
 type DexMixin struct{}
@@ -56,6 +62,7 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 		sameHeightTolerance:  c.SameHeightTolerance,
 		poolSnapshotInterval: c.PoolSnapshotInterval,
 		validationInterval:   c.ValidationInterval,
+		validationSignal:     make(chan struct{}, 1),
 	}
 }
 
@@ -83,15 +90,11 @@ func (app *dexApp) Run() error {
 		return fmt.Errorf("app.Run: %w", err)
 	}
 
+	app.signalValidation(localSynced)
+
 	// to avoid skipping validation error
-	if (localSynced % uint64(app.validationInterval)) == 0 {
-		poolInfos, err := app.GetPoolInfos((localSynced))
-		if err != nil {
-			return fmt.Errorf("app.Run: %w", err)
-		}
-		if err := app.validate(0, (localSynced), poolInfos); err != nil {
-			return fmt.Errorf("app.Run: %w", err)
-		}
+	if app.isValidationHeight(localSynced) {
+		app.triggerValidation(localSynced)
 	}
 
 	app.logger.Infof("current synced height: %d, remote node height: %d", localSynced, srcHeight)
@@ -130,16 +133,8 @@ func (app *dexApp) Run() error {
 			return fmt.Errorf("app.Run: %w", err)
 		}
 
-		if (cur % uint64(app.validationInterval)) == 0 {
-			if len(poolInfos) == 0 {
-				poolInfos, err = app.GetPoolInfos(cur)
-				if err != nil {
-					return fmt.Errorf("app.Run: %w", err)
-				}
-			}
-			if err := app.validate(0, cur, poolInfos); err != nil {
-				return fmt.Errorf("app.Run: %w", err)
-			}
+		if app.isValidationHeight(cur) {
+			app.triggerValidation(cur)
 		}
 	}
 	app.lastSrcHeight = srcHeight
@@ -180,6 +175,134 @@ func (app *dexApp) checkRemoteHeight(srcHeight uint64) error {
 		app.sameHeightCount = 0
 	}
 	return nil
+}
+
+// isValidationHeight reports whether the given height is a configured
+// validation interval boundary.
+func (app *dexApp) isValidationHeight(height uint64) bool {
+	if app.validationInterval == 0 || height == 0 {
+		return false
+	}
+	return height%uint64(app.validationInterval) == 0
+}
+
+// triggerValidation persists a validation cursor when none exists, then wakes
+// the async validator for the synced height that just reached an interval.
+func (app *dexApp) triggerValidation(height uint64) {
+	validationHeight, err := app.GetValidationHeight()
+	if err != nil {
+		app.logger.Errorf("validator: failed to load validation height: %s", err)
+		return
+	}
+	if validationHeight == 0 {
+		if err := app.SetValidationHeight(height); err != nil {
+			app.logger.Errorf("validator: failed to persist validation height %d: %s", height, err)
+			return
+		}
+	}
+	app.signalValidation(height)
+}
+
+// signalValidation starts the single validation worker and records the latest
+// synced height it should validate up to. Multiple calls coalesce into one wakeup.
+func (app *dexApp) signalValidation(syncedHeight uint64) {
+	if app.validationInterval == 0 {
+		return
+	}
+
+	app.validationWorkerOnce.Do(func() {
+		if app.validationSignal == nil {
+			app.validationSignal = make(chan struct{}, 1)
+		}
+		go app.runValidationWorker()
+	})
+
+	app.validationMu.Lock()
+	if syncedHeight > app.latestValidationSyncedHeight {
+		app.latestValidationSyncedHeight = syncedHeight
+	}
+	app.validationMu.Unlock()
+
+	select {
+	case app.validationSignal <- struct{}{}:
+	default:
+	}
+}
+
+// runValidationWorker consumes validation wakeups and drains all persisted
+// validation work up to the latest synced height observed while it is running.
+func (app *dexApp) runValidationWorker() {
+	for range app.validationSignal {
+		for {
+			app.validationMu.Lock()
+			syncedHeight := app.latestValidationSyncedHeight
+			app.latestValidationSyncedHeight = 0
+			app.validationMu.Unlock()
+
+			if syncedHeight == 0 {
+				break
+			}
+
+			app.processPendingValidations(syncedHeight)
+
+			app.validationMu.Lock()
+			hasPendingSignal := app.latestValidationSyncedHeight > 0
+			app.validationMu.Unlock()
+			if !hasPendingSignal {
+				break
+			}
+		}
+	}
+}
+
+// processPendingValidations validates the persisted validation cursor up to
+// syncedHeight. Successful validation advances the cursor by validationInterval
+// before the next validation, so restarts continue from the next unresolved
+// validation height.
+func (app *dexApp) processPendingValidations(syncedHeight uint64) {
+	if app.validationInterval == 0 {
+		return
+	}
+
+	for {
+		height, err := app.GetValidationHeight()
+		if err != nil {
+			app.logger.Errorf("validator: failed to load validation height: %s", err)
+			return
+		}
+		if height == 0 || height > syncedHeight {
+			return
+		}
+		if !app.validateAtHeight(height) {
+			return
+		}
+		next := height + uint64(app.validationInterval)
+		if next <= height {
+			if err := app.ClearValidationHeight(); err != nil {
+				app.logger.Errorf("validator: failed to clear validation height after overflow: %s", err)
+			}
+			return
+		}
+		if err := app.SetValidationHeight(next); err != nil {
+			app.logger.Errorf("validator: failed to advance validation height from %d to %d: %s", height, next, err)
+			return
+		}
+	}
+}
+
+// validateAtHeight compares source pool info with parsed DB state for one
+// validation height and returns false when validation should be retried later.
+func (app *dexApp) validateAtHeight(height uint64) bool {
+	poolInfos, err := app.GetPoolInfos(height)
+	if err != nil {
+		app.logger.Errorf("validator: GetPoolInfos at height %d: %s", height, err)
+		return false
+	}
+	if err := app.validate(0, height, poolInfos); err != nil {
+		app.logger.Errorf("validator: pool mismatch at height %d: %s", height, err)
+		return false
+	}
+	return true
 }
 
 // validate with `expected` from the node, compare database updates, as `actual`

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -2,11 +2,14 @@ package dex
 
 import (
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // insert implements parser
@@ -344,4 +347,202 @@ func Test_collectLpBurnTxs(t *testing.T) {
 		result := CollectLpBurnTxs(tc.burnTxs, lpPairAddrs)
 		assert.Equal(tc.expected, result, tc.errMsg)
 	}
+}
+
+// testRepoMock extends RepoMock to control the persisted validation height
+// and track every SetValidationHeight call.
+type testRepoMock struct {
+	RepoMock
+	mu                sync.Mutex
+	validationHeight  uint64
+	setValidationArgs []uint64
+	setValidationErrs []error
+	clearCount        int
+}
+
+func (m *testRepoMock) GetValidationHeight() (uint64, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.validationHeight, nil
+}
+
+func (m *testRepoMock) SetValidationHeight(h uint64) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.setValidationArgs = append(m.setValidationArgs, h)
+	if len(m.setValidationErrs) > 0 {
+		err := m.setValidationErrs[0]
+		m.setValidationErrs = m.setValidationErrs[1:]
+		if err != nil {
+			return err
+		}
+	}
+	m.validationHeight = h
+	return nil
+}
+
+func (m *testRepoMock) ClearValidationHeight() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.clearCount++
+	m.validationHeight = 0
+	return nil
+}
+
+func (m *testRepoMock) validationState() (uint64, []uint64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.validationHeight, append([]uint64(nil), m.setValidationArgs...)
+}
+
+func Test_processPendingValidations_AdvancesPersistedCursor(t *testing.T) {
+	pool := PoolInfo{
+		ContractAddr: "pool1",
+		TotalShare:   "1000",
+		Assets:       []Asset{{"token0", "500"}, {"token1", "500"}},
+	}
+	const firstHeight = uint64(100)
+	const secondHeight = uint64(200)
+
+	srcStore := &RawStoreMock{}
+	repo := &testRepoMock{validationHeight: firstHeight}
+	app := &dexApp{
+		Repo:               repo,
+		SourceDataStore:    srcStore,
+		logger:             logging.Discard,
+		validationInterval: 100,
+	}
+
+	srcStore.On("GetPoolInfos", firstHeight).Return([]PoolInfo{pool}, nil)
+	srcStore.On("GetPoolInfos", secondHeight).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), firstHeight).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), secondHeight).Return([]PoolInfo{pool}, nil)
+	repo.On("ValidationExceptionList").Return([]string{}, nil)
+
+	app.processPendingValidations(250)
+
+	assert.Equal(t, []uint64{secondHeight, 300}, repo.setValidationArgs)
+	assert.Equal(t, uint64(300), repo.validationHeight)
+}
+
+func Test_processPendingValidations_LeavesCursorOnValidationFailure(t *testing.T) {
+	pool := PoolInfo{
+		ContractAddr: "pool1",
+		TotalShare:   "1000",
+		Assets:       []Asset{{"token0", "500"}, {"token1", "500"}},
+	}
+	const height = uint64(100)
+
+	srcStore := &RawStoreMock{}
+	repo := &testRepoMock{validationHeight: height}
+	app := &dexApp{
+		Repo:               repo,
+		SourceDataStore:    srcStore,
+		logger:             logging.Discard,
+		validationInterval: 100,
+	}
+
+	srcStore.On("GetPoolInfos", height).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), height).Return([]PoolInfo{}, nil)
+	repo.On("ValidationExceptionList").Return([]string{}, nil)
+
+	app.processPendingValidations(height)
+
+	assert.Empty(t, repo.setValidationArgs)
+	assert.Equal(t, height, repo.validationHeight)
+}
+
+func Test_triggerValidation_PersistsCursorBeforeValidation(t *testing.T) {
+	pool := PoolInfo{
+		ContractAddr: "pool1",
+		TotalShare:   "1000",
+		Assets:       []Asset{{"token0", "500"}, {"token1", "500"}},
+	}
+	const height = uint64(100)
+
+	srcStore := &RawStoreMock{}
+	repo := &testRepoMock{}
+	app := &dexApp{
+		Repo:               repo,
+		SourceDataStore:    srcStore,
+		logger:             logging.Discard,
+		validationInterval: 100,
+	}
+
+	srcStore.On("GetPoolInfos", height).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), height).Return([]PoolInfo{pool}, nil)
+	repo.On("ValidationExceptionList").Return([]string{}, nil)
+
+	app.triggerValidation(height)
+
+	require.Eventually(t, func() bool {
+		validationHeight, setValidationArgs := repo.validationState()
+		return validationHeight == 200 && assert.ObjectsAreEqual([]uint64{height, 200}, setValidationArgs)
+	}, time.Second, 10*time.Millisecond)
+}
+
+func Test_processPendingValidations_RetriesCursorAfterAdvanceFailure(t *testing.T) {
+	pool := PoolInfo{
+		ContractAddr: "pool1",
+		TotalShare:   "1000",
+		Assets:       []Asset{{"token0", "500"}, {"token1", "500"}},
+	}
+	const height = uint64(100)
+
+	srcStore := &RawStoreMock{}
+	repo := &testRepoMock{
+		validationHeight:  height,
+		setValidationErrs: []error{errors.New("db unavailable")},
+	}
+	app := &dexApp{
+		Repo:               repo,
+		SourceDataStore:    srcStore,
+		logger:             logging.Discard,
+		validationInterval: 100,
+	}
+
+	srcStore.On("GetPoolInfos", height).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), height).Return([]PoolInfo{pool}, nil)
+	repo.On("ValidationExceptionList").Return([]string{}, nil)
+
+	app.processPendingValidations(height)
+
+	assert.Equal(t, []uint64{200}, repo.setValidationArgs)
+	assert.Equal(t, height, repo.validationHeight)
+}
+
+func Test_Run_FollowsPersistedValidationCursor(t *testing.T) {
+	pool := PoolInfo{
+		ContractAddr: "pool1",
+		TotalShare:   "1000",
+		Assets:       []Asset{{"token0", "500"}, {"token1", "500"}},
+	}
+	const firstHeight = uint64(100)
+	const secondHeight = uint64(200)
+
+	srcStore := &RawStoreMock{}
+	repo := &testRepoMock{validationHeight: firstHeight}
+	app := &dexApp{
+		Repo:                repo,
+		SourceDataStore:     srcStore,
+		logger:              logging.Discard,
+		validationInterval:  100,
+		sameHeightTolerance: 5,
+	}
+
+	repo.On("GetTokenExceptions").Return(map[string]bool{}, nil)
+	repo.On("GetSyncedHeight").Return(secondHeight, nil)
+	srcStore.On("GetSourceSyncedHeight").Return(secondHeight, nil)
+	srcStore.On("GetPoolInfos", firstHeight).Return([]PoolInfo{pool}, nil)
+	srcStore.On("GetPoolInfos", secondHeight).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), firstHeight).Return([]PoolInfo{pool}, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), secondHeight).Return([]PoolInfo{pool}, nil)
+	repo.On("ValidationExceptionList").Return([]string{}, nil)
+
+	require.NoError(t, app.Run())
+
+	require.Eventually(t, func() bool {
+		validationHeight, setValidationArgs := repo.validationState()
+		return validationHeight == 300 && assert.ObjectsAreEqual([]uint64{secondHeight, 300}, setValidationArgs)
+	}, time.Second, 10*time.Millisecond)
 }

--- a/parser/dex/interface.go
+++ b/parser/dex/interface.go
@@ -23,6 +23,9 @@ type Repo interface {
 	ParsedPoolsInfo(from, to uint64) ([]PoolInfo, error)
 	ValidationExceptionList() ([]string, error)
 	InsertPairValidationException(chainID string, contractAddress string) error
+	GetValidationHeight() (uint64, error)
+	SetValidationHeight(height uint64) error
+	ClearValidationHeight() error
 }
 
 type SourceDataStore interface {

--- a/parser/dex/mock.go
+++ b/parser/dex/mock.go
@@ -104,3 +104,18 @@ func (m *RepoMock) ValidationExceptionList() ([]string, error) {
 	args := m.MethodCalled("ValidationExceptionList")
 	return args.Get(0).([]string), args.Error(1)
 }
+
+// GetValidationHeight implements Repo.
+func (m *RepoMock) GetValidationHeight() (uint64, error) {
+	return 0, nil
+}
+
+// SetValidationHeight implements Repo.
+func (m *RepoMock) SetValidationHeight(_ uint64) error {
+	return nil
+}
+
+// ClearValidationHeight implements Repo.
+func (m *RepoMock) ClearValidationHeight() error {
+	return nil
+}

--- a/parser/dex/repo/repository.go
+++ b/parser/dex/repo/repository.go
@@ -183,3 +183,43 @@ func (r *repoImpl) ValidationExceptionList() ([]string, error) {
 	}
 	return exceptions, nil
 }
+
+// GetValidationHeight implements dex.Repo.
+func (r *repoImpl) GetValidationHeight() (uint64, error) {
+	sh := schemas.SyncedHeight{}
+	if tx := r.db.FirstOrCreate(&sh, schemas.SyncedHeight{ChainId: r.chainId}); tx.Error != nil {
+		return 0, fmt.Errorf("GetValidationHeight: %w", tx.Error)
+	}
+	if sh.ValidationHeight == nil {
+		return 0, nil
+	}
+	return *sh.ValidationHeight, nil
+}
+
+// SetValidationHeight implements dex.Repo.
+func (r *repoImpl) SetValidationHeight(height uint64) error {
+	tx := r.db.Model(&schemas.SyncedHeight{}).
+		Where("chain_id = ?", r.chainId).
+		Update("validation_height", height)
+	if tx.Error != nil {
+		return fmt.Errorf("SetValidationHeight: %w", tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("SetValidationHeight: no row found for chain_id %s", r.chainId)
+	}
+	return nil
+}
+
+// ClearValidationHeight implements dex.Repo.
+func (r *repoImpl) ClearValidationHeight() error {
+	tx := r.db.Model(&schemas.SyncedHeight{}).
+		Where("chain_id = ?", r.chainId).
+		Update("validation_height", nil)
+	if tx.Error != nil {
+		return fmt.Errorf("ClearValidationHeight: %w", tx.Error)
+	}
+	if tx.RowsAffected == 0 {
+		return fmt.Errorf("ClearValidationHeight: no row found for chain_id %s", r.chainId)
+	}
+	return nil
+}

--- a/parser/dex/repo/repository_test.go
+++ b/parser/dex/repo/repository_test.go
@@ -229,6 +229,93 @@ func (s *validationExceptionSuite) Test_InsertPairValidationException() {
 	assert.Error(err)
 }
 
+type validationHeightSuite struct {
+	baseSuite
+}
+
+func (s *validationHeightSuite) Test_GetValidationHeight_WithValue() {
+	const validationHeight = uint64(42)
+	rows := sqlmock.NewRows([]string{"chain_id", "height", "validation_height"}).
+		AddRow(s.Repo.chainId, uint64(0), validationHeight)
+	s.Mock.ExpectQuery(`^SELECT (.+) FROM "synced_height" WHERE (.+)?[chain_id ](.+)=`).WillReturnRows(rows)
+
+	h, err := s.Repo.GetValidationHeight()
+	s.NoError(err)
+	s.Equal(validationHeight, h)
+}
+
+func (s *validationHeightSuite) Test_GetValidationHeight_Nil() {
+	rows := sqlmock.NewRows([]string{"chain_id", "height", "validation_height"}).
+		AddRow(s.Repo.chainId, uint64(0), nil) // NULL → returns 0
+	s.Mock.ExpectQuery(`^SELECT (.+) FROM "synced_height" WHERE (.+)?[chain_id ](.+)=`).WillReturnRows(rows)
+
+	h, err := s.Repo.GetValidationHeight()
+	s.NoError(err)
+	s.Equal(uint64(0), h)
+}
+
+func (s *validationHeightSuite) Test_GetValidationHeight_Create() {
+	// Row not found → FirstOrCreate inserts a new row (wrapped in a transaction).
+	s.Mock.ExpectQuery(`^SELECT (.+) FROM "synced_height" WHERE (.+)?[chain_id ](.+)=`).
+		WillReturnRows(sqlmock.NewRows([]string{}))
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`^INSERT INTO "synced_height" (.+) VALUES (.+)`).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.Mock.ExpectCommit()
+
+	h, err := s.Repo.GetValidationHeight()
+	s.NoError(err)
+	s.Equal(uint64(0), h)
+}
+
+func (s *validationHeightSuite) Test_GetValidationHeight_Fail() {
+	s.Mock.ExpectQuery(`^SELECT (.+) FROM "synced_height" WHERE (.+)?[chain_id ](.+)=`).
+		WillReturnError(errors.New("db error"))
+
+	_, err := s.Repo.GetValidationHeight()
+	s.Error(err)
+}
+
+func (s *validationHeightSuite) Test_SetValidationHeight() {
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`UPDATE "synced_height" SET "validation_height"=\$1 WHERE chain_id = \$2`).
+		WithArgs(uint64(42), s.Repo.chainId).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.Mock.ExpectCommit()
+
+	s.NoError(s.Repo.SetValidationHeight(42))
+}
+
+func (s *validationHeightSuite) Test_SetValidationHeight_NoRow() {
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`UPDATE "synced_height" SET "validation_height"=\$1 WHERE chain_id = \$2`).
+		WithArgs(uint64(42), s.Repo.chainId).
+		WillReturnResult(sqlmock.NewResult(0, 0)) // RowsAffected = 0
+	s.Mock.ExpectCommit()
+
+	s.Error(s.Repo.SetValidationHeight(42))
+}
+
+func (s *validationHeightSuite) Test_SetValidationHeight_Fail() {
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`UPDATE "synced_height" SET "validation_height"=\$1 WHERE chain_id = \$2`).
+		WithArgs(uint64(42), s.Repo.chainId).
+		WillReturnError(errors.New("db error"))
+	s.Mock.ExpectRollback()
+
+	s.Error(s.Repo.SetValidationHeight(42))
+}
+
+func (s *validationHeightSuite) Test_ClearValidationHeight() {
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`UPDATE "synced_height" SET "validation_height"=\$1 WHERE chain_id = \$2`).
+		WithArgs(nil, s.Repo.chainId).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+	s.Mock.ExpectCommit()
+
+	s.NoError(s.Repo.ClearValidationHeight())
+}
+
 func Test_repo(t *testing.T) {
 	dex.FakerCustomGenerator()
 	faker.CustomGenerator()
@@ -236,4 +323,5 @@ func Test_repo(t *testing.T) {
 	suite.Run(t, new(pairsSuite))
 	suite.Run(t, new(insertSuite))
 	suite.Run(t, new(validationExceptionSuite))
+	suite.Run(t, new(validationHeightSuite))
 }

--- a/pkg/db/schemas/parser.models.go
+++ b/pkg/db/schemas/parser.models.go
@@ -50,6 +50,10 @@ type Pair struct {
 type SyncedHeight struct {
 	ChainId string `json:"chainId"`
 	Height  uint64 `json:"height"`
+	// ValidationHeight is the next validation cursor persisted for restart recovery.
+	// nil means no validation is pending. A positive value means the parser must
+	// validate that height next and only advance it after successful validation.
+	ValidationHeight *uint64 `json:"validationHeight"`
 }
 
 type PairValidationException struct {


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Parser validation can detect pool-state mismatches, but the first failing height was not persisted for later investigation or revalidation.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This PR improves parser validation tracking via:
- Add `first_invalid_height` to `synced_height` with parser DB migration.
- Persist the first validation failure height and re-enqueue it on parser startup.
- Move pool validation into an async queue so validation failures are logged/tracked without blocking parser progress.
- Add tests for validation persistence, retry behavior, repository get/set behavior.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background validation worker to run parser validations asynchronously, reducing startup and runtime blocking.
  * Validation progress tracking so validation can resume from the last pending height after restarts.

* **Database Migrations**
  * Schema extended to persist a per-chain validation cursor.

* **Tests**
  * Added tests covering validation-worker behavior, cursor persistence, retry and recovery scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->