### PR TITLE
fix: price token liquidity valuation in pair stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ unittest.config.yaml
 
 # builds
 build
+
+# go
+.cache
+
+.tool-versions

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -4,15 +4,17 @@ aggregator:
   srcDb:
     host: localhost
     port: 5432
-    database: cosmwasm-etl
+    database: cosmwasm_etl
     username: app
     password: appPW
+    sslmode: disable
   destDb:
     host: localhost
     port: 5432
-    database: cosmwasm-etl
+    database: cosmwasm_etl
     username: app
     password: appPW
+    sslmode: disable
   cleanDups: true
 
 log:

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -494,19 +494,23 @@ required_height_by_token AS (
     JOIN tokens t ON p.chain_id = t.chain_id AND (p.asset0 = t.address OR p.asset1 = t.address)
 ),
 token_price_by_height AS (
-    SELECT DISTINCT
-        COALESCE(FIRST_VALUE(p.price) OVER (PARTITION BY p.token_id ORDER BY p.height DESC), 0) price,
+    SELECT
+        CASE
+            WHEN rht.token_address = ? THEN 1::numeric
+            ELSE COALESCE(pr.price, 0::numeric)
+        END AS price,
         rht.token_address,
         rht.token_decimals,
         rht.height
-    FROM required_height_by_token rht LEFT JOIN price p ON rht.token_id = p.token_id AND p.height <= rht.height
-    UNION
-    SELECT 1 price,
-       rht.token_address,
-       rht.token_decimals,
-       rht.height
     FROM required_height_by_token rht
-    WHERE token_address = ?
+    LEFT JOIN LATERAL (
+        SELECT p.price
+        FROM price p
+        WHERE p.token_id = rht.token_id
+          AND p.height <= rht.height
+        ORDER BY p.height DESC, p.id DESC
+        LIMIT 1
+    ) pr ON true
 )
 SELECT lh.pair_id,
        lh.liquidity0,

--- a/pkg/db/parser/repository_test.go
+++ b/pkg/db/parser/repository_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -554,6 +555,47 @@ func (s *aggregatorReadRepoSuite) Test_CommissionAmountInPair() {
 	assert.NoError(err)
 	assert.Equal(expectedAsset0, actualAsset0)
 	assert.Equal(expectedAsset1, actualAsset1)
+}
+
+func (s *aggregatorReadRepoSuite) Test_LiquiditiesOfPairStats_UsesOneForPriceToken() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	pairId := uint64(100)
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, lp_history, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, "terra0pricepair", priceToken, "terra0asset", "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, $4), ($5, $6, $7, $8)`,
+		1000, chainName, priceToken, 6,
+		1001, chainName, "terra0asset", 6,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES($1, $2, $3, $4, $5, $6)`,
+		99, chainName, 1001, "2", 1000, 0,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO lp_history(height, pair_id, chain_id, liquidity0, liquidity1, timestamp) VALUES($1, $2, $3, $4, $5, $6)`,
+		100, pairId, chainName, "1000000", "2000000", start,
+	).Error)
+
+	actual, err := s.Repo.LiquiditiesOfPairStats(start, end, priceToken)
+
+	require.NoError(err)
+	require.Contains(actual, pairId)
+	assert.Equal("1000000", actual[pairId].Liquidity0)
+	assert.Equal("2000000", actual[pairId].Liquidity1)
+
+	liquidity0InPrice, err := strconv.ParseFloat(actual[pairId].Liquidity0InPrice, 64)
+	require.NoError(err)
+	liquidity1InPrice, err := strconv.ParseFloat(actual[pairId].Liquidity1InPrice, 64)
+	require.NoError(err)
+	assert.Equal(1.0, liquidity0InPrice)
+	assert.Equal(4.0, liquidity1InPrice)
 }
 
 func createTestPairs(db *gorm.DB) {


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`LiquiditiesOfPairStats` should value the configured `priceToken` as `1` because the `price` table does not store price token rows.

The previous query added the price token value with a `UNION`, but **the main price lookup could also create a `0` row for the same token/height**. That made liquidity valuation nondeterministic and could produce `0` for a price token.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Changed `LiquiditiesOfPairStats` to assign `1::numeric` to the configured price token directly with `CASE`.
- Replaced the previous window/`UNION` price lookup with a `LEFT JOIN LATERAL` query that selects the latest price per token/height.
- Added deterministic ordering for price lookup with `ORDER BY p.height DESC, p.id DESC`.
- Added a regression test covering price token liquidity valuation.
- Updated local test config and gitignore entries needed for this branch.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration for test environments and Go development workflows.

* **Refactor**
  * Improved token price calculation logic in liquidity statistics.

* **Tests**
  * Added test coverage for token price handling in pair liquidity calculations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/123?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->