### PR TITLE
fix: use int64 for ts in persistence

### DIFF
--- a/collector/repo/repository.go
+++ b/collector/repo/repository.go
@@ -106,14 +106,11 @@ func (r *repository) SaveHeight(chainID string, height uint64, blockTime time.Ti
 	}
 
 	return r.db.Transaction(func(tx *gorm.DB) error {
-		now := time.Now().UTC()
 		block := schemas.CollectorBlock{
 			ChainId:   chainID,
 			Height:    height,
 			BlockTime: blockTime.UTC(),
 			Txs:       schemas.CollectorJSON(txBytes),
-			CreatedAt: now,
-			UpdatedAt: now,
 		}
 		if err := upsert(tx, block, []string{"chain_id", "height"}, []string{"block_time", "txs", "updated_at"}); err != nil {
 			return pkgerrors.Wrap(err, "collector repo save block")
@@ -124,8 +121,6 @@ func (r *repository) SaveHeight(chainID string, height uint64, blockTime time.Ti
 				ChainId:   chainID,
 				Height:    height,
 				PoolInfos: schemas.CollectorJSON(poolBytes),
-				CreatedAt: now,
-				UpdatedAt: now,
 			}
 			if err := upsert(tx, pool, []string{"chain_id", "height"}, []string{"pool_infos", "updated_at"}); err != nil {
 				return pkgerrors.Wrap(err, "collector repo save pool snapshot")
@@ -133,16 +128,14 @@ func (r *repository) SaveHeight(chainID string, height uint64, blockTime time.Ti
 		}
 
 		synced := schemas.CollectorSyncedHeight{
-			ChainId:   chainID,
-			Height:    height,
-			CreatedAt: now,
-			UpdatedAt: now,
+			ChainId: chainID,
+			Height:  height,
 		}
 		if err := tx.Clauses(clause.OnConflict{
 			Columns: []clause.Column{{Name: "chain_id"}},
 			DoUpdates: clause.Assignments(map[string]interface{}{
 				"height":     gorm.Expr("GREATEST(collector_synced_heights.height, EXCLUDED.height)"),
-				"updated_at": now,
+				"updated_at": gorm.Expr("EXCLUDED.updated_at"),
 			}),
 		}).Create(&synced).Error; err != nil {
 			return pkgerrors.Wrap(err, "collector repo save synced height")

--- a/collector/repo/repository_test.go
+++ b/collector/repo/repository_test.go
@@ -70,7 +70,7 @@ func TestGetBlockTxs(t *testing.T) {
 	repo, mock := newMockRepo(t)
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 	rows := sqlmock.NewRows([]string{"chain_id", "height", "block_time", "txs", "created_at", "updated_at"}).
-		AddRow("phoenix-1", 10, ts, schemas.CollectorJSON(`[{"hash":"hash","sender":"sender","timestamp":"2026-05-19T01:02:03Z","logResults":[]}]`), ts, ts)
+		AddRow("phoenix-1", 10, ts, schemas.CollectorJSON(`[{"hash":"hash","sender":"sender","timestamp":"2026-05-19T01:02:03Z","logResults":[]}]`), ts.Unix(), ts.Unix())
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_blocks"`)).WillReturnRows(rows)
 
 	txs, blockTime, err := repo.GetBlockTxs("phoenix-1", 10)
@@ -96,7 +96,7 @@ func TestGetBlockTxsMalformedJSONDoesNotMapToFallbackError(t *testing.T) {
 	repo, mock := newMockRepo(t)
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 	rows := sqlmock.NewRows([]string{"chain_id", "height", "block_time", "txs", "created_at", "updated_at"}).
-		AddRow("phoenix-1", 10, ts, schemas.CollectorJSON(`{bad json`), ts, ts)
+		AddRow("phoenix-1", 10, ts, schemas.CollectorJSON(`{bad json`), ts.Unix(), ts.Unix())
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_blocks"`)).WillReturnRows(rows)
 
 	_, _, err := repo.GetBlockTxs("phoenix-1", 10)
@@ -111,7 +111,7 @@ func TestGetPoolInfos(t *testing.T) {
 	repo, mock := newMockRepo(t)
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 	rows := sqlmock.NewRows([]string{"chain_id", "height", "pool_infos", "created_at", "updated_at"}).
-		AddRow("phoenix-1", 10, schemas.CollectorJSON(`[{"contractAddr":"pair","assets":[{"addr":"asset0","amount":"1"}],"lpAddr":"lp","totalShare":"2"}]`), ts, ts)
+		AddRow("phoenix-1", 10, schemas.CollectorJSON(`[{"contractAddr":"pair","assets":[{"addr":"asset0","amount":"1"}],"lpAddr":"lp","totalShare":"2"}]`), ts.Unix(), ts.Unix())
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_pool_snapshots"`)).WillReturnRows(rows)
 
 	poolInfos, err := repo.GetPoolInfos("phoenix-1", 10)
@@ -130,7 +130,7 @@ func TestGetPoolInfosMalformedJSONDoesNotMapToFallbackError(t *testing.T) {
 	repo, mock := newMockRepo(t)
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 	rows := sqlmock.NewRows([]string{"chain_id", "height", "pool_infos", "created_at", "updated_at"}).
-		AddRow("phoenix-1", 10, schemas.CollectorJSON(`{bad json`), ts, ts)
+		AddRow("phoenix-1", 10, schemas.CollectorJSON(`{bad json`), ts.Unix(), ts.Unix())
 	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "collector_pool_snapshots"`)).WillReturnRows(rows)
 
 	_, err := repo.GetPoolInfos("phoenix-1", 10)
@@ -157,8 +157,8 @@ func TestSaveHeightUpsertsBlockPoolAndSyncedHeight(t *testing.T) {
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 
 	mock.ExpectBegin()
-	expectUpsert(mock, `collector_blocks`)
-	expectUpsert(mock, `collector_pool_snapshots`)
+	expectUpsert(mock, `collector_blocks`, `"chain_id","height","block_time","txs"`)
+	expectUpsert(mock, `collector_pool_snapshots`, `"chain_id","height","pool_infos"`)
 	expectSyncedHeightInsert(mock)
 	mock.ExpectCommit()
 
@@ -180,7 +180,7 @@ func TestSaveHeightWithoutPoolSnapshotSkipsPoolUpsert(t *testing.T) {
 	ts := time.Date(2026, 5, 19, 1, 2, 3, 0, time.UTC)
 
 	mock.ExpectBegin()
-	expectUpsert(mock, `collector_blocks`)
+	expectUpsert(mock, `collector_blocks`, `"chain_id","height","block_time","txs"`)
 	expectSyncedHeightInsert(mock)
 	mock.ExpectCommit()
 
@@ -217,7 +217,7 @@ func TestSaveHeightRollsBackWhenPoolUpsertFails(t *testing.T) {
 	expected := errors.New("pool insert failed")
 
 	mock.ExpectBegin()
-	expectUpsert(mock, `collector_blocks`)
+	expectUpsert(mock, `collector_blocks`, `"chain_id","height","block_time","txs"`)
 	mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO "collector_pool_snapshots"`)).
 		WillReturnError(expected)
 	mock.ExpectRollback()
@@ -233,7 +233,7 @@ func TestSaveHeightRollsBackWhenSyncedHeightUpsertFails(t *testing.T) {
 	expected := errors.New("synced insert failed")
 
 	mock.ExpectBegin()
-	expectUpsert(mock, `collector_blocks`)
+	expectUpsert(mock, `collector_blocks`, `"chain_id","height","block_time","txs"`)
 	mock.ExpectExec(syncedHeightInsertPattern()).
 		WillReturnError(expected)
 	mock.ExpectRollback()
@@ -255,11 +255,11 @@ func TestIsUndefinedTableRejectsUnrelatedDoesNotExistErrors(t *testing.T) {
 	require.False(t, isUndefinedTable(errors.New(`role "etl" does not exist`)))
 }
 
-func expectUpsert(mock sqlmock.Sqlmock, table string) {
+func expectUpsert(mock sqlmock.Sqlmock, table string, columns string) {
 	mock.ExpectExec(
-		regexp.QuoteMeta(
-			`INSERT INTO "`+table+`"`) +
-			`.*` + regexp.QuoteMeta(`ON CONFLICT`),
+		regexp.QuoteMeta(`INSERT INTO "`+table+`" (`+columns+`) VALUES`) +
+			`.*` + regexp.QuoteMeta(`ON CONFLICT`) +
+			`.*` + regexp.QuoteMeta(`"updated_at"="excluded"."updated_at"`),
 	).
 		WillReturnResult(sqlmock.NewResult(1, 1))
 }
@@ -270,7 +270,9 @@ func expectSyncedHeightInsert(mock sqlmock.Sqlmock) {
 }
 
 func syncedHeightInsertPattern() string {
-	return regexp.QuoteMeta(`INSERT INTO "collector_synced_heights"`) +
+	return regexp.QuoteMeta(`INSERT INTO "collector_synced_heights" ("chain_id","height") VALUES`) +
 		`.*` +
-		regexp.QuoteMeta(`GREATEST(collector_synced_heights.height, EXCLUDED.height)`)
+		regexp.QuoteMeta(`GREATEST(collector_synced_heights.height, EXCLUDED.height)`) +
+		`.*` +
+		regexp.QuoteMeta(`EXCLUDED.updated_at`)
 }

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -239,7 +239,7 @@ func Test_CollectorConfig_Validate(t *testing.T) {
 			config := valid
 			config.PollIntervalSec = 0
 			return config
-		}(), expected: "invalid start height: set collector.poll_interval_sec to a value greater than 0"},
+		}(), expected: "invalid poll interval: set collector.poll_interval_sec to a value greater than 0"},
 	}
 
 	for _, testCase := range testCases {

--- a/db/migrations/collector/20260526171200_store_audit_timestamps_as_epoch.down.sql
+++ b/db/migrations/collector/20260526171200_store_audit_timestamps_as_epoch.down.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+ALTER TABLE "public"."collector_blocks"
+    ALTER COLUMN "created_at" DROP DEFAULT,
+    ALTER COLUMN "updated_at" DROP DEFAULT;
+
+ALTER TABLE "public"."collector_blocks"
+    ALTER COLUMN "created_at" TYPE timestamp
+        USING to_timestamp("created_at") AT TIME ZONE 'UTC',
+    ALTER COLUMN "created_at" SET DEFAULT now(),
+    ALTER COLUMN "updated_at" TYPE timestamp
+        USING to_timestamp("updated_at") AT TIME ZONE 'UTC',
+    ALTER COLUMN "updated_at" SET DEFAULT now();
+
+ALTER TABLE "public"."collector_pool_snapshots"
+    ALTER COLUMN "created_at" DROP DEFAULT,
+    ALTER COLUMN "updated_at" DROP DEFAULT;
+
+ALTER TABLE "public"."collector_pool_snapshots"
+    ALTER COLUMN "created_at" TYPE timestamp
+        USING to_timestamp("created_at") AT TIME ZONE 'UTC',
+    ALTER COLUMN "created_at" SET DEFAULT now(),
+    ALTER COLUMN "updated_at" TYPE timestamp
+        USING to_timestamp("updated_at") AT TIME ZONE 'UTC',
+    ALTER COLUMN "updated_at" SET DEFAULT now();
+
+ALTER TABLE "public"."collector_synced_heights"
+    ALTER COLUMN "created_at" DROP DEFAULT,
+    ALTER COLUMN "updated_at" DROP DEFAULT;
+
+ALTER TABLE "public"."collector_synced_heights"
+    ALTER COLUMN "created_at" TYPE timestamp
+        USING to_timestamp("created_at") AT TIME ZONE 'UTC',
+    ALTER COLUMN "created_at" SET DEFAULT now(),
+    ALTER COLUMN "updated_at" TYPE timestamp
+        USING to_timestamp("updated_at") AT TIME ZONE 'UTC',
+    ALTER COLUMN "updated_at" SET DEFAULT now();
+
+COMMIT;

--- a/db/migrations/collector/20260526171200_store_audit_timestamps_as_epoch.up.sql
+++ b/db/migrations/collector/20260526171200_store_audit_timestamps_as_epoch.up.sql
@@ -1,3 +1,6 @@
+-- NOTE: This rollback reconstructs timestamps from epoch seconds via to_timestamp().
+-- Sub-second precision from the original timestamp values is lost and cannot be recovered.
+-- Consider this migration forward-only in practice.
 BEGIN;
 
 ALTER TABLE "public"."collector_blocks"

--- a/db/migrations/collector/20260526171200_store_audit_timestamps_as_epoch.up.sql
+++ b/db/migrations/collector/20260526171200_store_audit_timestamps_as_epoch.up.sql
@@ -1,0 +1,39 @@
+BEGIN;
+
+ALTER TABLE "public"."collector_blocks"
+    ALTER COLUMN "created_at" DROP DEFAULT,
+    ALTER COLUMN "updated_at" DROP DEFAULT;
+
+ALTER TABLE "public"."collector_blocks"
+    ALTER COLUMN "created_at" TYPE int8
+        USING FLOOR(EXTRACT(EPOCH FROM "created_at" AT TIME ZONE 'UTC'))::int8,
+    ALTER COLUMN "created_at" SET DEFAULT FLOOR(EXTRACT(EPOCH FROM now()))::int8,
+    ALTER COLUMN "updated_at" TYPE int8
+        USING FLOOR(EXTRACT(EPOCH FROM "updated_at" AT TIME ZONE 'UTC'))::int8,
+    ALTER COLUMN "updated_at" SET DEFAULT FLOOR(EXTRACT(EPOCH FROM now()))::int8;
+
+ALTER TABLE "public"."collector_pool_snapshots"
+    ALTER COLUMN "created_at" DROP DEFAULT,
+    ALTER COLUMN "updated_at" DROP DEFAULT;
+
+ALTER TABLE "public"."collector_pool_snapshots"
+    ALTER COLUMN "created_at" TYPE int8
+        USING FLOOR(EXTRACT(EPOCH FROM "created_at" AT TIME ZONE 'UTC'))::int8,
+    ALTER COLUMN "created_at" SET DEFAULT FLOOR(EXTRACT(EPOCH FROM now()))::int8,
+    ALTER COLUMN "updated_at" TYPE int8
+        USING FLOOR(EXTRACT(EPOCH FROM "updated_at" AT TIME ZONE 'UTC'))::int8,
+    ALTER COLUMN "updated_at" SET DEFAULT FLOOR(EXTRACT(EPOCH FROM now()))::int8;
+
+ALTER TABLE "public"."collector_synced_heights"
+    ALTER COLUMN "created_at" DROP DEFAULT,
+    ALTER COLUMN "updated_at" DROP DEFAULT;
+
+ALTER TABLE "public"."collector_synced_heights"
+    ALTER COLUMN "created_at" TYPE int8
+        USING FLOOR(EXTRACT(EPOCH FROM "created_at" AT TIME ZONE 'UTC'))::int8,
+    ALTER COLUMN "created_at" SET DEFAULT FLOOR(EXTRACT(EPOCH FROM now()))::int8,
+    ALTER COLUMN "updated_at" TYPE int8
+        USING FLOOR(EXTRACT(EPOCH FROM "updated_at" AT TIME ZONE 'UTC'))::int8,
+    ALTER COLUMN "updated_at" SET DEFAULT FLOOR(EXTRACT(EPOCH FROM now()))::int8;
+
+COMMIT;

--- a/pkg/db/schemas/collector.models.go
+++ b/pkg/db/schemas/collector.models.go
@@ -24,21 +24,21 @@ type CollectorBlock struct {
 	Height    uint64        `json:"height"`
 	BlockTime time.Time     `json:"blockTime"`
 	Txs       CollectorJSON `json:"txs" gorm:"type:jsonb"`
-	CreatedAt time.Time     `json:"createdAt"`
-	UpdatedAt time.Time     `json:"updatedAt"`
+	CreatedAt int64         `json:"createdAt" gorm:"->"`
+	UpdatedAt int64         `json:"updatedAt" gorm:"->"`
 }
 
 type CollectorPoolSnapshot struct {
 	ChainId   string        `json:"chainId"`
 	Height    uint64        `json:"height"`
 	PoolInfos CollectorJSON `json:"poolInfos" gorm:"type:jsonb"`
-	CreatedAt time.Time     `json:"createdAt"`
-	UpdatedAt time.Time     `json:"updatedAt"`
+	CreatedAt int64         `json:"createdAt" gorm:"->"`
+	UpdatedAt int64         `json:"updatedAt" gorm:"->"`
 }
 
 type CollectorSyncedHeight struct {
-	ChainId   string    `json:"chainId"`
-	Height    uint64    `json:"height"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ChainId   string `json:"chainId"`
+	Height    uint64 `json:"height"`
+	CreatedAt int64  `json:"createdAt" gorm:"->"`
+	UpdatedAt int64  `json:"updatedAt" gorm:"->"`
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Collector audit columns `created_at` and `updated_at` were PostgreSQL `timestamp` values set explicitly in application code via `time.Now().UTC()`. That couples Go `time.Time` mapping with DB timestamps and can diverge on upserts. This change stores audit timestamps as Unix epoch seconds (`int8`) with DB-managed defaults, and treats those fields as read-only in the app layer.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Converts `created_at` / `updated_at` on `collector_blocks`, `collector_pool_snapshots`, and `collector_synced_heights` to UTC epoch seconds (`int8`), with defaults `FLOOR(EXTRACT(EPOCH FROM now()))::int8`. Existing `timestamp` values are migrated via `USING FLOOR(EXTRACT(EPOCH FROM ... AT TIME ZONE 'UTC'))`.
- `CreatedAt` / `UpdatedAt` on `CollectorBlock`, `CollectorPoolSnapshot`, and `CollectorSyncedHeight` are `int64` with `gorm:"->"` so inserts/updates do not set them from Go.
- `SaveHeight` no longer sets `CreatedAt` / `UpdatedAt` manually; DB defaults and `ON CONFLICT` handle `updated_at` (including `collector_synced_heights` using `EXCLUDED.updated_at` instead of a Go `now` value).

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated collector timestamp storage to use epoch seconds for consistency across collector data.
  * Applied database migration to convert existing collector timestamps to the new format.

* **Bug Fixes**
  * Corrected the poll-interval validation error message to clearly instruct setting collector.poll_interval_sec > 0.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dezswap/cosmwasm-etl/pull/126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->