### PR TITLE
refactor(collector): add database-backed parser source flow

### DIFF
--- a/cmd/collector/columbus4/main.go
+++ b/cmd/collector/columbus4/main.go
@@ -51,7 +51,7 @@ var columbus4_pairs = []string{
 func main() {
 	cfg := configs.New()
 	fcdCfg := cfg.Collector.FcdConfig
-	dbCon := fcdCfg.RdbConfig
+	dbCon := cfg.Rdb
 	dbDsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", dbCon.Host, dbCon.Port, dbCon.Username, dbCon.Password, dbCon.Database)
 	writer := io.MultiWriter(os.Stdout)
 	db, err := gorm.Open(postgres.Open(dbDsn), &gorm.Config{
@@ -84,7 +84,7 @@ func main() {
 
 	// default setting is for columbus-4 network
 	targets := columbus4_pairs
-	fcdCfg.UntilHeight = terraswap.COLUMBUS_4_END_HEIGHT
+	cfg.Collector.UntilHeight = terraswap.COLUMBUS_4_END_HEIGHT
 
 	app := fcd_collector.New(repo, store)
 	logger := logging.New("col4_collector", cfg.Log)
@@ -95,7 +95,7 @@ func main() {
 	for _, addr := range targets {
 		logger.Infof("start collecting addr(%s)", addr)
 		for errCount := uint(0); errCount <= uint(errTolerance); {
-			if err := app.Collect(addr, uint32(fcdCfg.UntilHeight)); err != nil {
+			if err := app.Collect(addr, uint32(cfg.Collector.UntilHeight)); err != nil {
 				errCount++
 				logger.Errorf("errCount: %d, err: %s", errCount, err)
 			} else {

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -2,31 +2,25 @@ package main
 
 import (
 	"fmt"
-	"net/http"
 	"os"
 	"runtime/debug"
-	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/dezswap/cosmwasm-etl/collector"
-	"github.com/dezswap/cosmwasm-etl/collector/datastore"
+	"github.com/dezswap/cosmwasm-etl/collector/repo"
 	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser/dex/srcstore/terraswap"
 	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 )
 
-const (
-	HTTP_REDIRECT_LIMIT = 15
-	app                 = "collector"
-)
+const app = "collector"
 
 var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
 
 func main() {
 	c := configs.New()
-	nodeConf := c.Collector.NodeConfig
 	logger := logging.New("main", c.Log)
-
 	if c.Sentry.DSN != "" {
 		sentryEnv := fmt.Sprintf("%s-%s", c.Collector.ChainId, app)
 		logging.ConfigureReporter(logger, c.Sentry.DSN, sentryEnv, map[string]string{
@@ -35,39 +29,28 @@ func main() {
 			"x-env":      c.Log.Environment,
 		})
 	}
-	if nodeConf.GrpcConfig.BackoffDelay.Duration == time.Duration(0) {
-		panic("invalid back off delay")
-	}
-
 	defer catch(logger)
 
 	logger.WithField("version", version).Info("starting collector")
-
 	grpc.SetLogConfig(c.Log)
-	serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)
-	httpClient := &http.Client{
-		Transport: &http.Transport{
-			MaxIdleConns:      10,               // Maximum idle connections to keep open
-			IdleConnTimeout:   30 * time.Second, // Time to keep idle connections open
-			DisableKeepAlives: false,            // Use HTTP Keep-Alive
-		},
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			if len(via) >= HTTP_REDIRECT_LIMIT { // Increase the maximum number of redirects allowed here
-				return fmt.Errorf("stopped after %d redirects", HTTP_REDIRECT_LIMIT)
-			}
-			return nil
-		},
+
+	factoryAddress := c.Collector.PairFactoryContractAddress
+	if factoryAddress == "" {
+		factoryAddress = c.Parser.DexConfig.FactoryAddress
 	}
 
-	failoverClient := datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpClient)
-	col, err := datastore.New(c, serviceDesc, failoverClient)
-	if err != nil {
-		logger.Panic(err)
+	nodeConfig := c.Collector.NodeConfig
+	if nodeConfig.RestClientConfig.RpcHost == "" && nodeConfig.RestClientConfig.LcdHost == "" {
+		nodeConfig = c.Parser.DexConfig.NodeConfig
 	}
 
-	err = collector.DoCollect(col, logger)
+	source, err := terraswap.NewFromConfig(nodeConfig, factoryAddress)
 	if err != nil {
-		logger.Panic(err)
+		panic(err)
+	}
+
+	if err := collector.DoCollect(repo.New(c.Rdb), source, c.Collector, c.Parser.DexConfig, logger); err != nil {
+		panic(err)
 	}
 }
 

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -46,7 +46,7 @@ func main() {
 		panic(err)
 	}
 
-	if err := collector.DoCollect(repo.New(c.Rdb), source, c.Collector, c.Parser.DexConfig, logger); err != nil {
+	if err := collector.DoCollect(repo.New(c.Rdb), source, c.Collector, logger); err != nil {
 		panic(err)
 	}
 }

--- a/cmd/collector/main.go
+++ b/cmd/collector/main.go
@@ -39,10 +39,7 @@ func main() {
 		factoryAddress = c.Parser.DexConfig.FactoryAddress
 	}
 
-	nodeConfig := c.Collector.NodeConfig
-	if nodeConfig.RestClientConfig.RpcHost == "" && nodeConfig.RestClientConfig.LcdHost == "" {
-		nodeConfig = c.Parser.DexConfig.NodeConfig
-	}
+	nodeConfig := c.Collector.NodeConfigWithFallback(c.Parser.DexConfig.NodeConfig)
 
 	source, err := terraswap.NewFromConfig(nodeConfig, factoryAddress)
 	if err != nil {

--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -4,13 +4,13 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"net/http"
 	"os"
 	"runtime/debug"
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/dezswap/cosmwasm-etl/collector/datastore"
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
 	"github.com/dezswap/cosmwasm-etl/configs"
 	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
 	pds "github.com/dezswap/cosmwasm-etl/parser/dex/dezswap"
@@ -20,17 +20,11 @@ import (
 	psf "github.com/dezswap/cosmwasm-etl/parser/dex/starfleit"
 	pts "github.com/dezswap/cosmwasm-etl/parser/dex/terraswap"
 	"github.com/dezswap/cosmwasm-etl/pkg/dex"
-	dts "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap"
-	dts_colv1 "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/columbusv1"
-	dts_colv2 "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/columbusv2"
-	dts_phoenix "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/phoenix"
+	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
 
 	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/dezswap/cosmwasm-etl/pkg/s3client"
-	"github.com/dezswap/cosmwasm-etl/pkg/terra/col4"
-	terra_cosmos45 "github.com/dezswap/cosmwasm-etl/pkg/terra/cosmos45"
-	"github.com/dezswap/cosmwasm-etl/pkg/terra/rpc"
 )
 
 const (
@@ -38,19 +32,6 @@ const (
 )
 
 var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
-
-func newHttpClient(c configs.HttpClientConfig) *http.Client {
-	return &http.Client{
-		Timeout: c.Timeout.Duration,
-		Transport: &http.Transport{
-			MaxIdleConns:        c.MaxIdleConns,
-			MaxIdleConnsPerHost: c.MaxIdleConnsPerHost,
-			IdleConnTimeout:     c.IdleConnTimeout.Duration,
-			DisableKeepAlives:   c.DisableKeepAlives,
-			ForceAttemptHTTP2:   c.ForceAttemptHTTP2,
-		},
-	}
-}
 
 func getDexCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) datastore.ReadStore {
 	nodeConf := dc.NodeConfig
@@ -63,7 +44,7 @@ func getDexCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) data
 			panic(err)
 		}
 		if nodeConf.FailoverLcdHost != "" {
-			store, _ = datastore.New(c, serviceDesc, datastore.NewLcdClient(nodeConf.FailoverLcdHost, newHttpClient(dc.NodeConfig.HttpClientConfig)))
+			store, _ = datastore.New(c, serviceDesc, datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)))
 		}
 
 		return datastore.NewReadStoreWithGrpc(dc.ChainId, store)
@@ -108,28 +89,11 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 
 	var rawDataStore p_dex.SourceDataStore
 	if c.TargetApp == dex.Terraswap {
-		httpClient := newHttpClient(c.NodeConfig.HttpClientConfig)
-		r := rpc.New(c.NodeConfig.RestClientConfig.RpcHost, httpClient)
-
-		switch dts.TerraswapFactory(c.FactoryAddress) {
-		case dts.MAINNET_FACTORY:
-			lcd := terra_cosmos45.NewLcd(c.NodeConfig.RestClientConfig.LcdHost, httpClient)
-			terraswapQueryClient := dts_phoenix.NewPhoenixClient(lcd)
-			rawDataStore = ts_srcstore.NewPhoenixStore(c.FactoryAddress, r, lcd, terraswapQueryClient)
-		case dts.CLASSIC_V2_FACTORY:
-			lcd := terra_cosmos45.NewLcd(c.NodeConfig.RestClientConfig.LcdHost, httpClient)
-			terraswapQueryClient := dts_colv2.NewColumbusV2Client(lcd)
-			rawDataStore = ts_srcstore.NewCol5Store(c.FactoryAddress, r, lcd, terraswapQueryClient)
-
-		case dts.PISCO_FACTORY:
-			panic(errors.New("not implemented yet"))
-		case dts.CLASSIC_V1_FACTORY:
-			lcd := col4.NewLcd(c.NodeConfig.RestClientConfig.LcdHost, httpClient)
-			terraswapQueryClient := dts_colv1.NewCol4Client(lcd)
-			rawDataStore = ts_srcstore.NewCol4Store(c.FactoryAddress, r, lcd, terraswapQueryClient)
-		default:
-			panic(fmt.Errorf("invalid factory address: %s", c.FactoryAddress))
+		fallback, err := ts_srcstore.NewFromConfig(c.NodeConfig, c.FactoryAddress)
+		if err != nil {
+			panic(err)
 		}
+		rawDataStore = srcstore.NewCollectorFallback(c.ChainId, collectorrepo.New(rdbc), fallback, logger)
 	} else {
 		rawDataStore = srcstore.New(readStore)
 	}

--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -44,7 +44,15 @@ func getDexCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) data
 			panic(err)
 		}
 		if nodeConf.FailoverLcdHost != "" {
-			store, _ = datastore.New(c, serviceDesc, datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)))
+			failoverStore, err := datastore.New(
+				c,
+				serviceDesc,
+				datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)),
+			)
+			if err != nil {
+				panic(err)
+			}
+			store = failoverStore
 		}
 
 		return datastore.NewReadStoreWithGrpc(dc.ChainId, store)

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -66,7 +66,7 @@ func (c *sourceHeightCollector) CollectHeight(height uint64) error {
 		return err
 	}
 
-	blockTime := time.Now().UTC()
+	blockTime := time.Time{}
 	if len(txs) > 0 {
 		blockTime = txs[0].Timestamp
 	}

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -2,6 +2,7 @@ package collector
 
 import (
 	"errors"
+	"fmt"
 	"time"
 
 	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
@@ -18,10 +19,10 @@ const collectorPollInterval = 5 * time.Second
 // optional pool snapshots, and synced height in PostgreSQL. That keeps the loop
 // reusable for future DEX apps as long as they expose the same parser source
 // interface.
-func DoCollect(repo collectorrepo.Repository, source dex.SourceDataStore, collectorConfig configs.CollectorConfig, parserConfig configs.ParserDexConfig, logger logging.Logger) error {
+func DoCollect(repo collectorrepo.Repository, source dex.SourceDataStore, collectorConfig configs.CollectorConfig, logger logging.Logger) error {
 	chainID := collectorConfig.ChainId
 	if chainID == "" {
-		chainID = parserConfig.ChainId
+		return fmt.Errorf("missing chain id: set collector.chainid")
 	}
 
 	startHeight := collectorStartHeight(collectorConfig)
@@ -30,7 +31,7 @@ func DoCollect(repo collectorrepo.Repository, source dex.SourceDataStore, collec
 		source:               source,
 		chainID:              chainID,
 		startHeight:          startHeight,
-		poolSnapshotInterval: collectorPoolSnapshotInterval(collectorConfig, parserConfig),
+		poolSnapshotInterval: collectorPoolSnapshotInterval(collectorConfig),
 	}, heightCollectorConfig{
 		StartHeight: startHeight,
 		UntilHeight: collectorConfig.UntilHeight,
@@ -90,12 +91,10 @@ func collectorStartHeight(c configs.CollectorConfig) uint64 {
 	return 1
 }
 
-func collectorPoolSnapshotInterval(c configs.CollectorConfig, parserConfig configs.ParserDexConfig) uint {
+func collectorPoolSnapshotInterval(c configs.CollectorConfig) uint {
 	if c.PoolSnapshotInterval > 0 {
 		return c.PoolSnapshotInterval
 	}
-	if parserConfig.PoolSnapshotInterval > 0 {
-		return parserConfig.PoolSnapshotInterval
-	}
+
 	return configs.PARSER_POOL_SNAPSHOT_INTERVAL
 }

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1,120 +1,101 @@
 package collector
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
+	"errors"
 	"time"
 
-	tendermintType "github.com/cometbft/cometbft/proto/tendermint/types"
-	"github.com/pkg/errors"
-
-	"github.com/dezswap/cosmwasm-etl/collector/datastore"
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 )
 
-func DoCollect(store datastore.DataStore, logger logging.Logger) error {
-	blockQueue := make(chan *tendermintType.Block, 10)
-	errChan := make(chan error)
+const collectorPollInterval = 5 * time.Second
 
-	blockFolderPath := datastore.GetBlockFolderPath(store.GetChainId())
-	pairFolderPath := datastore.GetPairFolderPath(store.GetChainId())
+// DoCollect persists normalized parser source data into the collector DB.
+//
+// It consumes any dex SourceDataStore implementation and stores per-height txs,
+// optional pool snapshots, and synced height in PostgreSQL. That keeps the loop
+// reusable for future DEX apps as long as they expose the same parser source
+// interface.
+func DoCollect(repo collectorrepo.Repository, source dex.SourceDataStore, collectorConfig configs.CollectorConfig, parserConfig configs.ParserDexConfig, logger logging.Logger) error {
+	chainID := collectorConfig.ChainId
+	if chainID == "" {
+		chainID = parserConfig.ChainId
+	}
 
-	// block collecting job
-	go func() {
-		latestBlock, err := store.GetLatestProcessedBlockNumber(blockFolderPath...)
+	startHeight := collectorStartHeight(collectorConfig)
+	return collectHeights(&sourceHeightCollector{
+		repo:                 repo,
+		source:               source,
+		chainID:              chainID,
+		startHeight:          startHeight,
+		poolSnapshotInterval: collectorPoolSnapshotInterval(collectorConfig, parserConfig),
+	}, heightCollectorConfig{
+		StartHeight: startHeight,
+		UntilHeight: collectorConfig.UntilHeight,
+	}, logger)
+}
+
+type sourceHeightCollector struct {
+	repo                 collectorrepo.Repository
+	source               dex.SourceDataStore
+	chainID              string
+	startHeight          uint64
+	poolSnapshotInterval uint
+}
+
+func (c *sourceHeightCollector) LocalHeight() (uint64, error) {
+	localHeight, err := c.repo.GetSyncedHeight(c.chainID)
+	if err == nil {
+		return localHeight, nil
+	}
+	if errors.Is(err, collectorrepo.ErrNotFound) || errors.Is(err, collectorrepo.ErrUnavailable) {
+		return c.startHeight - 1, nil
+	}
+	return 0, err
+}
+
+func (c *sourceHeightCollector) SourceHeight() (uint64, error) {
+	return c.source.GetSourceSyncedHeight()
+}
+
+func (c *sourceHeightCollector) CollectHeight(height uint64) error {
+	txs, err := c.source.GetSourceTxs(height)
+	if err != nil {
+		return err
+	}
+
+	blockTime := time.Now().UTC()
+	if len(txs) > 0 {
+		blockTime = txs[0].Timestamp
+	}
+
+	savePoolSnapshot := c.poolSnapshotInterval > 0 && height%uint64(c.poolSnapshotInterval) == 0
+	poolInfos := []dex.PoolInfo{}
+	if savePoolSnapshot {
+		poolInfos, err = c.source.GetPoolInfos(height)
 		if err != nil {
-			err = errors.Wrap(err, "DoCollect, GetLatestProcessedBlockNumber")
-			errChan <- err
-			return
-		}
-
-		logger.Infof("Start collecting from the block %d ...", latestBlock+1)
-
-		for {
-			block, err := store.GetBlockByHeight(latestBlock + 1)
-			if err != nil && strings.Contains(err.Error(), "invalid height") {
-				// case 1: new block is not yet produced
-				// TODO: print logger: "waiting new blocks..."
-
-				timer := time.NewTimer(time.Second * 3)
-				<-timer.C
-
-				continue
-			} else if err != nil {
-				// case 2: other error
-				err = errors.Wrap(err, "DoCollect, GetBlockByHeight")
-				errChan <- err
-				return
-			}
-
-			if block != nil {
-				blockQueue <- block
-
-				latestBlock = block.Header.Height
-			} else {
-				errChan <- fmt.Errorf("received block is nil")
-				return
-			}
-
-			logger.Infof("Collected block %d ...", latestBlock)
-		}
-	}()
-
-	// tx storing job
-	for {
-		select {
-		case block := <-blockQueue:
-			// store block
-			blockId := block.GetHeader().Height
-
-			logger.Infof("Processing block %d ...", blockId)
-
-			blockInfo, err := store.GetBlockTxsFromBlockData(block)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, GetBlockTxsFromBlockData")
-			}
-
-			data, err := json.Marshal(blockInfo)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, Marshal")
-			}
-
-			err = store.UploadBlockBinary(blockId, data, blockFolderPath...)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, UploadBlockBinaryAsLatest")
-			}
-
-			logger.Infof("Pair processing in block %d ...", blockId)
-
-			// store pair
-			pairStatus, err := store.GetCurrentPoolStatusOfAllPairs(blockId)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, GetCurrentPoolStatusOfAllPairs")
-			}
-
-			pairStatusByte, err := json.Marshal(pairStatus)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, Marshal, pair")
-			}
-
-			err = store.UploadPoolInfoBinary(blockId, pairStatusByte, pairFolderPath...)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, UploadPoolInfoBinary, pair")
-			}
-
-			err = store.ChangeLatestBlock(blockId, blockFolderPath...)
-			if err != nil {
-				return errors.Wrap(err, "DoCollect, ChangeLatestBlock")
-			}
-
-			logger.Infof("Block %d process done!", blockId)
-
-		case err := <-errChan:
-			if err != nil {
-				logger.Error(err)
-				return err
-			}
+			return err
 		}
 	}
+
+	return c.repo.SaveHeight(c.chainID, height, blockTime, txs, poolInfos, savePoolSnapshot)
+}
+
+func collectorStartHeight(c configs.CollectorConfig) uint64 {
+	if c.StartHeight > 0 {
+		return c.StartHeight
+	}
+	return 1
+}
+
+func collectorPoolSnapshotInterval(c configs.CollectorConfig, parserConfig configs.ParserDexConfig) uint {
+	if c.PoolSnapshotInterval > 0 {
+		return c.PoolSnapshotInterval
+	}
+	if parserConfig.PoolSnapshotInterval > 0 {
+		return parserConfig.PoolSnapshotInterval
+	}
+	return configs.PARSER_POOL_SNAPSHOT_INTERVAL
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -102,7 +102,6 @@ func TestDoCollectSourceCollectsFromStartHeightToUntilHeight(t *testing.T) {
 		repo,
 		source,
 		configs.CollectorConfig{ChainId: "chain", StartHeight: 5, UntilHeight: 6, PoolSnapshotInterval: 2},
-		configs.ParserDexConfig{},
 		logging.Discard,
 	)
 
@@ -116,7 +115,7 @@ func TestDoCollectSourceCollectsFromStartHeightToUntilHeight(t *testing.T) {
 	require.Equal(t, []dex.PoolInfo{{ContractAddr: "pair6"}}, repo.saved[1].poolInfos)
 }
 
-func TestDoCollectSourceUsesParserChainAndSnapshotIntervalFallbacks(t *testing.T) {
+func TestDoCollectSourceUsesChainAndSnapshotIntervalFallbacks(t *testing.T) {
 	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrUnavailable}
 	source := &sourceStoreMock{
 		syncedHeight: 3,
@@ -133,14 +132,13 @@ func TestDoCollectSourceUsesParserChainAndSnapshotIntervalFallbacks(t *testing.T
 	err := DoCollect(
 		repo,
 		source,
-		configs.CollectorConfig{UntilHeight: 3},
-		configs.ParserDexConfig{ChainId: "parser-chain", PoolSnapshotInterval: 2},
+		configs.CollectorConfig{ChainId: "chain", UntilHeight: 3, PoolSnapshotInterval: 2},
 		logging.Discard,
 	)
 
 	require.NoError(t, err)
 	require.Len(t, repo.saved, 3)
-	require.Equal(t, "parser-chain", repo.saved[0].chainID)
+	require.Equal(t, "chain", repo.saved[0].chainID)
 	require.False(t, repo.saved[0].savePoolSnapshot)
 	require.True(t, repo.saved[1].savePoolSnapshot)
 	require.False(t, repo.saved[2].savePoolSnapshot)
@@ -155,7 +153,6 @@ func TestDoCollectSourceReturnsSourceTxError(t *testing.T) {
 		repo,
 		source,
 		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
-		configs.ParserDexConfig{},
 		logging.Discard,
 	)
 
@@ -176,7 +173,6 @@ func TestDoCollectSourceReturnsPoolInfoError(t *testing.T) {
 		repo,
 		source,
 		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1, PoolSnapshotInterval: 1},
-		configs.ParserDexConfig{},
 		logging.Discard,
 	)
 
@@ -192,7 +188,6 @@ func TestDoCollectReturnsRepositoryHeightError(t *testing.T) {
 		repo,
 		&sourceStoreMock{syncedHeight: 1},
 		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
-		configs.ParserDexConfig{},
 		logging.Discard,
 	)
 
@@ -208,7 +203,6 @@ func TestDoCollectReturnsSourceHeightError(t *testing.T) {
 		repo,
 		&sourceStoreMock{syncedErr: expected},
 		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
-		configs.ParserDexConfig{},
 		logging.Discard,
 	)
 
@@ -228,7 +222,6 @@ func TestDoCollectReturnsSaveHeightError(t *testing.T) {
 		repo,
 		source,
 		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
-		configs.ParserDexConfig{},
 		logging.Discard,
 	)
 
@@ -242,7 +235,6 @@ func TestCollectorStartHeight(t *testing.T) {
 }
 
 func TestCollectorPoolSnapshotInterval(t *testing.T) {
-	require.Equal(t, uint(7), collectorPoolSnapshotInterval(configs.CollectorConfig{PoolSnapshotInterval: 7}, configs.ParserDexConfig{PoolSnapshotInterval: 2}))
-	require.Equal(t, uint(2), collectorPoolSnapshotInterval(configs.CollectorConfig{}, configs.ParserDexConfig{PoolSnapshotInterval: 2}))
-	require.Equal(t, uint(configs.PARSER_POOL_SNAPSHOT_INTERVAL), collectorPoolSnapshotInterval(configs.CollectorConfig{}, configs.ParserDexConfig{}))
+	require.Equal(t, uint(7), collectorPoolSnapshotInterval(configs.CollectorConfig{PoolSnapshotInterval: 7}))
+	require.Equal(t, uint(configs.PARSER_POOL_SNAPSHOT_INTERVAL), collectorPoolSnapshotInterval(configs.CollectorConfig{}))
 }

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1,408 +1,248 @@
 package collector
 
 import (
-	context "context"
-	"encoding/base64"
-	"fmt"
-	"os"
+	"errors"
 	"testing"
 	"time"
 
-	grpc1 "github.com/cosmos/gogoproto/grpc"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"google.golang.org/grpc"
-
-	wasm "github.com/CosmWasm/wasmd/x/wasm/types"
-	tendermintType "github.com/cometbft/cometbft/proto/tendermint/types"
-	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
-	"github.com/cosmos/cosmos-sdk/types"
-	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
-
-	"github.com/dezswap/cosmwasm-etl/collector/datastore"
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
 	"github.com/dezswap/cosmwasm-etl/configs"
-	grpcConn "github.com/dezswap/cosmwasm-etl/pkg/grpc"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
-	"github.com/dezswap/cosmwasm-etl/pkg/s3client"
+	"github.com/stretchr/testify/require"
 )
 
-const startBlock int64 = 495466
+type sourceRepoMock struct {
+	syncedHeight uint64
+	syncedErr    error
+	saved        []savedHeight
+	saveErr      error
+}
 
-var (
-	testRawTxByte   []byte
-	testRawTxByte2  []byte
-	testRawTxString string
-	store           datastore.DataStore
-	testFactoryAddr string
-)
+type savedHeight struct {
+	chainID          string
+	height           uint64
+	txs              parser.RawTxs
+	poolInfos        []dex.PoolInfo
+	savePoolSnapshot bool
+}
 
-func Test01DoCollect(t *testing.T) {
-	// test specific setup
-	makeTxByte()
-	logger := logging.New("test", configs.LogConfig{})
+func (m *sourceRepoMock) GetSyncedHeight(string) (uint64, error) {
+	if len(m.saved) > 0 && (errors.Is(m.syncedErr, collectorrepo.ErrNotFound) || errors.Is(m.syncedErr, collectorrepo.ErrUnavailable)) {
+		return m.syncedHeight, nil
+	}
+	return m.syncedHeight, m.syncedErr
+}
 
-	m := serviceClientMock{}
-	lcdMock := lcdClientMock{}
+func (m *sourceRepoMock) GetBlockTxs(string, uint64) (parser.RawTxs, time.Time, error) {
+	return nil, time.Time{}, nil
+}
 
-	// collect block
-	// input 2 valid block & 1 pending response
-	m.On("GetBlockWithTxs", mock.Anything, &txtypes.GetBlockWithTxsRequest{Height: startBlock}).
-		Return(&txtypes.GetBlockWithTxsResponse{
-			Block: &tendermintType.Block{
-				Header: tendermintType.Header{
-					Height: startBlock,
-				},
-				Data: tendermintType.Data{
-					Txs: [][]byte{testRawTxByte},
-				},
-			},
-		}, nil)
-	m.On("GetBlockWithTxs", mock.Anything, &txtypes.GetBlockWithTxsRequest{Height: startBlock + 1}).
-		Return(&txtypes.GetBlockWithTxsResponse{
-			Block: &tendermintType.Block{
-				Header: tendermintType.Header{
-					Height: startBlock + 1,
-				},
-				Data: tendermintType.Data{
-					Txs: [][]byte{testRawTxByte2},
-				},
-			},
-		}, nil)
-	m.On("GetBlockWithTxs", mock.Anything, &txtypes.GetBlockWithTxsRequest{Height: startBlock + 2}).
-		Return((*txtypes.GetBlockWithTxsResponse)(nil), fmt.Errorf("invalid height: %d", startBlock+2))
+func (m *sourceRepoMock) GetPoolInfos(string, uint64) ([]dex.PoolInfo, error) {
+	return nil, nil
+}
 
-	// process block
-	m.On("GetTx", mock.Anything, &txtypes.GetTxRequest{Hash: "1608CE8E8C3AC55FF7F04A3C5771B6732B84AF9205F4788A607B1CB05125AC3B"}).
-		Return(&txtypes.GetTxResponse{
-			Tx: &txtypes.Tx{},
-			TxResponse: &types.TxResponse{
-				Height: startBlock,
-				TxHash: "1608CE8E8C3AC55FF7F04A3C5771B6732B84AF9205F4788A607B1CB05125AC3B",
-				Code:   0,
-				RawLog: testRawTxString,
-			},
-		}, nil)
+func (m *sourceRepoMock) SaveHeight(chainID string, height uint64, _ time.Time, txs parser.RawTxs, poolInfos []dex.PoolInfo, savePoolSnapshot bool) error {
+	if m.saveErr != nil {
+		return m.saveErr
+	}
+	m.saved = append(m.saved, savedHeight{
+		chainID:          chainID,
+		height:           height,
+		txs:              txs,
+		poolInfos:        poolInfos,
+		savePoolSnapshot: savePoolSnapshot,
+	})
+	m.syncedHeight = height
+	return nil
+}
 
-	m.On("GetTx", mock.Anything, &txtypes.GetTxRequest{Hash: "5EC8E130FBD2FFAAC87252C2E10AF4AF67900D9866F9ED053FC6A2137E559CD2"}).
-		Return(&txtypes.GetTxResponse{
-			Tx: &txtypes.Tx{},
-			TxResponse: &types.TxResponse{
-				Height: startBlock + 1,
-				TxHash: "5EC8E130FBD2FFAAC87252C2E10AF4AF67900D9866F9ED053FC6A2137E559CD2",
-				Code:   0,
-				RawLog: testRawTxString,
-			},
-		}, nil)
+type sourceStoreMock struct {
+	syncedHeight uint64
+	syncedErr    error
+	txs          map[uint64]parser.RawTxs
+	txsErr       error
+	poolInfos    map[uint64][]dex.PoolInfo
+	poolInfoErr  error
+}
 
-	// querying pairs
-	m.On("SmartContractState",
-		mock.Anything,
-		&wasm.QuerySmartContractStateRequest{
-			Address:   testFactoryAddr,
-			QueryData: wasm.RawContractMessage([]byte(`{"pairs":{"start_after":[{"token":{"contract_addr":"terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg"}},{"native_token":{"denom":"uluna"}}]}}`)),
-		}).Once().Return(&wasm.QuerySmartContractStateResponse{
-		Data: wasm.RawContractMessage([]byte(emptyFactoryPairsRes)),
-	}, nil)
+func (m *sourceStoreMock) GetSourceSyncedHeight() (uint64, error) {
+	return m.syncedHeight, m.syncedErr
+}
 
-	m.On("SmartContractState", mock.Anything,
-		&wasm.QuerySmartContractStateRequest{
-			Address:   testFactoryAddr,
-			QueryData: wasm.RawContractMessage([]byte(`{"pairs":{}}`)),
-		}).Once().Return(&wasm.QuerySmartContractStateResponse{
-		Data: wasm.RawContractMessage([]byte(lightFactoryResp)),
-	}, nil)
+func (m *sourceStoreMock) GetSourceTxs(height uint64) (parser.RawTxs, error) {
+	if m.txsErr != nil {
+		return nil, m.txsErr
+	}
+	return m.txs[height], nil
+}
 
-	m.On("SmartContractState", mock.Anything,
-		&wasm.QuerySmartContractStateRequest{
-			Address:   "terra1xjv2pmf26yaz3wqft7caafgckdg4eflzsw56aqhdcjw58qx0v2mqux87t8",
-			QueryData: wasm.RawContractMessage([]byte(`{"pool": {}}`)),
-		}).Return(&wasm.QuerySmartContractStateResponse{
-		Data: wasm.RawContractMessage([]byte(poolResponse)),
-	}, nil)
+func (m *sourceStoreMock) GetPoolInfos(height uint64) ([]dex.PoolInfo, error) {
+	if m.poolInfoErr != nil {
+		return nil, m.poolInfoErr
+	}
+	return m.poolInfos[height], nil
+}
 
-	mockFunc := func(cc grpc1.ClientConn) txtypes.ServiceClient {
-		return &m
+func TestDoCollectSourceCollectsFromStartHeightToUntilHeight(t *testing.T) {
+	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrNotFound}
+	source := &sourceStoreMock{
+		syncedHeight: 10,
+		txs: map[uint64]parser.RawTxs{
+			5: {{Hash: "tx5", Timestamp: time.Date(2026, 5, 19, 0, 0, 5, 0, time.UTC)}},
+			6: {{Hash: "tx6", Timestamp: time.Date(2026, 5, 19, 0, 0, 6, 0, time.UTC)}},
+		},
+		poolInfos: map[uint64][]dex.PoolInfo{
+			6: {{ContractAddr: "pair6"}},
+		},
 	}
 
-	mockQueryFunc := func(cc grpc1.ClientConn) wasm.QueryClient {
-		return &m
+	err := DoCollect(
+		repo,
+		source,
+		configs.CollectorConfig{ChainId: "chain", StartHeight: 5, UntilHeight: 6, PoolSnapshotInterval: 2},
+		configs.ParserDexConfig{},
+		logging.Discard,
+	)
+
+	require.NoError(t, err)
+	require.Len(t, repo.saved, 2)
+	require.Equal(t, uint64(5), repo.saved[0].height)
+	require.False(t, repo.saved[0].savePoolSnapshot)
+	require.Equal(t, parser.RawTxs{{Hash: "tx5", Timestamp: time.Date(2026, 5, 19, 0, 0, 5, 0, time.UTC)}}, repo.saved[0].txs)
+	require.Equal(t, uint64(6), repo.saved[1].height)
+	require.True(t, repo.saved[1].savePoolSnapshot)
+	require.Equal(t, []dex.PoolInfo{{ContractAddr: "pair6"}}, repo.saved[1].poolInfos)
+}
+
+func TestDoCollectSourceUsesParserChainAndSnapshotIntervalFallbacks(t *testing.T) {
+	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrUnavailable}
+	source := &sourceStoreMock{
+		syncedHeight: 3,
+		txs: map[uint64]parser.RawTxs{
+			1: {{Hash: "tx1"}},
+			2: {{Hash: "tx2"}},
+			3: {{Hash: "tx3"}},
+		},
+		poolInfos: map[uint64][]dex.PoolInfo{
+			2: {{ContractAddr: "pair2"}},
+		},
 	}
 
-	store.SetNewServiceClientFunc(mockFunc)
-	store.SetNewQueryClientFunc(mockQueryFunc)
+	err := DoCollect(
+		repo,
+		source,
+		configs.CollectorConfig{UntilHeight: 3},
+		configs.ParserDexConfig{ChainId: "parser-chain", PoolSnapshotInterval: 2},
+		logging.Discard,
+	)
 
-	mockS3Client := s3ClientMock{}
+	require.NoError(t, err)
+	require.Len(t, repo.saved, 3)
+	require.Equal(t, "parser-chain", repo.saved[0].chainID)
+	require.False(t, repo.saved[0].savePoolSnapshot)
+	require.True(t, repo.saved[1].savePoolSnapshot)
+	require.False(t, repo.saved[2].savePoolSnapshot)
+}
 
-	// collect block
-	// the latest old block
-	mockS3Client.On("GetLatestProcessedBlockNumber", mock.Anything).Return(startBlock-1, nil)
+func TestDoCollectSourceReturnsSourceTxError(t *testing.T) {
+	expected := errors.New("tx source failed")
+	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrNotFound}
+	source := &sourceStoreMock{syncedHeight: 1, txsErr: expected}
 
-	// process block
-	mockS3Client.On("ChangeLatestBlock", int64(startBlock-1), mock.Anything).Return(nil)
-	mockS3Client.On("ChangeLatestBlock", int64(startBlock), mock.Anything).Return(fmt.Errorf("artificial error")) // <- for finishing test
-	mockS3Client.On("UploadBlockBinary", mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	mockS3Client.On("UploadFileToS3", mock.Anything, mock.Anything).Return(nil)
+	err := DoCollect(
+		repo,
+		source,
+		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
+		configs.ParserDexConfig{},
+		logging.Discard,
+	)
 
-	lcdMock.On("GetTx", mock.Anything).Return(nil, nil)
+	require.ErrorIs(t, err, expected)
+	require.Empty(t, repo.saved)
+}
 
-	mockS3ClientCreateFunc := func(configs.S3Config) (s3client.S3ClientInterface, error) {
-		return &mockS3Client, nil
+func TestDoCollectSourceReturnsPoolInfoError(t *testing.T) {
+	expected := errors.New("pool source failed")
+	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrNotFound}
+	source := &sourceStoreMock{
+		syncedHeight: 1,
+		txs:          map[uint64]parser.RawTxs{1: {{Hash: "tx1"}}},
+		poolInfoErr:  expected,
 	}
 
-	store.SetNewS3ClientFunc(mockS3ClientCreateFunc)
+	err := DoCollect(
+		repo,
+		source,
+		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1, PoolSnapshotInterval: 1},
+		configs.ParserDexConfig{},
+		logging.Discard,
+	)
 
-	// run test method
-	err := DoCollect(store, logger)
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "artificial error")
+	require.ErrorIs(t, err, expected)
+	require.Empty(t, repo.saved)
 }
 
-func TestMain(m *testing.M) {
-	setUp()
-	code := m.Run()
-	tearDown()
-	os.Exit(code)
+func TestDoCollectReturnsRepositoryHeightError(t *testing.T) {
+	expected := errors.New("repo height failed")
+	repo := &sourceRepoMock{syncedErr: expected}
+
+	err := DoCollect(
+		repo,
+		&sourceStoreMock{syncedHeight: 1},
+		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
+		configs.ParserDexConfig{},
+		logging.Discard,
+	)
+
+	require.ErrorIs(t, err, expected)
+	require.Empty(t, repo.saved)
 }
 
-func setUp() {
-	var err error
-	testconf := configs.New()
-	testFactoryAddr = testconf.Collector.PairFactoryContractAddress
-	testServiceDesc := grpcConn.ServiceDescMock{}
-	testServiceDesc.On("GetConnection", mock.Anything).Return(&grpc.ClientConn{})
-	lcdMock := lcdClientMock{}
-	store, err = datastore.New(testconf, &testServiceDesc, &lcdMock)
-	if err != nil {
-		panic(err)
+func TestDoCollectReturnsSourceHeightError(t *testing.T) {
+	expected := errors.New("source height failed")
+	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrNotFound}
+
+	err := DoCollect(
+		repo,
+		&sourceStoreMock{syncedErr: expected},
+		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
+		configs.ParserDexConfig{},
+		logging.Discard,
+	)
+
+	require.ErrorIs(t, err, expected)
+	require.Empty(t, repo.saved)
+}
+
+func TestDoCollectReturnsSaveHeightError(t *testing.T) {
+	expected := errors.New("save height failed")
+	repo := &sourceRepoMock{syncedErr: collectorrepo.ErrNotFound, saveErr: expected}
+	source := &sourceStoreMock{
+		syncedHeight: 1,
+		txs:          map[uint64]parser.RawTxs{1: {{Hash: "tx1"}}},
 	}
 
-	time.Sleep(time.Second * 1)
+	err := DoCollect(
+		repo,
+		source,
+		configs.CollectorConfig{ChainId: "chain", UntilHeight: 1},
+		configs.ParserDexConfig{},
+		logging.Discard,
+	)
 
-	// dummy add for testing AddCustomInterfaceRegistry
-	store.AddCustomInterfaceRegistry(cryptocodec.RegisterInterfaces)
+	require.ErrorIs(t, err, expected)
+	require.Empty(t, repo.saved)
 }
 
-func tearDown() {}
-
-type serviceClientMock struct {
-	mock.Mock
+func TestCollectorStartHeight(t *testing.T) {
+	require.Equal(t, uint64(1), collectorStartHeight(configs.CollectorConfig{}))
+	require.Equal(t, uint64(42), collectorStartHeight(configs.CollectorConfig{StartHeight: 42}))
 }
 
-var _ txtypes.ServiceClient = &serviceClientMock{}
-var _ wasm.QueryClient = &serviceClientMock{}
-
-// BroadcastTx implements tx.ServiceClient
-func (s *serviceClientMock) BroadcastTx(ctx context.Context, in *txtypes.BroadcastTxRequest, opts ...grpc.CallOption) (*txtypes.BroadcastTxResponse, error) {
-	args := s.MethodCalled("BroadcastTx", ctx, in)
-	return args.Get(0).(*txtypes.BroadcastTxResponse), args.Error(1)
-}
-
-// GetBlockWithTxs implements tx.ServiceClient
-func (s *serviceClientMock) GetBlockWithTxs(ctx context.Context, in *txtypes.GetBlockWithTxsRequest, opts ...grpc.CallOption) (*txtypes.GetBlockWithTxsResponse, error) {
-	args := s.MethodCalled("GetBlockWithTxs", ctx, in)
-	return args.Get(0).(*txtypes.GetBlockWithTxsResponse), args.Error(1)
-}
-
-// GetTx implements tx.ServiceClient
-func (s *serviceClientMock) GetTx(ctx context.Context, in *txtypes.GetTxRequest, opts ...grpc.CallOption) (*txtypes.GetTxResponse, error) {
-	args := s.MethodCalled("GetTx", ctx, in)
-	return args.Get(0).(*txtypes.GetTxResponse), args.Error(1)
-}
-
-// GetTxsEvent implements tx.ServiceClient
-func (s *serviceClientMock) GetTxsEvent(ctx context.Context, in *txtypes.GetTxsEventRequest, opts ...grpc.CallOption) (*txtypes.GetTxsEventResponse, error) {
-	args := s.MethodCalled("GetTxsEvent", ctx, in)
-	return args.Get(0).(*txtypes.GetTxsEventResponse), args.Error(1)
-}
-
-// Simulate implements tx.ServiceClient
-func (s *serviceClientMock) Simulate(ctx context.Context, in *txtypes.SimulateRequest, opts ...grpc.CallOption) (*txtypes.SimulateResponse, error) {
-	args := s.MethodCalled("Simulate", ctx, in)
-	return args.Get(0).(*txtypes.SimulateResponse), args.Error(1)
-}
-
-func (s *serviceClientMock) ContractInfo(ctx context.Context, in *wasm.QueryContractInfoRequest, opts ...grpc.CallOption) (*wasm.QueryContractInfoResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) ContractHistory(ctx context.Context, in *wasm.QueryContractHistoryRequest, opts ...grpc.CallOption) (*wasm.QueryContractHistoryResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) ContractsByCode(ctx context.Context, in *wasm.QueryContractsByCodeRequest, opts ...grpc.CallOption) (*wasm.QueryContractsByCodeResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) AllContractState(ctx context.Context, in *wasm.QueryAllContractStateRequest, opts ...grpc.CallOption) (*wasm.QueryAllContractStateResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) RawContractState(ctx context.Context, in *wasm.QueryRawContractStateRequest, opts ...grpc.CallOption) (*wasm.QueryRawContractStateResponse, error) {
-	panic("unimplemented")
-}
-
-// Simulate implements wasm.QueryClient
-func (s *serviceClientMock) SmartContractState(ctx context.Context, in *wasm.QuerySmartContractStateRequest, opts ...grpc.CallOption) (*wasm.QuerySmartContractStateResponse, error) {
-	args := s.MethodCalled("SmartContractState", ctx, in)
-	return args.Get(0).(*wasm.QuerySmartContractStateResponse), args.Error(1)
-}
-
-func (s *serviceClientMock) Code(ctx context.Context, in *wasm.QueryCodeRequest, opts ...grpc.CallOption) (*wasm.QueryCodeResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) Codes(ctx context.Context, in *wasm.QueryCodesRequest, opts ...grpc.CallOption) (*wasm.QueryCodesResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) PinnedCodes(ctx context.Context, in *wasm.QueryPinnedCodesRequest, opts ...grpc.CallOption) (*wasm.QueryPinnedCodesResponse, error) {
-	panic("unimplemented")
-}
-
-func (s *serviceClientMock) Params(ctx context.Context, in *wasm.QueryParamsRequest, opts ...grpc.CallOption) (*wasm.QueryParamsResponse, error) {
-	panic("implement me")
-}
-
-func (s *serviceClientMock) ContractsByCreator(ctx context.Context, in *wasm.QueryContractsByCreatorRequest, opts ...grpc.CallOption) (*wasm.QueryContractsByCreatorResponse, error) {
-	panic("implement me")
-}
-
-func (s *serviceClientMock) BuildAddress(ctx context.Context, in *wasm.QueryBuildAddressRequest, opts ...grpc.CallOption) (*wasm.QueryBuildAddressResponse, error) {
-	panic("implement me")
-}
-
-func (s *serviceClientMock) TxDecode(ctx context.Context, in *txtypes.TxDecodeRequest, opts ...grpc.CallOption) (*txtypes.TxDecodeResponse, error) {
-	panic("implement me")
-}
-
-func (s *serviceClientMock) TxEncode(ctx context.Context, in *txtypes.TxEncodeRequest, opts ...grpc.CallOption) (*txtypes.TxEncodeResponse, error) {
-	panic("implement me")
-}
-
-func (s *serviceClientMock) TxEncodeAmino(ctx context.Context, in *txtypes.TxEncodeAminoRequest, opts ...grpc.CallOption) (*txtypes.TxEncodeAminoResponse, error) {
-	panic("implement me")
-}
-
-func (s *serviceClientMock) TxDecodeAmino(ctx context.Context, in *txtypes.TxDecodeAminoRequest, opts ...grpc.CallOption) (*txtypes.TxDecodeAminoResponse, error) {
-	panic("implement me")
-}
-
-type s3ClientMock struct {
-	mock.Mock
-}
-
-var _ s3client.S3ClientInterface = &s3ClientMock{}
-
-func (s *s3ClientMock) GetLatestProcessedBlockNumber(folderPath ...string) (int64, error) {
-	args := s.MethodCalled("GetLatestProcessedBlockNumber", mock.Anything)
-	return args.Get(0).(int64), args.Error(1)
-}
-
-func (s *s3ClientMock) ChangeLatestBlock(blockNum int64, folderPath ...string) error {
-	args := s.MethodCalled("ChangeLatestBlock", blockNum, folderPath)
-	return args.Error(0)
-}
-
-func (s *s3ClientMock) UploadBlockBinary(blockNum int64, data []byte, folderPath ...string) error {
-	args := s.MethodCalled("UploadBlockBinary", blockNum, data, folderPath)
-	return args.Error(0)
-}
-
-func (s *s3ClientMock) GetFileFromS3(in ...string) ([]byte, error) {
-	args := s.MethodCalled("GetFileFromS3", in)
-	return args.Get(0).([]byte), args.Error(0)
-}
-
-func (s *s3ClientMock) UploadFileToS3(in1 []byte, in2 ...string) error {
-	args := s.MethodCalled("UploadFileToS3", in1, in2)
-	return args.Error(0)
-}
-
-func (s *s3ClientMock) GetBlockFilePath(blockNum int64, folderPath ...string) []string {
-	return append(folderPath, fmt.Sprintf("%s_%d.json", "block", blockNum))
-}
-
-func makeTxByte() {
-	var err error
-	testRawTxByte, err = base64.StdEncoding.DecodeString("CqgCCqUCCiQvY29zbXdhc20ud2FzbS52MS5Nc2dFeGVjdXRlQ29udHJhY3QS/AEKLHRlcnJhMTR2ajZlZDRoZ203ZHY5NGR6NzY5NjRnM2x4bDV3ajk1amFmcGw4EkB0ZXJyYTF6NzcwNXQycDVwNnJlbDkzZmQ3enJzaDhhNGx1eHl4ejg4YTR6a21sY3R3ZjM4eWg1MjBxdDk0OW44GnZ7InN3YXAiOnsibWluaW11bV9yZWNlaXZlIjoiOTg1MTQyMTkiLCJvZmZlcl9hc3NldCI6eyJhbW91bnQiOiIxMDAwMDAwMDAiLCJpbmZvIjp7Im5hdGl2ZV90b2tlbiI6eyJkZW5vbSI6InVsdW5hIn19fX19KhIKBXVsdW5hEgkxMDAwMDAwMDASaApQCkYKHy9jb3Ntb3MuY3J5cHRvLnNlY3AyNTZrMS5QdWJLZXkSIwohA4RvoQ6AJPcezRNaBc8IK6qS0iTJUsikM6AuVJfGLCfdEgQKAggBGBcSFAoOCgV1bHVuYRIFOTAxNDUQg9ckGkD7+6yMOW70wuuXu1tIcMBBOGHYnY1mBbeBI5AJcK3k6CfobItfYil9pJcxpkvZ33Jxlk3r6xISEJDpfGTi0Evc")
-	if err != nil {
-		panic(err)
-	}
-
-	testRawTxByte2, err = base64.StdEncoding.DecodeString("CqMBCqABCiUvY29zbW9zLnN0YWtpbmcudjFiZXRhMS5Nc2dVbmRlbGVnYXRlEncKLHRlcnJhMWhkbXg3ODBkc2ttZDQ1dHU3NmZoa2tnc3d5NHZlcjN5OTh3d2d4EjN0ZXJyYXZhbG9wZXIxa2duNnp6bmZxMnh3cnczaHJoN3F0cWp3dTk4ZXM3dnQ4YXpqbDMaEgoFdWx1bmESCTEwOTMyMDUyMBJmCk4KRgofL2Nvc21vcy5jcnlwdG8uc2VjcDI1NmsxLlB1YktleRIjCiEDdHnIdCP9Dyy3zyp/VVPZ+1Qw1jVCROJ2IBGsbMQpp/8SBAoCCAESFAoOCgV1bHVuYRIFNTc4NjgQ+sUXGkCc2s5SVR/yQeT3JpTCEzERCFYeLRxmSFvgeLXm8hWX1z7+zzrrzJxhoKWjgyPhsgZ6yCG9qQ6B0pp3niiM0Qbb")
-	if err != nil {
-		panic(err)
-	}
-
-	testRawTxString = `"[{\"events\":[{\"type\":\"coin_received\",\"attributes\":[{\"key\":\"receiver\",\"value\":\"terra1z7705t2p5p6rel93fd7zrsh8a4luxyxz88a4zkmlctwf38yh520qt949n8\"},{\"key\":\"amount\",\"value\":\"100000000uluna\"}]},{\"type\":\"coin_spent\",\"attributes\":[{\"key\":\"spender\",\"value\":\"terra14vj6ed4hgm7dv94dz76964g3lxl5wj95jafpl8\"},{\"key\":\"amount\",\"value\":\"100000000uluna\"}]},{\"type\":\"execute\",\"attributes\":[{\"key\":\"_contract_address\",\"value\":\"terra1z7705t2p5p6rel93fd7zrsh8a4luxyxz88a4zkmlctwf38yh520qt949n8\"},{\"key\":\"_contract_address\",\"value\":\"terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh\"}]},{\"type\":\"message\",\"attributes\":[{\"key\":\"action\",\"value\":\"/cosmwasm.wasm.v1.MsgExecuteContract\"},{\"key\":\"module\",\"value\":\"wasm\"},{\"key\":\"sender\",\"value\":\"terra14vj6ed4hgm7dv94dz76964g3lxl5wj95jafpl8\"}]},{\"type\":\"transfer\",\"attributes\":[{\"key\":\"recipient\",\"value\":\"terra1z7705t2p5p6rel93fd7zrsh8a4luxyxz88a4zkmlctwf38yh520qt949n8\"},{\"key\":\"sender\",\"value\":\"terra14vj6ed4hgm7dv94dz76964g3lxl5wj95jafpl8\"},{\"key\":\"amount\",\"value\":\"100000000uluna\"}]},{\"type\":\"wasm\",\"attributes\":[{\"key\":\"_contract_address\",\"value\":\"terra1z7705t2p5p6rel93fd7zrsh8a4luxyxz88a4zkmlctwf38yh520qt949n8\"},{\"key\":\"action\",\"value\":\"swap\"},{\"key\":\"sender\",\"value\":\"terra14vj6ed4hgm7dv94dz76964g3lxl5wj95jafpl8\"},{\"key\":\"receiver\",\"value\":\"terra14vj6ed4hgm7dv94dz76964g3lxl5wj95jafpl8\"},{\"key\":\"offer_asset\",\"value\":\"uluna\"},{\"key\":\"ask_asset\",\"value\":\"terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh\"},{\"key\":\"offer_amount\",\"value\":\"100000000\"},{\"key\":\"return_amount\",\"value\":\"99009265\"},{\"key\":\"spread_amount\",\"value\":\"951116\"},{\"key\":\"commission_amount\",\"value\":\"39619\"},{\"key\":\"maker_fee_amount\",\"value\":\"0\"},{\"key\":\"_contract_address\",\"value\":\"terra14xsm2wzvu7xaf567r693vgfkhmvfs08l68h4tjj5wjgyn5ky8e2qvzyanh\"},{\"key\":\"action\",\"value\":\"transfer\"},{\"key\":\"from\",\"value\":\"terra1z7705t2p5p6rel93fd7zrsh8a4luxyxz88a4zkmlctwf38yh520qt949n8\"},{\"key\":\"to\",\"value\":\"terra14vj6ed4hgm7dv94dz76964g3lxl5wj95jafpl8\"},{\"key\":\"amount\",\"value\":\"99009265\"}]}]}]",`
-}
-
-const (
-	poolResponse = `
-		{
-			"assets": [
-				{
-					"info": {
-						"token": {
-							"contract_addr": "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg"
-						}
-					},
-					"amount": "50000000000000"
-				},
-				{
-					"info": {
-						"native_token": {
-							"denom": "uluna"
-						}
-					},
-					"amount": "5000000"
-				}
-			],
-			"total_share": "15811388300"
-		}
-	`
-
-	lightFactoryResp = `
-		{
-			"pairs": [
-				{
-					"asset_infos": [
-						{
-							"token": {
-								"contract_addr": "terra1qj5hs3e86qn4vm9dvtgtlkdp550r0rayk9wpay44mfw3gn3tr8nq5jw3dg"
-							}
-						},
-						{
-							"native_token": {
-								"denom": "uluna"
-							}
-						}
-					],
-					"contract_addr": "terra1xjv2pmf26yaz3wqft7caafgckdg4eflzsw56aqhdcjw58qx0v2mqux87t8",
-					"liquidity_token": "terra1ttaekgrc60xc3xcflq069m49lwu79m5t552rjcws48rzhxcr4g6shmdw2v",
-					"asset_decimals": [
-						6,
-						6
-					]
-				}
-			]
-		}
-	`
-	emptyFactoryPairsRes = `{"pairs": []}`
-)
-
-type lcdClientMock struct {
-	mock.Mock
-}
-
-// GetTx implements lcdClient
-func (c *lcdClientMock) GetTx(txHash string) (*txtypes.GetTxResponse, error) {
-	args := c.Mock.MethodCalled("GetTx", txHash)
-	return args.Get(0).(*txtypes.GetTxResponse), args.Error(1)
-}
-
-// GetBlockWithTxs implements lcdClient.
-func (c *lcdClientMock) GetBlockWithTxs(height int64) (*txtypes.GetBlockWithTxsResponse, error) {
-	args := c.Mock.MethodCalled("GetBlockWithTxs", height)
-	return args.Get(0).(*txtypes.GetBlockWithTxsResponse), args.Error(1)
+func TestCollectorPoolSnapshotInterval(t *testing.T) {
+	require.Equal(t, uint(7), collectorPoolSnapshotInterval(configs.CollectorConfig{PoolSnapshotInterval: 7}, configs.ParserDexConfig{PoolSnapshotInterval: 2}))
+	require.Equal(t, uint(2), collectorPoolSnapshotInterval(configs.CollectorConfig{}, configs.ParserDexConfig{PoolSnapshotInterval: 2}))
+	require.Equal(t, uint(configs.PARSER_POOL_SNAPSHOT_INTERVAL), collectorPoolSnapshotInterval(configs.CollectorConfig{}, configs.ParserDexConfig{}))
 }

--- a/collector/height_runner.go
+++ b/collector/height_runner.go
@@ -1,6 +1,7 @@
 package collector
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
@@ -22,18 +23,12 @@ type heightCollectorConfig struct {
 // Implementations own source reads and persistence for a single height, while
 // the runner handles local/source progress, until-height bounds, and polling.
 func collectHeights(collector heightCollector, config heightCollectorConfig, logger logging.Logger) error {
-func collectHeights(collector heightCollector, config heightCollectorConfig, logger logging.Logger) error {
 	startHeight := normalizeStartHeight(config.StartHeight)
 	if config.UntilHeight > 0 && config.UntilHeight < startHeight {
 		return fmt.Errorf("invalid height range: start_height=%d until_height=%d", startHeight, config.UntilHeight)
 	}
 
 	pollInterval := config.PollInterval
-	if pollInterval == 0 {
-		pollInterval = collectorPollInterval
-	}
-	// ... rest of function
-}
 	if pollInterval == 0 {
 		pollInterval = collectorPollInterval
 	}

--- a/collector/height_runner.go
+++ b/collector/height_runner.go
@@ -22,8 +22,18 @@ type heightCollectorConfig struct {
 // Implementations own source reads and persistence for a single height, while
 // the runner handles local/source progress, until-height bounds, and polling.
 func collectHeights(collector heightCollector, config heightCollectorConfig, logger logging.Logger) error {
+func collectHeights(collector heightCollector, config heightCollectorConfig, logger logging.Logger) error {
 	startHeight := normalizeStartHeight(config.StartHeight)
+	if config.UntilHeight > 0 && config.UntilHeight < startHeight {
+		return fmt.Errorf("invalid height range: start_height=%d until_height=%d", startHeight, config.UntilHeight)
+	}
+
 	pollInterval := config.PollInterval
+	if pollInterval == 0 {
+		pollInterval = collectorPollInterval
+	}
+	// ... rest of function
+}
 	if pollInterval == 0 {
 		pollInterval = collectorPollInterval
 	}

--- a/collector/height_runner.go
+++ b/collector/height_runner.go
@@ -55,7 +55,12 @@ func collectHeights(collector heightCollector, config heightCollectorConfig, log
 			continue
 		}
 
-		for height := localHeight + 1; height <= targetHeight; height++ {
+		nextHeight := localHeight + 1
+		if nextHeight < startHeight {
+			nextHeight = startHeight
+		}
+
+		for height := nextHeight; height <= targetHeight; height++ {
 			if height < startHeight {
 				continue
 			}

--- a/collector/height_runner.go
+++ b/collector/height_runner.go
@@ -59,6 +59,11 @@ func collectHeights(collector heightCollector, config heightCollectorConfig, log
 		if nextHeight < startHeight {
 			nextHeight = startHeight
 		}
+		if nextHeight > targetHeight {
+			logger.Infof("no collectible height yet: local=%d source=%d start=%d", localHeight, srcHeight, startHeight)
+			time.Sleep(pollInterval)
+			continue
+		}
 
 		for height := nextHeight; height <= targetHeight; height++ {
 			if height < startHeight {

--- a/collector/height_runner.go
+++ b/collector/height_runner.go
@@ -1,0 +1,81 @@
+package collector
+
+import (
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+)
+
+type heightCollector interface {
+	LocalHeight() (uint64, error)
+	SourceHeight() (uint64, error)
+	CollectHeight(height uint64) error
+}
+
+type heightCollectorConfig struct {
+	StartHeight  uint64
+	UntilHeight  uint64
+	PollInterval time.Duration
+}
+
+// collectHeights runs the common contiguous-height collection loop.
+// Implementations own source reads and persistence for a single height, while
+// the runner handles local/source progress, until-height bounds, and polling.
+func collectHeights(collector heightCollector, config heightCollectorConfig, logger logging.Logger) error {
+	startHeight := normalizeStartHeight(config.StartHeight)
+	pollInterval := config.PollInterval
+	if pollInterval == 0 {
+		pollInterval = collectorPollInterval
+	}
+
+	for {
+		localHeight, err := collector.LocalHeight()
+		if err != nil {
+			return err
+		}
+
+		srcHeight, err := collector.SourceHeight()
+		if err != nil {
+			return err
+		}
+
+		targetHeight := boundedTargetHeight(srcHeight, config.UntilHeight)
+		if localHeight >= targetHeight {
+			if reachedUntilHeight(localHeight, config.UntilHeight) {
+				logger.Infof("collector reached until height %d", config.UntilHeight)
+				return nil
+			}
+			logger.Infof("no new collector source height: local=%d source=%d", localHeight, srcHeight)
+			time.Sleep(pollInterval)
+			continue
+		}
+
+		for height := localHeight + 1; height <= targetHeight; height++ {
+			if height < startHeight {
+				continue
+			}
+			if err := collector.CollectHeight(height); err != nil {
+				return err
+			}
+			logger.Infof("collected source height %d", height)
+		}
+	}
+}
+
+func normalizeStartHeight(height uint64) uint64 {
+	if height > 0 {
+		return height
+	}
+	return 1
+}
+
+func boundedTargetHeight(sourceHeight, untilHeight uint64) uint64 {
+	if untilHeight > 0 && untilHeight < sourceHeight {
+		return untilHeight
+	}
+	return sourceHeight
+}
+
+func reachedUntilHeight(localHeight, untilHeight uint64) bool {
+	return untilHeight > 0 && localHeight >= untilHeight
+}

--- a/collector/height_runner_test.go
+++ b/collector/height_runner_test.go
@@ -1,0 +1,118 @@
+package collector
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+	"github.com/stretchr/testify/require"
+)
+
+type heightCollectorMock struct {
+	localHeight  uint64
+	localErr     error
+	sourceHeight uint64
+	sourceErr    error
+	collectErr   error
+	collected    []uint64
+}
+
+func (m *heightCollectorMock) LocalHeight() (uint64, error) {
+	return m.localHeight, m.localErr
+}
+
+func (m *heightCollectorMock) SourceHeight() (uint64, error) {
+	return m.sourceHeight, m.sourceErr
+}
+
+func (m *heightCollectorMock) CollectHeight(height uint64) error {
+	if m.collectErr != nil {
+		return m.collectErr
+	}
+	m.collected = append(m.collected, height)
+	m.localHeight = height
+	return nil
+}
+
+func TestCollectHeightsCollectsBoundedRange(t *testing.T) {
+	collector := &heightCollectorMock{
+		localHeight:  3,
+		sourceHeight: 10,
+	}
+
+	err := collectHeights(collector, heightCollectorConfig{
+		StartHeight: 5,
+		UntilHeight: 7,
+	}, logging.Discard)
+
+	require.NoError(t, err)
+	require.Equal(t, []uint64{5, 6, 7}, collector.collected)
+}
+
+func TestCollectHeightsStopsWhenUntilHeightAlreadyReached(t *testing.T) {
+	collector := &heightCollectorMock{
+		localHeight:  7,
+		sourceHeight: 10,
+	}
+
+	err := collectHeights(collector, heightCollectorConfig{
+		StartHeight: 5,
+		UntilHeight: 7,
+	}, logging.Discard)
+
+	require.NoError(t, err)
+	require.Empty(t, collector.collected)
+}
+
+func TestCollectHeightsReturnsSourceError(t *testing.T) {
+	expected := errors.New("source height failed")
+	collector := &heightCollectorMock{
+		localHeight: 0,
+		sourceErr:   expected,
+	}
+
+	err := collectHeights(collector, heightCollectorConfig{
+		UntilHeight: 1,
+	}, logging.Discard)
+
+	require.ErrorIs(t, err, expected)
+}
+
+func TestCollectHeightsReturnsLocalError(t *testing.T) {
+	expected := errors.New("local height failed")
+	collector := &heightCollectorMock{localErr: expected}
+
+	err := collectHeights(collector, heightCollectorConfig{
+		UntilHeight: 1,
+	}, logging.Discard)
+
+	require.ErrorIs(t, err, expected)
+}
+
+func TestCollectHeightsReturnsCollectError(t *testing.T) {
+	expected := errors.New("collect height failed")
+	collector := &heightCollectorMock{
+		localHeight:  0,
+		sourceHeight: 1,
+		collectErr:   expected,
+	}
+
+	err := collectHeights(collector, heightCollectorConfig{
+		UntilHeight: 1,
+	}, logging.Discard)
+
+	require.ErrorIs(t, err, expected)
+	require.Empty(t, collector.collected)
+}
+
+func TestBoundedTargetHeight(t *testing.T) {
+	require.Equal(t, uint64(7), boundedTargetHeight(10, 7))
+	require.Equal(t, uint64(10), boundedTargetHeight(10, 0))
+	require.Equal(t, uint64(5), boundedTargetHeight(5, 7))
+}
+
+func TestReachedUntilHeight(t *testing.T) {
+	require.True(t, reachedUntilHeight(7, 7))
+	require.False(t, reachedUntilHeight(6, 7))
+	require.False(t, reachedUntilHeight(7, 0))
+}

--- a/collector/repo/repository.go
+++ b/collector/repo/repository.go
@@ -1,0 +1,176 @@
+package repo
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/db"
+	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
+	"github.com/lib/pq"
+	pkgerrors "github.com/pkg/errors"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+var (
+	ErrNotFound    = errors.New("collector source data not found")
+	ErrUnavailable = errors.New("collector source table unavailable")
+)
+
+// Repository stores parser-ready source data collected by DoCollectSource.
+// Missing rows and missing tables are exposed separately so parser can fall
+// back to direct chain reads without masking malformed stored data.
+type Repository interface {
+	GetSyncedHeight(chainID string) (uint64, error)
+	GetBlockTxs(chainID string, height uint64) (parser.RawTxs, time.Time, error)
+	GetPoolInfos(chainID string, height uint64) ([]dex.PoolInfo, error)
+	SaveHeight(chainID string, height uint64, blockTime time.Time, txs parser.RawTxs, poolInfos []dex.PoolInfo, savePoolSnapshot bool) error
+}
+
+type repository struct {
+	db *gorm.DB
+}
+
+var _ Repository = (*repository)(nil)
+
+func New(dbConfig configs.RdbConfig) Repository {
+	pqDB := db.PostgresDb{}
+	if err := pqDB.Init(dbConfig); err != nil {
+		panic(err)
+	}
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: pqDB.Db}), &gorm.Config{})
+	if err != nil {
+		panic(err)
+	}
+
+	return NewWithDB(gormDB)
+}
+
+func NewWithDB(db *gorm.DB) Repository {
+	return &repository{db: db}
+}
+
+func (r *repository) GetSyncedHeight(chainID string) (uint64, error) {
+	row := schemas.CollectorSyncedHeight{}
+	if err := r.db.Where("chain_id = ?", chainID).First(&row).Error; err != nil {
+		return 0, classifyReadErr(err)
+	}
+	return row.Height, nil
+}
+
+func (r *repository) GetBlockTxs(chainID string, height uint64) (parser.RawTxs, time.Time, error) {
+	row := schemas.CollectorBlock{}
+	if err := r.db.Where("chain_id = ? AND height = ?", chainID, height).First(&row).Error; err != nil {
+		return nil, time.Time{}, classifyReadErr(err)
+	}
+
+	txs := parser.RawTxs{}
+	if err := json.Unmarshal(row.Txs, &txs); err != nil {
+		return nil, time.Time{}, pkgerrors.Wrap(err, "collector repo unmarshal block txs")
+	}
+	return txs, row.BlockTime, nil
+}
+
+func (r *repository) GetPoolInfos(chainID string, height uint64) ([]dex.PoolInfo, error) {
+	row := schemas.CollectorPoolSnapshot{}
+	if err := r.db.Where("chain_id = ? AND height = ?", chainID, height).First(&row).Error; err != nil {
+		return nil, classifyReadErr(err)
+	}
+
+	poolInfos := []dex.PoolInfo{}
+	if err := json.Unmarshal(row.PoolInfos, &poolInfos); err != nil {
+		return nil, pkgerrors.Wrap(err, "collector repo unmarshal pool infos")
+	}
+	return poolInfos, nil
+}
+
+func (r *repository) SaveHeight(chainID string, height uint64, blockTime time.Time, txs parser.RawTxs, poolInfos []dex.PoolInfo, savePoolSnapshot bool) error {
+	txBytes, err := json.Marshal(txs)
+	if err != nil {
+		return pkgerrors.Wrap(err, "collector repo marshal block txs")
+	}
+
+	var poolBytes []byte
+	if savePoolSnapshot {
+		poolBytes, err = json.Marshal(poolInfos)
+		if err != nil {
+			return pkgerrors.Wrap(err, "collector repo marshal pool infos")
+		}
+	}
+
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		now := time.Now().UTC()
+		block := schemas.CollectorBlock{
+			ChainId:   chainID,
+			Height:    height,
+			BlockTime: blockTime.UTC(),
+			Txs:       schemas.CollectorJSON(txBytes),
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := upsert(tx, block, []string{"chain_id", "height"}, []string{"block_time", "txs", "updated_at"}); err != nil {
+			return pkgerrors.Wrap(err, "collector repo save block")
+		}
+
+		if savePoolSnapshot {
+			pool := schemas.CollectorPoolSnapshot{
+				ChainId:   chainID,
+				Height:    height,
+				PoolInfos: schemas.CollectorJSON(poolBytes),
+				CreatedAt: now,
+				UpdatedAt: now,
+			}
+			if err := upsert(tx, pool, []string{"chain_id", "height"}, []string{"pool_infos", "updated_at"}); err != nil {
+				return pkgerrors.Wrap(err, "collector repo save pool snapshot")
+			}
+		}
+
+		synced := schemas.CollectorSyncedHeight{
+			ChainId:   chainID,
+			Height:    height,
+			CreatedAt: now,
+			UpdatedAt: now,
+		}
+		if err := upsert(tx, synced, []string{"chain_id"}, []string{"height", "updated_at"}); err != nil {
+			return pkgerrors.Wrap(err, "collector repo save synced height")
+		}
+		return nil
+	})
+}
+
+func upsert[T any](db *gorm.DB, value T, keyColumns []string, updateColumns []string) error {
+	columns := make([]clause.Column, 0, len(keyColumns))
+	for _, column := range keyColumns {
+		columns = append(columns, clause.Column{Name: column})
+	}
+	return db.Clauses(clause.OnConflict{
+		Columns:   columns,
+		DoUpdates: clause.AssignmentColumns(updateColumns),
+	}).Create(&value).Error
+}
+
+func classifyReadErr(err error) error {
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return ErrNotFound
+	}
+	if isUndefinedTable(err) {
+		return ErrUnavailable
+	}
+	return err
+}
+
+func isUndefinedTable(err error) bool {
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) && pqErr.Code == "42P01" {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "sqlstate 42p01") || strings.Contains(msg, "does not exist")
+}

--- a/collector/repo/repository.go
+++ b/collector/repo/repository.go
@@ -138,7 +138,13 @@ func (r *repository) SaveHeight(chainID string, height uint64, blockTime time.Ti
 			CreatedAt: now,
 			UpdatedAt: now,
 		}
-		if err := upsert(tx, synced, []string{"chain_id"}, []string{"height", "updated_at"}); err != nil {
+		if err := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "chain_id"}},
+			DoUpdates: clause.Assignments(map[string]interface{}{
+				"height":     gorm.Expr("GREATEST(collector_synced_heights.height, EXCLUDED.height)"),
+				"updated_at": now,
+			}),
+		}).Create(&synced).Error; err != nil {
 			return pkgerrors.Wrap(err, "collector repo save synced height")
 		}
 		return nil

--- a/collector/repo/repository.go
+++ b/collector/repo/repository.go
@@ -172,5 +172,6 @@ func isUndefinedTable(err error) bool {
 		return true
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "sqlstate 42p01") || strings.Contains(msg, "does not exist")
+	return strings.Contains(msg, "sqlstate 42p01") ||
+		(strings.Contains(msg, "relation") && strings.Contains(msg, "does not exist"))
 }

--- a/collector/repo/repository_test.go
+++ b/collector/repo/repository_test.go
@@ -250,6 +250,11 @@ func TestIsUndefinedTableHandlesDriverAndSQLStateErrors(t *testing.T) {
 	require.False(t, isUndefinedTable(errors.New("connection refused")))
 }
 
+func TestIsUndefinedTableRejectsUnrelatedDoesNotExistErrors(t *testing.T) {
+	require.False(t, isUndefinedTable(errors.New(`database "collector" does not exist`)))
+	require.False(t, isUndefinedTable(errors.New(`role "etl" does not exist`)))
+}
+
 func expectInsert(mock sqlmock.Sqlmock, sql string) {
 	mock.ExpectExec(regexp.QuoteMeta(sql)).
 		WillReturnResult(sqlmock.NewResult(1, 1))

--- a/collector/repo/repository_test.go
+++ b/collector/repo/repository_test.go
@@ -159,7 +159,7 @@ func TestSaveHeightUpsertsBlockPoolAndSyncedHeight(t *testing.T) {
 	mock.ExpectBegin()
 	expectInsert(mock, `INSERT INTO "collector_blocks"`)
 	expectInsert(mock, `INSERT INTO "collector_pool_snapshots"`)
-	expectInsert(mock, `INSERT INTO "collector_synced_heights"`)
+	expectSyncedHeightInsert(mock)
 	mock.ExpectCommit()
 
 	err := repo.SaveHeight(
@@ -181,7 +181,7 @@ func TestSaveHeightWithoutPoolSnapshotSkipsPoolUpsert(t *testing.T) {
 
 	mock.ExpectBegin()
 	expectInsert(mock, `INSERT INTO "collector_blocks"`)
-	expectInsert(mock, `INSERT INTO "collector_synced_heights"`)
+	expectSyncedHeightInsert(mock)
 	mock.ExpectCommit()
 
 	err := repo.SaveHeight(
@@ -234,7 +234,7 @@ func TestSaveHeightRollsBackWhenSyncedHeightUpsertFails(t *testing.T) {
 
 	mock.ExpectBegin()
 	expectInsert(mock, `INSERT INTO "collector_blocks"`)
-	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "collector_synced_heights"`)).
+	mock.ExpectExec(syncedHeightInsertPattern()).
 		WillReturnError(expected)
 	mock.ExpectRollback()
 
@@ -258,4 +258,15 @@ func TestIsUndefinedTableRejectsUnrelatedDoesNotExistErrors(t *testing.T) {
 func expectInsert(mock sqlmock.Sqlmock, sql string) {
 	mock.ExpectExec(regexp.QuoteMeta(sql)).
 		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+func expectSyncedHeightInsert(mock sqlmock.Sqlmock) {
+	mock.ExpectExec(syncedHeightInsertPattern()).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}
+
+func syncedHeightInsertPattern() string {
+	return regexp.QuoteMeta(`INSERT INTO "collector_synced_heights"`) +
+		`.*` +
+		regexp.QuoteMeta(`GREATEST(collector_synced_heights.height, EXCLUDED.height)`)
 }

--- a/collector/repo/repository_test.go
+++ b/collector/repo/repository_test.go
@@ -1,0 +1,256 @@
+package repo
+
+import (
+	"errors"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
+	"github.com/lib/pq"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func newMockRepo(t *testing.T) (*repository, sqlmock.Sqlmock) {
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	gormDB, err := gorm.Open(postgres.New(postgres.Config{
+		Conn:                 sqlDB,
+		PreferSimpleProtocol: true,
+	}), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	require.NoError(t, err)
+
+	return NewWithDB(gormDB).(*repository), mock
+}
+
+func TestGetSyncedHeightNotFound(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_synced_heights"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"chain_id", "height", "created_at", "updated_at"}))
+
+	_, err := repo.GetSyncedHeight("phoenix-1")
+
+	require.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSyncedHeightUnavailable(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_synced_heights"`)).
+		WillReturnError(&pq.Error{Code: "42P01", Message: "relation does not exist"})
+
+	_, err := repo.GetSyncedHeight("phoenix-1")
+
+	require.ErrorIs(t, err, ErrUnavailable)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetSyncedHeightReturnsHardError(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	expected := errors.New("database failed")
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_synced_heights"`)).
+		WillReturnError(expected)
+
+	_, err := repo.GetSyncedHeight("phoenix-1")
+
+	require.ErrorIs(t, err, expected)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetBlockTxs(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"chain_id", "height", "block_time", "txs", "created_at", "updated_at"}).
+		AddRow("phoenix-1", 10, ts, schemas.CollectorJSON(`[{"hash":"hash","sender":"sender","timestamp":"2026-05-19T01:02:03Z","logResults":[]}]`), ts, ts)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_blocks"`)).WillReturnRows(rows)
+
+	txs, blockTime, err := repo.GetBlockTxs("phoenix-1", 10)
+
+	require.NoError(t, err)
+	require.Equal(t, ts, blockTime)
+	require.Equal(t, parser.RawTxs{{Hash: "hash", Sender: "sender", Timestamp: ts, LogResults: eventlog.LogResults{}}}, txs)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetBlockTxsNotFound(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_blocks"`)).
+		WillReturnRows(sqlmock.NewRows([]string{"chain_id", "height", "block_time", "txs", "created_at", "updated_at"}))
+
+	_, _, err := repo.GetBlockTxs("phoenix-1", 10)
+
+	require.ErrorIs(t, err, ErrNotFound)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetBlockTxsMalformedJSONDoesNotMapToFallbackError(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"chain_id", "height", "block_time", "txs", "created_at", "updated_at"}).
+		AddRow("phoenix-1", 10, ts, schemas.CollectorJSON(`{bad json`), ts, ts)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_blocks"`)).WillReturnRows(rows)
+
+	_, _, err := repo.GetBlockTxs("phoenix-1", 10)
+
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrNotFound))
+	require.False(t, errors.Is(err, ErrUnavailable))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetPoolInfos(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"chain_id", "height", "pool_infos", "created_at", "updated_at"}).
+		AddRow("phoenix-1", 10, schemas.CollectorJSON(`[{"contractAddr":"pair","assets":[{"addr":"asset0","amount":"1"}],"lpAddr":"lp","totalShare":"2"}]`), ts, ts)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_pool_snapshots"`)).WillReturnRows(rows)
+
+	poolInfos, err := repo.GetPoolInfos("phoenix-1", 10)
+
+	require.NoError(t, err)
+	require.Equal(t, []dex.PoolInfo{{
+		ContractAddr: "pair",
+		Assets:       []dex.Asset{{Addr: "asset0", Amount: "1"}},
+		LpAddr:       "lp",
+		TotalShare:   "2",
+	}}, poolInfos)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetPoolInfosMalformedJSONDoesNotMapToFallbackError(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{"chain_id", "height", "pool_infos", "created_at", "updated_at"}).
+		AddRow("phoenix-1", 10, schemas.CollectorJSON(`{bad json`), ts, ts)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_pool_snapshots"`)).WillReturnRows(rows)
+
+	_, err := repo.GetPoolInfos("phoenix-1", 10)
+
+	require.Error(t, err)
+	require.False(t, errors.Is(err, ErrNotFound))
+	require.False(t, errors.Is(err, ErrUnavailable))
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestGetPoolInfosUnavailable(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_pool_snapshots"`)).
+		WillReturnError(&pq.Error{Code: "42P01", Message: "relation does not exist"})
+
+	_, err := repo.GetPoolInfos("phoenix-1", 10)
+
+	require.ErrorIs(t, err, ErrUnavailable)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSaveHeightUpsertsBlockPoolAndSyncedHeight(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+
+	mock.ExpectBegin()
+	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	expectInsert(mock, `INSERT INTO "collector_pool_snapshots"`)
+	expectInsert(mock, `INSERT INTO "collector_synced_heights"`)
+	mock.ExpectCommit()
+
+	err := repo.SaveHeight(
+		"phoenix-1",
+		10,
+		ts,
+		parser.RawTxs{{Hash: "hash", Timestamp: ts}},
+		[]dex.PoolInfo{{ContractAddr: "pair"}},
+		true,
+	)
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSaveHeightWithoutPoolSnapshotSkipsPoolUpsert(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
+
+	mock.ExpectBegin()
+	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	expectInsert(mock, `INSERT INTO "collector_synced_heights"`)
+	mock.ExpectCommit()
+
+	err := repo.SaveHeight(
+		"phoenix-1",
+		10,
+		ts,
+		parser.RawTxs{{Hash: "hash", Timestamp: ts}},
+		nil,
+		false,
+	)
+
+	require.NoError(t, err)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSaveHeightRollsBackWhenBlockUpsertFails(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	expected := errors.New("block insert failed")
+
+	mock.ExpectBegin()
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "collector_blocks"`)).
+		WillReturnError(expected)
+	mock.ExpectRollback()
+
+	err := repo.SaveHeight("phoenix-1", 10, time.Now(), parser.RawTxs{}, nil, false)
+
+	require.ErrorIs(t, err, expected)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSaveHeightRollsBackWhenPoolUpsertFails(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	expected := errors.New("pool insert failed")
+
+	mock.ExpectBegin()
+	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "collector_pool_snapshots"`)).
+		WillReturnError(expected)
+	mock.ExpectRollback()
+
+	err := repo.SaveHeight("phoenix-1", 10, time.Now(), parser.RawTxs{}, []dex.PoolInfo{}, true)
+
+	require.ErrorIs(t, err, expected)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestSaveHeightRollsBackWhenSyncedHeightUpsertFails(t *testing.T) {
+	repo, mock := newMockRepo(t)
+	expected := errors.New("synced insert failed")
+
+	mock.ExpectBegin()
+	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "collector_synced_heights"`)).
+		WillReturnError(expected)
+	mock.ExpectRollback()
+
+	err := repo.SaveHeight("phoenix-1", 10, time.Now(), parser.RawTxs{}, nil, false)
+
+	require.ErrorIs(t, err, expected)
+	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestIsUndefinedTableHandlesDriverAndSQLStateErrors(t *testing.T) {
+	require.True(t, isUndefinedTable(&pq.Error{Code: "42P01"}))
+	require.True(t, isUndefinedTable(errors.New(`relation "collector_blocks" does not exist (SQLSTATE 42P01)`)))
+	require.False(t, isUndefinedTable(errors.New("connection refused")))
+}
+
+func expectInsert(mock sqlmock.Sqlmock, sql string) {
+	mock.ExpectExec(regexp.QuoteMeta(sql)).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+}

--- a/collector/repo/repository_test.go
+++ b/collector/repo/repository_test.go
@@ -157,8 +157,8 @@ func TestSaveHeightUpsertsBlockPoolAndSyncedHeight(t *testing.T) {
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 
 	mock.ExpectBegin()
-	expectInsert(mock, `INSERT INTO "collector_blocks"`)
-	expectInsert(mock, `INSERT INTO "collector_pool_snapshots"`)
+	expectUpsert(mock, `collector_blocks`)
+	expectUpsert(mock, `collector_pool_snapshots`)
 	expectSyncedHeightInsert(mock)
 	mock.ExpectCommit()
 
@@ -180,7 +180,7 @@ func TestSaveHeightWithoutPoolSnapshotSkipsPoolUpsert(t *testing.T) {
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 
 	mock.ExpectBegin()
-	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	expectUpsert(mock, `collector_blocks`)
 	expectSyncedHeightInsert(mock)
 	mock.ExpectCommit()
 
@@ -217,7 +217,7 @@ func TestSaveHeightRollsBackWhenPoolUpsertFails(t *testing.T) {
 	expected := errors.New("pool insert failed")
 
 	mock.ExpectBegin()
-	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	expectUpsert(mock, `collector_blocks`)
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "collector_pool_snapshots"`)).
 		WillReturnError(expected)
 	mock.ExpectRollback()
@@ -233,7 +233,7 @@ func TestSaveHeightRollsBackWhenSyncedHeightUpsertFails(t *testing.T) {
 	expected := errors.New("synced insert failed")
 
 	mock.ExpectBegin()
-	expectInsert(mock, `INSERT INTO "collector_blocks"`)
+	expectUpsert(mock, `collector_blocks`)
 	mock.ExpectExec(syncedHeightInsertPattern()).
 		WillReturnError(expected)
 	mock.ExpectRollback()
@@ -255,8 +255,12 @@ func TestIsUndefinedTableRejectsUnrelatedDoesNotExistErrors(t *testing.T) {
 	require.False(t, isUndefinedTable(errors.New(`role "etl" does not exist`)))
 }
 
-func expectInsert(mock sqlmock.Sqlmock, sql string) {
-	mock.ExpectExec(regexp.QuoteMeta(sql)).
+func expectUpsert(mock sqlmock.Sqlmock, table string) {
+	mock.ExpectExec(
+		regexp.QuoteMeta(
+			`INSERT INTO "`+table+`"`) +
+			`.*` + regexp.QuoteMeta(`ON CONFLICT`),
+	).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
 

--- a/configs/collector.config.go
+++ b/configs/collector.config.go
@@ -5,11 +5,12 @@ type CollectorConfig struct {
 	PairFactoryContractAddress string     `mapstructure:"pair_factory_contract_address"`
 	NodeConfig                 NodeConfig `mapstructure:"node"`
 	FcdConfig                  FcdConfig  `mapstructure:"fcd"`
+	StartHeight                uint64     `mapstructure:"start_height"`
+	UntilHeight                uint64     `mapstructure:"until_height"`
+	PoolSnapshotInterval       uint       `mapstructure:"pool_snapshot_interval"`
 }
 
 type FcdConfig struct {
-	RdbConfig       RdbConfig `mapstructure:"rdb"`
-	Url             string    `mapstructure:"url"`
-	TargetAddresses []string  `mapstructure:"target_addresses"`
-	UntilHeight     uint      `mapstructure:"until_height"`
+	Url             string   `mapstructure:"url"`
+	TargetAddresses []string `mapstructure:"target_addresses"`
 }

--- a/configs/collector.config.go
+++ b/configs/collector.config.go
@@ -14,3 +14,20 @@ type FcdConfig struct {
 	Url             string   `mapstructure:"url"`
 	TargetAddresses []string `mapstructure:"target_addresses"`
 }
+
+// NodeConfigWithFallback resolves node settings for collectors migrating from
+// parser-owned node configuration while preserving collector endpoint overrides.
+func (c CollectorConfig) NodeConfigWithFallback(fallback NodeConfig) NodeConfig {
+	if c.NodeConfig.RestClientConfig.RpcHost == "" && c.NodeConfig.RestClientConfig.LcdHost == "" {
+		return fallback
+	}
+
+	nodeConfig := c.NodeConfig
+	if nodeConfig.RestClientConfig.RpcHost == "" {
+		nodeConfig.RestClientConfig.RpcHost = fallback.RestClientConfig.RpcHost
+	}
+	if nodeConfig.RestClientConfig.LcdHost == "" {
+		nodeConfig.RestClientConfig.LcdHost = fallback.RestClientConfig.LcdHost
+	}
+	return nodeConfig
+}

--- a/configs/collector.config_test.go
+++ b/configs/collector.config_test.go
@@ -1,0 +1,58 @@
+package configs
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectorNodeConfigWithFallbackKeepsCollectorEndpointsWhenConfigured(t *testing.T) {
+	collectorConfig := CollectorConfig{NodeConfig: testCollectorNodeConfig("collector-rpc", "collector-lcd", time.Second)}
+	fallback := testCollectorNodeConfig("parser-rpc", "parser-lcd", 2*time.Second)
+
+	actual := collectorConfig.NodeConfigWithFallback(fallback)
+
+	require.Equal(t, collectorConfig.NodeConfig, actual)
+}
+
+func TestCollectorNodeConfigWithFallbackUsesEntireFallbackWhenCollectorEndpointsAreEmpty(t *testing.T) {
+	collectorConfig := CollectorConfig{NodeConfig: testCollectorNodeConfig("", "", time.Second)}
+	fallback := testCollectorNodeConfig("parser-rpc", "parser-lcd", 2*time.Second)
+
+	actual := collectorConfig.NodeConfigWithFallback(fallback)
+
+	require.Equal(t, fallback, actual)
+}
+
+func TestCollectorNodeConfigWithFallbackFillsMissingCollectorRPCEndpoint(t *testing.T) {
+	collectorConfig := CollectorConfig{NodeConfig: testCollectorNodeConfig("", "collector-lcd", time.Second)}
+	fallback := testCollectorNodeConfig("parser-rpc", "parser-lcd", 2*time.Second)
+
+	actual := collectorConfig.NodeConfigWithFallback(fallback)
+
+	require.Equal(t, "parser-rpc", actual.RestClientConfig.RpcHost)
+	require.Equal(t, "collector-lcd", actual.RestClientConfig.LcdHost)
+	require.Equal(t, collectorConfig.NodeConfig.HttpClientConfig, actual.HttpClientConfig)
+}
+
+func TestCollectorNodeConfigWithFallbackFillsMissingCollectorLCDEndpoint(t *testing.T) {
+	collectorConfig := CollectorConfig{NodeConfig: testCollectorNodeConfig("collector-rpc", "", time.Second)}
+	fallback := testCollectorNodeConfig("parser-rpc", "parser-lcd", 2*time.Second)
+
+	actual := collectorConfig.NodeConfigWithFallback(fallback)
+
+	require.Equal(t, "collector-rpc", actual.RestClientConfig.RpcHost)
+	require.Equal(t, "parser-lcd", actual.RestClientConfig.LcdHost)
+	require.Equal(t, collectorConfig.NodeConfig.HttpClientConfig, actual.HttpClientConfig)
+}
+
+func testCollectorNodeConfig(rpcHost string, lcdHost string, timeout time.Duration) NodeConfig {
+	return NodeConfig{
+		RestClientConfig: RestClientConfig{RpcHost: rpcHost, LcdHost: lcdHost},
+		HttpClientConfig: HttpClientConfig{
+			Timeout:         &Duration{Duration: timeout},
+			IdleConnTimeout: &Duration{Duration: timeout},
+		},
+	}
+}

--- a/configs/config.go
+++ b/configs/config.go
@@ -123,7 +123,6 @@ func (c Config) Redacted() Config {
 	cp := c
 
 	// Collector
-	cp.Collector.FcdConfig.RdbConfig.Password = "***"
 	cp.S3.Secret = "***"
 
 	// Parser

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -152,14 +152,12 @@ func Test_CollectorConfig_EnvVars(t *testing.T) {
 	t.Setenv("APP_COLLECTOR_NODE_GRPC_HOST", "grpc.example.com")
 	t.Setenv("APP_COLLECTOR_NODE_GRPC_PORT", "9090")
 	t.Setenv("APP_COLLECTOR_NODE_FAILOVER_LCD_HOST", "lcd-failover.example.com")
-	t.Setenv("APP_COLLECTOR_FCD_RDB_HOST", "fcd-host")
-	t.Setenv("APP_COLLECTOR_FCD_RDB_PORT", "5432")
-	t.Setenv("APP_COLLECTOR_FCD_RDB_USERNAME", "fcduser")
-	t.Setenv("APP_COLLECTOR_FCD_RDB_PASSWORD", "fcdpass")
-	t.Setenv("APP_COLLECTOR_FCD_RDB_DATABASE", "fcddb")
-	t.Setenv("APP_COLLECTOR_FCD_RDB_SSLMODE", "require")
+	t.Setenv("APP_COLLECTOR_NODE_REST_LCD", "https://lcd.example.com")
+	t.Setenv("APP_COLLECTOR_NODE_REST_RPC", "https://rpc.example.com")
 	t.Setenv("APP_COLLECTOR_FCD_URL", "https://fcd.example.com")
-	t.Setenv("APP_COLLECTOR_FCD_UNTIL_HEIGHT", "1000")
+	t.Setenv("APP_COLLECTOR_START_HEIGHT", "123")
+	t.Setenv("APP_COLLECTOR_UNTIL_HEIGHT", "1000")
+	t.Setenv("APP_COLLECTOR_POOL_SNAPSHOT_INTERVAL", "50")
 
 	tmp := t.TempDir()
 	defer withTestBasepath(t, tmp)()
@@ -171,14 +169,12 @@ func Test_CollectorConfig_EnvVars(t *testing.T) {
 	require.Equal(t, "grpc.example.com", col.NodeConfig.GrpcConfig.Host)
 	require.Equal(t, 9090, col.NodeConfig.GrpcConfig.Port)
 	require.Equal(t, "lcd-failover.example.com", col.NodeConfig.FailoverLcdHost)
-	require.Equal(t, "fcd-host", col.FcdConfig.RdbConfig.Host)
-	require.Equal(t, 5432, col.FcdConfig.RdbConfig.Port)
-	require.Equal(t, "fcduser", col.FcdConfig.RdbConfig.Username)
-	require.Equal(t, "fcdpass", col.FcdConfig.RdbConfig.Password)
-	require.Equal(t, "fcddb", col.FcdConfig.RdbConfig.Database)
-	require.Equal(t, "require", col.FcdConfig.RdbConfig.SslMode)
+	require.Equal(t, "https://lcd.example.com", col.NodeConfig.RestClientConfig.LcdHost)
+	require.Equal(t, "https://rpc.example.com", col.NodeConfig.RestClientConfig.RpcHost)
 	require.Equal(t, "https://fcd.example.com", col.FcdConfig.Url)
-	require.Equal(t, uint(1000), col.FcdConfig.UntilHeight)
+	require.Equal(t, uint64(123), col.StartHeight)
+	require.Equal(t, uint64(1000), col.UntilHeight)
+	require.Equal(t, uint(50), col.PoolSnapshotInterval)
 }
 
 func Test_ParserConfig_EnvVars(t *testing.T) {
@@ -290,13 +286,6 @@ func TestConfig_Redacted(t *testing.T) {
 	expected := "***"
 
 	cfg := Config{
-		Collector: CollectorConfig{
-			FcdConfig: FcdConfig{
-				RdbConfig: RdbConfig{
-					Password: "original-collector-pw",
-				},
-			},
-		},
 		S3: S3Config{
 			Secret: "original-s3-secret",
 		},
@@ -316,14 +305,12 @@ func TestConfig_Redacted(t *testing.T) {
 	redacted := cfg.Redacted()
 
 	// all sensitive fields must be redacted
-	require.Equal(t, expected, redacted.Collector.FcdConfig.RdbConfig.Password)
 	require.Equal(t, expected, redacted.S3.Secret)
 	require.Equal(t, expected, redacted.Rdb.Password)
 	require.Equal(t, expected, redacted.Aggregator.SrcDb.Password)
 	require.Equal(t, expected, redacted.Aggregator.DestDb.Password)
 
 	// ensure original config is not modified
-	require.Equal(t, "original-collector-pw", cfg.Collector.FcdConfig.RdbConfig.Password)
 	require.Equal(t, "original-s3-secret", cfg.S3.Secret)
 	require.Equal(t, "original-parser-pw", cfg.Rdb.Password)
 	require.Equal(t, "src-db-password", cfg.Aggregator.SrcDb.Password)

--- a/db/migrations/collector/20260519120000_collector_source_tables.down.sql
+++ b/db/migrations/collector/20260519120000_collector_source_tables.down.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+DROP TABLE IF EXISTS "collector_synced_heights";
+DROP TABLE IF EXISTS "collector_pool_snapshots";
+DROP TABLE IF EXISTS "collector_blocks";
+
+COMMIT;

--- a/db/migrations/collector/20260519120000_collector_source_tables.up.sql
+++ b/db/migrations/collector/20260519120000_collector_source_tables.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE TABLE "public"."collector_blocks" (
+CREATE TABLE IF NOT EXISTS "public"."collector_blocks" (
     "chain_id" varchar NOT NULL,
     "height" int8 NOT NULL,
     "block_time" timestamp NOT NULL,
@@ -10,7 +10,7 @@ CREATE TABLE "public"."collector_blocks" (
     PRIMARY KEY ("chain_id", "height")
 );
 
-CREATE TABLE "public"."collector_pool_snapshots" (
+CREATE TABLE IF NOT EXISTS "public"."collector_pool_snapshots" (
     "chain_id" varchar NOT NULL,
     "height" int8 NOT NULL,
     "pool_infos" jsonb NOT NULL,
@@ -19,14 +19,14 @@ CREATE TABLE "public"."collector_pool_snapshots" (
     PRIMARY KEY ("chain_id", "height")
 );
 
-CREATE TABLE "public"."collector_synced_heights" (
+CREATE TABLE IF NOT EXISTS "public"."collector_synced_heights" (
     "chain_id" varchar NOT NULL PRIMARY KEY,
     "height" int8 NOT NULL,
     "created_at" timestamp NOT NULL DEFAULT now(),
     "updated_at" timestamp NOT NULL DEFAULT now()
 );
 
-CREATE INDEX collector_blocks_height_idx ON collector_blocks(height);
-CREATE INDEX collector_pool_snapshots_height_idx ON collector_pool_snapshots(height);
+CREATE INDEX IF NOT EXISTS collector_blocks_height_idx ON collector_blocks(height);
+CREATE INDEX IF NOT EXISTS collector_pool_snapshots_height_idx ON collector_pool_snapshots(height);
 
 COMMIT;

--- a/db/migrations/collector/20260519120000_collector_source_tables.up.sql
+++ b/db/migrations/collector/20260519120000_collector_source_tables.up.sql
@@ -1,0 +1,32 @@
+BEGIN;
+
+CREATE TABLE "public"."collector_blocks" (
+    "chain_id" varchar NOT NULL,
+    "height" int8 NOT NULL,
+    "block_time" timestamp NOT NULL,
+    "txs" jsonb NOT NULL,
+    "created_at" timestamp NOT NULL DEFAULT now(),
+    "updated_at" timestamp NOT NULL DEFAULT now(),
+    PRIMARY KEY ("chain_id", "height")
+);
+
+CREATE TABLE "public"."collector_pool_snapshots" (
+    "chain_id" varchar NOT NULL,
+    "height" int8 NOT NULL,
+    "pool_infos" jsonb NOT NULL,
+    "created_at" timestamp NOT NULL DEFAULT now(),
+    "updated_at" timestamp NOT NULL DEFAULT now(),
+    PRIMARY KEY ("chain_id", "height")
+);
+
+CREATE TABLE "public"."collector_synced_heights" (
+    "chain_id" varchar NOT NULL PRIMARY KEY,
+    "height" int8 NOT NULL,
+    "created_at" timestamp NOT NULL DEFAULT now(),
+    "updated_at" timestamp NOT NULL DEFAULT now()
+);
+
+CREATE INDEX collector_blocks_height_idx ON collector_blocks(height);
+CREATE INDEX collector_pool_snapshots_height_idx ON collector_pool_snapshots(height);
+
+COMMIT;

--- a/parser/dex/srcstore/collector_datastore.go
+++ b/parser/dex/srcstore/collector_datastore.go
@@ -1,0 +1,84 @@
+package srcstore
+
+import (
+	"errors"
+	"sync"
+
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+)
+
+type collectorFallbackStore struct {
+	chainID  string
+	repo     collectorrepo.Repository
+	fallback dex.SourceDataStore
+	logger   logging.Logger
+
+	logUnavailableOnce sync.Once
+}
+
+var _ dex.SourceDataStore = (*collectorFallbackStore)(nil)
+
+// NewCollectorFallback reads parser source data from collector DB first and
+// delegates to fallback when collector data is not available yet. Corrupt data
+// or real DB failures are returned as errors so they are not hidden by fallback.
+func NewCollectorFallback(chainID string, repo collectorrepo.Repository, fallback dex.SourceDataStore, logger logging.Logger) dex.SourceDataStore {
+	return &collectorFallbackStore{
+		chainID:  chainID,
+		repo:     repo,
+		fallback: fallback,
+		logger:   logger,
+	}
+}
+
+func (s *collectorFallbackStore) GetSourceSyncedHeight() (uint64, error) {
+	height, err := s.repo.GetSyncedHeight(s.chainID)
+	if err == nil {
+		return height, nil
+	}
+	if shouldFallbackCollector(err) {
+		s.logCollectorFallback("synced height", err)
+		return s.fallback.GetSourceSyncedHeight()
+	}
+	return 0, err
+}
+
+func (s *collectorFallbackStore) GetSourceTxs(height uint64) (parser.RawTxs, error) {
+	txs, _, err := s.repo.GetBlockTxs(s.chainID, height)
+	if err == nil {
+		return txs, nil
+	}
+	if shouldFallbackCollector(err) {
+		s.logCollectorFallback("block txs", err)
+		return s.fallback.GetSourceTxs(height)
+	}
+	return nil, err
+}
+
+func (s *collectorFallbackStore) GetPoolInfos(height uint64) ([]dex.PoolInfo, error) {
+	poolInfos, err := s.repo.GetPoolInfos(s.chainID, height)
+	if err == nil {
+		return poolInfos, nil
+	}
+	if shouldFallbackCollector(err) {
+		s.logCollectorFallback("pool snapshot", err)
+		return s.fallback.GetPoolInfos(height)
+	}
+	return nil, err
+}
+
+func shouldFallbackCollector(err error) bool {
+	return errors.Is(err, collectorrepo.ErrNotFound) || errors.Is(err, collectorrepo.ErrUnavailable)
+}
+
+func (s *collectorFallbackStore) logCollectorFallback(target string, err error) {
+	if errors.Is(err, collectorrepo.ErrUnavailable) {
+		s.logUnavailableOnce.Do(func() {
+			s.logger.Warnf("collector source tables are unavailable; using source fallback")
+		})
+		return
+	}
+	s.logger.Debugf("collector %s not found; using source fallback", target)
+}

--- a/parser/dex/srcstore/collector_datastore_test.go
+++ b/parser/dex/srcstore/collector_datastore_test.go
@@ -1,0 +1,180 @@
+package srcstore
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeCollectorRepo struct {
+	height      uint64
+	heightErr   error
+	txs         parser.RawTxs
+	txsErr      error
+	poolInfos   []dex.PoolInfo
+	poolInfoErr error
+}
+
+func (f *fakeCollectorRepo) GetSyncedHeight(string) (uint64, error) {
+	return f.height, f.heightErr
+}
+
+func (f *fakeCollectorRepo) GetBlockTxs(string, uint64) (parser.RawTxs, time.Time, error) {
+	return f.txs, time.Time{}, f.txsErr
+}
+
+func (f *fakeCollectorRepo) GetPoolInfos(string, uint64) ([]dex.PoolInfo, error) {
+	return f.poolInfos, f.poolInfoErr
+}
+
+func (f *fakeCollectorRepo) SaveHeight(string, uint64, time.Time, parser.RawTxs, []dex.PoolInfo, bool) error {
+	return nil
+}
+
+type fakeCollectorFallback struct {
+	height    uint64
+	txs       parser.RawTxs
+	poolInfos []dex.PoolInfo
+	called    bool
+}
+
+func (f *fakeCollectorFallback) GetSourceSyncedHeight() (uint64, error) {
+	f.called = true
+	return f.height, nil
+}
+
+func (f *fakeCollectorFallback) GetSourceTxs(uint64) (parser.RawTxs, error) {
+	f.called = true
+	return f.txs, nil
+}
+
+func (f *fakeCollectorFallback) GetPoolInfos(uint64) ([]dex.PoolInfo, error) {
+	f.called = true
+	return f.poolInfos, nil
+}
+
+func TestCollectorFallbackStore_GetSourceTxsUsesCollectorDB(t *testing.T) {
+	repo := &fakeCollectorRepo{txs: parser.RawTxs{{Hash: "db"}}}
+	fallback := &fakeCollectorFallback{txs: parser.RawTxs{{Hash: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetSourceTxs(10)
+
+	require.NoError(t, err)
+	require.Equal(t, parser.RawTxs{{Hash: "db"}}, actual)
+	require.False(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetSourceSyncedHeightUsesCollectorDB(t *testing.T) {
+	repo := &fakeCollectorRepo{height: 15}
+	fallback := &fakeCollectorFallback{height: 99}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetSourceSyncedHeight()
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(15), actual)
+	require.False(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetSourceSyncedHeightFallbackOnUnavailableCollectorTables(t *testing.T) {
+	repo := &fakeCollectorRepo{heightErr: collectorrepo.ErrUnavailable}
+	fallback := &fakeCollectorFallback{height: 99}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetSourceSyncedHeight()
+
+	require.NoError(t, err)
+	require.Equal(t, uint64(99), actual)
+	require.True(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetSourceSyncedHeightDoesNotFallbackOnHardError(t *testing.T) {
+	hardErr := errors.New("db failed")
+	repo := &fakeCollectorRepo{heightErr: hardErr}
+	fallback := &fakeCollectorFallback{height: 99}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	_, err := store.GetSourceSyncedHeight()
+
+	require.ErrorIs(t, err, hardErr)
+	require.False(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetSourceTxsFallbackOnMissingCollectorData(t *testing.T) {
+	repo := &fakeCollectorRepo{txsErr: collectorrepo.ErrNotFound}
+	fallback := &fakeCollectorFallback{txs: parser.RawTxs{{Hash: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetSourceTxs(10)
+
+	require.NoError(t, err)
+	require.Equal(t, fallback.txs, actual)
+	require.True(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetSourceTxsDoesNotFallbackOnHardError(t *testing.T) {
+	hardErr := errors.New("bad json")
+	repo := &fakeCollectorRepo{txsErr: hardErr}
+	fallback := &fakeCollectorFallback{txs: parser.RawTxs{{Hash: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	_, err := store.GetSourceTxs(10)
+
+	require.ErrorIs(t, err, hardErr)
+	require.False(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetPoolInfosFallbackOnUnavailableCollectorTables(t *testing.T) {
+	repo := &fakeCollectorRepo{poolInfoErr: collectorrepo.ErrUnavailable}
+	fallback := &fakeCollectorFallback{poolInfos: []dex.PoolInfo{{ContractAddr: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetPoolInfos(10)
+
+	require.NoError(t, err)
+	require.Equal(t, fallback.poolInfos, actual)
+	require.True(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetPoolInfosUsesCollectorDB(t *testing.T) {
+	repo := &fakeCollectorRepo{poolInfos: []dex.PoolInfo{{ContractAddr: "db"}}}
+	fallback := &fakeCollectorFallback{poolInfos: []dex.PoolInfo{{ContractAddr: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetPoolInfos(10)
+
+	require.NoError(t, err)
+	require.Equal(t, repo.poolInfos, actual)
+	require.False(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetPoolInfosFallbackOnMissingCollectorData(t *testing.T) {
+	repo := &fakeCollectorRepo{poolInfoErr: collectorrepo.ErrNotFound}
+	fallback := &fakeCollectorFallback{poolInfos: []dex.PoolInfo{{ContractAddr: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	actual, err := store.GetPoolInfos(10)
+
+	require.NoError(t, err)
+	require.Equal(t, fallback.poolInfos, actual)
+	require.True(t, fallback.called)
+}
+
+func TestCollectorFallbackStore_GetPoolInfosDoesNotFallbackOnHardError(t *testing.T) {
+	hardErr := errors.New("bad json")
+	repo := &fakeCollectorRepo{poolInfoErr: hardErr}
+	fallback := &fakeCollectorFallback{poolInfos: []dex.PoolInfo{{ContractAddr: "fallback"}}}
+	store := NewCollectorFallback("chain", repo, fallback, logging.Discard)
+
+	_, err := store.GetPoolInfos(10)
+
+	require.ErrorIs(t, err, hardErr)
+	require.False(t, fallback.called)
+}

--- a/parser/dex/srcstore/terraswap/factory.go
+++ b/parser/dex/srcstore/terraswap/factory.go
@@ -1,0 +1,41 @@
+package terraswap
+
+import (
+	"fmt"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+	pdex "github.com/dezswap/cosmwasm-etl/parser/dex"
+	dts "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap"
+	dts_colv1 "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/columbusv1"
+	dts_colv2 "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/columbusv2"
+	dts_phoenix "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap/phoenix"
+	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
+	"github.com/dezswap/cosmwasm-etl/pkg/terra/col4"
+	terra_cosmos45 "github.com/dezswap/cosmwasm-etl/pkg/terra/cosmos45"
+	"github.com/dezswap/cosmwasm-etl/pkg/terra/rpc"
+	"github.com/pkg/errors"
+)
+
+func NewFromConfig(c configs.NodeConfig, factoryAddress string) (pdex.SourceDataStore, error) {
+	httpClient := httpclient.New(c.HttpClientConfig)
+	r := rpc.New(c.RestClientConfig.RpcHost, httpClient)
+
+	switch dts.TerraswapFactory(factoryAddress) {
+	case dts.MAINNET_FACTORY:
+		lcd := terra_cosmos45.NewLcd(c.RestClientConfig.LcdHost, httpClient)
+		terraswapQueryClient := dts_phoenix.NewPhoenixClient(lcd)
+		return NewPhoenixStore(factoryAddress, r, lcd, terraswapQueryClient), nil
+	case dts.CLASSIC_V2_FACTORY:
+		lcd := terra_cosmos45.NewLcd(c.RestClientConfig.LcdHost, httpClient)
+		terraswapQueryClient := dts_colv2.NewColumbusV2Client(lcd)
+		return NewCol5Store(factoryAddress, r, lcd, terraswapQueryClient), nil
+	case dts.PISCO_FACTORY:
+		return nil, errors.New("not implemented yet")
+	case dts.CLASSIC_V1_FACTORY:
+		lcd := col4.NewLcd(c.RestClientConfig.LcdHost, httpClient)
+		terraswapQueryClient := dts_colv1.NewCol4Client(lcd)
+		return NewCol4Store(factoryAddress, r, lcd, terraswapQueryClient), nil
+	default:
+		return nil, fmt.Errorf("invalid factory address: %s", factoryAddress)
+	}
+}

--- a/parser/dex/srcstore/terraswap/factory_test.go
+++ b/parser/dex/srcstore/terraswap/factory_test.go
@@ -1,0 +1,74 @@
+package terraswap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+	dts "github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewFromConfigCreatesSupportedStores(t *testing.T) {
+	tests := []struct {
+		name    string
+		factory dts.TerraswapFactory
+		assert  func(*testing.T, interface{})
+	}{
+		{
+			name:    "phoenix",
+			factory: dts.MAINNET_FACTORY,
+			assert: func(t *testing.T, store interface{}) {
+				require.IsType(t, &phoenixSourceDataStore{}, store)
+			},
+		},
+		{
+			name:    "columbus v2",
+			factory: dts.CLASSIC_V2_FACTORY,
+			assert: func(t *testing.T, store interface{}) {
+				require.IsType(t, &baseRawDataStoreImpl{}, store)
+			},
+		},
+		{
+			name:    "columbus v1",
+			factory: dts.CLASSIC_V1_FACTORY,
+			assert: func(t *testing.T, store interface{}) {
+				require.IsType(t, &baseRawDataStoreImpl{}, store)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			store, err := NewFromConfig(factoryNodeConfig(), string(tc.factory))
+
+			require.NoError(t, err)
+			tc.assert(t, store)
+		})
+	}
+}
+
+func TestNewFromConfigRejectsUnsupportedFactory(t *testing.T) {
+	_, err := NewFromConfig(factoryNodeConfig(), string(dts.PISCO_FACTORY))
+
+	require.EqualError(t, err, "not implemented yet")
+}
+
+func TestNewFromConfigRejectsUnknownFactory(t *testing.T) {
+	_, err := NewFromConfig(factoryNodeConfig(), "terra1unknown")
+
+	require.EqualError(t, err, "invalid factory address: terra1unknown")
+}
+
+func factoryNodeConfig() configs.NodeConfig {
+	return configs.NodeConfig{
+		HttpClientConfig: configs.HttpClientConfig{
+			Timeout:         &configs.Duration{Duration: time.Second},
+			IdleConnTimeout: &configs.Duration{Duration: time.Second},
+		},
+		RestClientConfig: configs.RestClientConfig{
+			RpcHost: "http://rpc",
+			LcdHost: "http://lcd",
+		},
+	}
+}

--- a/pkg/db/schemas/collector.models.go
+++ b/pkg/db/schemas/collector.models.go
@@ -16,3 +16,29 @@ type FcdTxLog struct {
 func (c FcdTxLog) TableName() string {
 	return "fcd_tx_log"
 }
+
+type CollectorJSON []byte
+
+type CollectorBlock struct {
+	ChainId   string        `json:"chainId"`
+	Height    uint64        `json:"height"`
+	BlockTime time.Time     `json:"blockTime"`
+	Txs       CollectorJSON `json:"txs" gorm:"type:jsonb"`
+	CreatedAt time.Time     `json:"createdAt"`
+	UpdatedAt time.Time     `json:"updatedAt"`
+}
+
+type CollectorPoolSnapshot struct {
+	ChainId   string        `json:"chainId"`
+	Height    uint64        `json:"height"`
+	PoolInfos CollectorJSON `json:"poolInfos" gorm:"type:jsonb"`
+	CreatedAt time.Time     `json:"createdAt"`
+	UpdatedAt time.Time     `json:"updatedAt"`
+}
+
+type CollectorSyncedHeight struct {
+	ChainId   string    `json:"chainId"`
+	Height    uint64    `json:"height"`
+	CreatedAt time.Time `json:"createdAt"`
+	UpdatedAt time.Time `json:"updatedAt"`
+}

--- a/pkg/db/schemas/collector.models.gorm.go
+++ b/pkg/db/schemas/collector.models.gorm.go
@@ -1,0 +1,40 @@
+package schemas
+
+import (
+	"database/sql/driver"
+	"errors"
+	"fmt"
+)
+
+func (CollectorBlock) TableName() string {
+	return "collector_blocks"
+}
+
+func (CollectorPoolSnapshot) TableName() string {
+	return "collector_pool_snapshots"
+}
+
+func (CollectorSyncedHeight) TableName() string {
+	return "collector_synced_heights"
+}
+
+func (CollectorJSON) GormDataType() string {
+	return "json"
+}
+
+func (j *CollectorJSON) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("failed to unmarshal JSONB value:", value))
+	}
+
+	*j = append((*j)[0:0], bytes...)
+	return nil
+}
+
+func (j CollectorJSON) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return []byte("null"), nil
+	}
+	return []byte(j), nil
+}

--- a/pkg/db/schemas/collector.models_test.go
+++ b/pkg/db/schemas/collector.models_test.go
@@ -1,0 +1,46 @@
+package schemas
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCollectorTableNames(t *testing.T) {
+	require.Equal(t, "collector_blocks", CollectorBlock{}.TableName())
+	require.Equal(t, "collector_pool_snapshots", CollectorPoolSnapshot{}.TableName())
+	require.Equal(t, "collector_synced_heights", CollectorSyncedHeight{}.TableName())
+}
+
+func TestCollectorJSONGormDataType(t *testing.T) {
+	require.Equal(t, "json", CollectorJSON{}.GormDataType())
+}
+
+func TestCollectorJSONScanCopiesBytePayload(t *testing.T) {
+	payload := []byte(`{"height":10}`)
+	var target CollectorJSON
+
+	err := target.Scan(payload)
+	payload[0] = '['
+
+	require.NoError(t, err)
+	require.Equal(t, CollectorJSON(`{"height":10}`), target)
+}
+
+func TestCollectorJSONScanRejectsUnexpectedValueType(t *testing.T) {
+	var target CollectorJSON
+
+	err := target.Scan(`{"height":10}`)
+
+	require.ErrorContains(t, err, "failed to unmarshal JSONB value")
+}
+
+func TestCollectorJSONValueSerializesEmptyAndNonEmptyPayloads(t *testing.T) {
+	empty, err := CollectorJSON(nil).Value()
+	require.NoError(t, err)
+	require.Equal(t, []byte("null"), empty)
+
+	payload, err := CollectorJSON(`{"height":10}`).Value()
+	require.NoError(t, err)
+	require.Equal(t, []byte(`{"height":10}`), payload)
+}

--- a/pkg/httpclient/httpclient.go
+++ b/pkg/httpclient/httpclient.go
@@ -1,0 +1,31 @@
+package httpclient
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+)
+
+func New(c configs.HttpClientConfig) *http.Client {
+	var timeout time.Duration
+	if c.Timeout != nil {
+		timeout = c.Timeout.Duration
+	}
+
+	var idleConnTimeout time.Duration
+	if c.IdleConnTimeout != nil {
+		idleConnTimeout = c.IdleConnTimeout.Duration
+	}
+
+	return &http.Client{
+		Timeout: timeout,
+		Transport: &http.Transport{
+			MaxIdleConns:        c.MaxIdleConns,
+			MaxIdleConnsPerHost: c.MaxIdleConnsPerHost,
+			IdleConnTimeout:     idleConnTimeout,
+			DisableKeepAlives:   c.DisableKeepAlives,
+			ForceAttemptHTTP2:   c.ForceAttemptHTTP2,
+		},
+	}
+}

--- a/pkg/httpclient/httpclient_test.go
+++ b/pkg/httpclient/httpclient_test.go
@@ -1,0 +1,39 @@
+package httpclient
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewAppliesHTTPClientConfiguration(t *testing.T) {
+	client := New(configs.HttpClientConfig{
+		MaxIdleConns:        20,
+		MaxIdleConnsPerHost: 5,
+		IdleConnTimeout:     &configs.Duration{Duration: 30 * time.Second},
+		DisableKeepAlives:   true,
+		ForceAttemptHTTP2:   true,
+		Timeout:             &configs.Duration{Duration: 5 * time.Second},
+	})
+
+	require.Equal(t, 5*time.Second, client.Timeout)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Equal(t, 20, transport.MaxIdleConns)
+	require.Equal(t, 5, transport.MaxIdleConnsPerHost)
+	require.Equal(t, 30*time.Second, transport.IdleConnTimeout)
+	require.True(t, transport.DisableKeepAlives)
+	require.True(t, transport.ForceAttemptHTTP2)
+}
+
+func TestNewAllowsOmittedDurations(t *testing.T) {
+	client := New(configs.HttpClientConfig{})
+
+	require.Zero(t, client.Timeout)
+	transport, ok := client.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.Zero(t, transport.IdleConnTimeout)
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The collector code path had become stale, and the parser still needed to fetch block data directly from RPC/LCD even when the collector had already collected the same source data.

This refactoring introduces a shared collector-backed source flow so the collector can persist parser-ready per-height data into PostgreSQL, while the parser can prefer that stored data and keep the existing RPC/LCD behavior as a fallback.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Refactor collector/parser source handling for Terraswap first.
- Add collector-owned PostgreSQL tables for collected blocks, pool snapshots, and synced heights.
- Add collector repository methods for saving and reading per-height parser source data.
- Add parser-side collector fallback source that reads collector DB first and falls back to RPC/LCD when collector data is unavailable.
- Extract Terraswap source construction into a reusable factory.
- Update collector config and config tests to match the current collector shape.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable collector start height, end height, and pool snapshot intervals via `CollectorConfig`.
  * Introduced collector data persistence via new database repository with fallback source support.

* **Database**
  * Added new database schema for storing collector state: `collector_blocks`, `collector_pool_snapshots`, and `collector_synced_heights` tables.

* **Configuration**
  * Simplified collector configuration by consolidating database settings; removed FCD-specific database config in favor of shared top-level settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/124?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->