### PR TITLE
fix: build collector migration URL from config

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -17,7 +17,6 @@ body = """
 {% for commit in commits %}
 - {{ commit.message | upper_first }} \
   ([`{{ commit.id | truncate(length=7, end="") }}`](https://github.com/dezswap/cosmwasm-etl/commit/{{ commit.id }}))\
-  {% if commit.remote.pr_number %}[#{{ commit.remote.pr_number }}](https://github.com/dezswap/cosmwasm-etl/pull/{{ commit.remote.pr_number }}){% endif %}\
 {% endfor %}
 {% endfor %}\n
 """

--- a/cmd/collector/columbus4/main.go
+++ b/cmd/collector/columbus4/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"io"
 	"log"
 	"math"
@@ -52,9 +51,8 @@ func main() {
 	cfg := configs.New()
 	fcdCfg := cfg.Collector.FcdConfig
 	dbCon := cfg.Rdb
-	dbDsn := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=disable", dbCon.Host, dbCon.Port, dbCon.Username, dbCon.Password, dbCon.Database)
 	writer := io.MultiWriter(os.Stdout)
-	db, err := gorm.Open(postgres.Open(dbDsn), &gorm.Config{
+	db, err := gorm.Open(postgres.Open(dbCon.PostgresURL()), &gorm.Config{
 		NowFunc: func() time.Time {
 			return time.Now().UTC()
 		},

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"net/url"
 	"testing"
 	"time"
 
@@ -60,6 +61,48 @@ func Test_RdbConfig_Defaults(t *testing.T) {
 	require.Equal(t, defaultRdbConfig.Username, cfg.Rdb.Username)
 	require.Equal(t, defaultRdbConfig.Password, cfg.Rdb.Password)
 	require.Equal(t, defaultRdbConfig.SslMode, cfg.Rdb.SslMode)
+}
+
+func Test_RdbConfig_PostgresURL(t *testing.T) {
+	cfg := RdbConfig{
+		Host:     "db.example.com",
+		Port:     5433,
+		Database: "cosmwasm_etl",
+		Username: "user:name",
+		Password: "p@ss word:/?#%+",
+		SslMode:  "require",
+	}
+
+	got := cfg.PostgresURL()
+	require.Contains(t, got, "p%40ss%20word")
+	require.NotContains(t, got, "p%40ss+word")
+
+	parsed, err := url.Parse(got)
+	require.NoError(t, err)
+	require.Equal(t, "postgres", parsed.Scheme)
+	require.Equal(t, "db.example.com:5433", parsed.Host)
+	require.Equal(t, "/cosmwasm_etl", parsed.Path)
+	require.Equal(t, "user:name", parsed.User.Username())
+	password, ok := parsed.User.Password()
+	require.True(t, ok)
+	require.Equal(t, "p@ss word:/?#%+", password)
+	require.Equal(t, "require", parsed.Query().Get("sslmode"))
+}
+
+func Test_RdbConfig_MigrationURL(t *testing.T) {
+	cfg := RdbConfig{
+		Host:     "localhost",
+		Port:     5432,
+		Database: "cosmwasm_etl",
+		Username: "app",
+		Password: "appPW",
+		SslMode:  "disable",
+	}
+
+	parsed, err := url.Parse(cfg.MigrationURL("collector_migration"))
+	require.NoError(t, err)
+	require.Equal(t, "disable", parsed.Query().Get("sslmode"))
+	require.Equal(t, "collector_migration", parsed.Query().Get("x-migrations-table"))
 }
 
 func Test_S3Config_EnvVars(t *testing.T) {

--- a/configs/rdb.config.go
+++ b/configs/rdb.config.go
@@ -1,6 +1,7 @@
 package configs
 
 import (
+	"net/url"
 	"strconv"
 
 	"github.com/spf13/viper"
@@ -27,6 +28,37 @@ var defaultRdbConfig = RdbConfig{
 
 func (c RdbConfig) Endpoint() string {
 	return c.Host + ":" + strconv.Itoa(c.Port)
+}
+
+func (c RdbConfig) PostgresURL() string {
+	return c.postgresURL(url.Values{})
+}
+
+func (c RdbConfig) MigrationURL(migrationTable string) string {
+	values := url.Values{}
+	values.Set("x-migrations-table", migrationTable)
+
+	return c.postgresURL(values)
+}
+
+func (c RdbConfig) postgresURL(extraQuery url.Values) string {
+	u := url.URL{
+		Scheme: "postgres",
+		User:   url.UserPassword(c.Username, c.Password),
+		Host:   c.Endpoint(),
+		Path:   c.Database,
+	}
+
+	query := u.Query()
+	query.Set("sslmode", c.SslMode)
+	for key, values := range extraQuery {
+		for _, value := range values {
+			query.Add(key, value)
+		}
+	}
+	u.RawQuery = query.Encode()
+
+	return u.String()
 }
 
 func SetDefaultRdbConfig(v *viper.Viper) {

--- a/db/migrations/aggregator/main.go
+++ b/db/migrations/aggregator/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
@@ -19,8 +17,7 @@ func main() {
 	rollBack := os.Args[1:]
 	c := configs.New().Rdb
 
-	url := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s&x-migrations-table=%s", c.Username, url.QueryEscape(c.Password), c.Host, c.Port, c.Database, c.SslMode, migTableName)
-	m, err := migrate.New("file://db/migrations/aggregator", url)
+	m, err := migrate.New("file://db/migrations/aggregator", c.MigrationURL(migTableName))
 	if err != nil {
 		panic(err)
 	}

--- a/db/migrations/collector/main.go
+++ b/db/migrations/collector/main.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
@@ -22,17 +20,7 @@ func main() {
 	rollBack := os.Args[1:]
 	c := configs.New().Rdb
 
-	url := fmt.Sprintf(
-		"postgres://%s:%s@%s:%d/%s?sslmode=%s&x-migrations-table=%s",
-		c.Username,
-		url.QueryEscape(c.Password),
-		c.Host,
-		c.Port,
-		c.Database,
-		c.SslMode,
-		migTableName,
-	)
-	m, err := migrate.New("file://db/migrations/collector", url)
+	m, err := migrate.New("file://db/migrations/collector", c.MigrationURL(migTableName))
 	if err != nil {
 		panic(err)
 	}

--- a/db/migrations/collector/main.go
+++ b/db/migrations/collector/main.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -21,7 +22,16 @@ func main() {
 	rollBack := os.Args[1:]
 	c := configs.New().Rdb
 
-	url := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=disable&x-migrations-table=%s", c.Username, c.Password, c.Host, c.Port, c.Database, migTableName)
+	url := fmt.Sprintf(
+		"postgres://%s:%s@%s:%d/%s?sslmode=%s&x-migrations-table=%s",
+		c.Username,
+		url.QueryEscape(c.Password),
+		c.Host,
+		c.Port,
+		c.Database,
+		c.SslMode,
+		migTableName,
+	)
 	m, err := migrate.New("file://db/migrations/collector", url)
 	if err != nil {
 		panic(err)

--- a/db/migrations/parser/main.go
+++ b/db/migrations/parser/main.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"fmt"
-	"net/url"
 	"os"
 	"strings"
 
@@ -20,8 +18,7 @@ func main() {
 	rollBack := os.Args[1:]
 	c := configs.New().Rdb
 
-	url := fmt.Sprintf("postgres://%s:%s@%s:%d/%s?sslmode=%s", c.Username, url.QueryEscape(c.Password), c.Host, c.Port, c.Database, c.SslMode)
-	m, err := migrate.New("file://db/migrations/parser", url)
+	m, err := migrate.New("file://db/migrations/parser", c.PostgresURL())
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/db/connector_test.go
+++ b/pkg/db/connector_test.go
@@ -1,1 +1,0 @@
-package db

--- a/pkg/db/postgres.go
+++ b/pkg/db/postgres.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"database/sql"
-	"fmt"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	_ "github.com/lib/pq"
@@ -13,15 +12,12 @@ type PostgresDb struct {
 }
 
 func (x *PostgresDb) Init(dbConfig configs.RdbConfig) error {
-	psqlInfo := fmt.Sprintf("host=%s port=%d user=%s password=%s dbname=%s sslmode=%s",
-		dbConfig.Host, dbConfig.Port, dbConfig.Username, dbConfig.Password, dbConfig.Database, dbConfig.SslMode)
-
 	if x.Db != nil {
 		x.Close()
 	}
 
 	var err error
-	if x.Db, err = sql.Open("postgres", psqlInfo); err != nil {
+	if x.Db, err = sql.Open("postgres", dbConfig.PostgresURL()); err != nil {
 		return err
 	}
 

--- a/pkg/db/postgres_test.go
+++ b/pkg/db/postgres_test.go
@@ -1,0 +1,18 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostgresDb_Init(t *testing.T) {
+	c := configs.New()
+
+	pdb := PostgresDb{}
+	require.NoError(t, pdb.Init(c.Rdb))
+	defer pdb.Close()
+
+	require.NoError(t, pdb.Db.Ping())
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Collector migration currently hardcodes `sslmode=disable`, so it cannot use the SSL mode configured through `APP_RDB_SSLMODE` or config files. The migration URL also did not escape DB passwords, unlike other migration entrypoints.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Use configured `Rdb.SslMode` when building the collector migration Postgres URL.
- Escape the DB password in the collector migration URL.
- Remove PR number links from generated changelog entries.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [ ] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection and migration reliability: credentials are URL-encoded, migrations use configurable connection strings, and SSL mode is no longer hardcoded.

* **New Features**
  * Added helpers to produce canonical Postgres and migration connection URLs (used across initialization and migrations).

* **Tests**
  * Added tests validating Postgres and migration URL construction.

* **Chores**
  * Changelog template updated to stop rendering PR links in commit entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->