### PR TITLE
chore: centralize GORM Postgres connection setup

### DIFF
--- a/aggregator/repo/repository.go
+++ b/aggregator/repo/repository.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"gorm.io/gorm/logger"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/pkg/db"
@@ -49,7 +48,7 @@ type repoImpl struct {
 }
 
 func New(chainId string, dbConfig configs.RdbConfig) Repo {
-	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
+	gormDB, err := db.OpenGormPostgres(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/aggregator/repo/repository.go
+++ b/aggregator/repo/repository.go
@@ -1,8 +1,6 @@
 package repo
 
 import (
-	"log"
-	"os"
 	"time"
 
 	"github.com/pkg/errors"
@@ -13,7 +11,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/dezswap/cosmwasm-etl/pkg/util"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -52,27 +49,7 @@ type repoImpl struct {
 }
 
 func New(chainId string, dbConfig configs.RdbConfig) Repo {
-	newLogger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
-		logger.Config{
-			SlowThreshold:             time.Second,  // Slow SQL threshold
-			LogLevel:                  logger.Error, // Log level
-			IgnoreRecordNotFoundError: true,         // Ignore ErrRecordNotFound error for logger
-			Colorful:                  false,        // Disable color
-		},
-	)
-
-	pq := db.PostgresDb{}
-	err := pq.Init(dbConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{
-		Logger: newLogger,
-	})
+	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
 	if err != nil {
 		panic(err)
 	}

--- a/aggregator/repo/repository_test.go
+++ b/aggregator/repo/repository_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/dezswap/cosmwasm-etl/pkg/util"
 	"github.com/stretchr/testify/assert"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -304,9 +303,7 @@ func initDb(config configs.RdbConfig) (*sql.DB, *gorm.DB, error) {
 	}
 
 	// verify
-	gormDb, _ := gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{})
+	gormDb, _ := db.OpenGormPostgresWithConn(pq.Db)
 
 	return pq.Db, gormDb, nil
 }

--- a/aggregator/repo/repository_test.go
+++ b/aggregator/repo/repository_test.go
@@ -303,7 +303,10 @@ func initDb(config configs.RdbConfig) (*sql.DB, *gorm.DB, error) {
 	}
 
 	// verify
-	gormDb, _ := db.OpenGormPostgresWithConn(pq.Db)
+	gormDb, err := db.OpenGormPostgresWithConn(pq.Db)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return pq.Db, gormDb, nil
 }

--- a/cmd/collector/columbus4/main.go
+++ b/cmd/collector/columbus4/main.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"io"
-	"log"
 	"math"
 	"net/http"
 	"os"
@@ -12,6 +10,7 @@ import (
 	"github.com/davecgh/go-spew/spew"
 	fcd_collector "github.com/dezswap/cosmwasm-etl/collector/terra/fcd"
 	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/dex/terraswap"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/dezswap/cosmwasm-etl/pkg/terra/fcd"
@@ -51,21 +50,13 @@ func main() {
 	cfg := configs.New()
 	fcdCfg := cfg.Collector.FcdConfig
 	dbCon := cfg.Rdb
-	writer := io.MultiWriter(os.Stdout)
-	db, err := gorm.Open(postgres.Open(dbCon.PostgresURL()), &gorm.Config{
-		NowFunc: func() time.Time {
-			return time.Now().UTC()
+	db, err := db.OpenGormPostgres(
+		dbCon,
+		func(gormConfig *gorm.Config, _ *postgres.Config) {
+			gormConfig.NowFunc = func() time.Time { return time.Now().UTC() }
 		},
-		Logger: glogger.New(
-			log.New(writer, "\r\n", log.LstdFlags),
-			glogger.Config{
-				IgnoreRecordNotFoundError: true,
-				SlowThreshold:             time.Second,
-				Colorful:                  false,
-				LogLevel:                  glogger.Warn,
-			},
-		),
-	})
+		db.WithGormLogLevel(glogger.Warn),
+	)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/collector/columbus4/main.go
+++ b/cmd/collector/columbus4/main.go
@@ -16,7 +16,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/terra/fcd"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	glogger "gorm.io/gorm/logger"
 )
 
 var columbus4_pairs = []string{
@@ -55,7 +54,6 @@ func main() {
 		func(gormConfig *gorm.Config, _ *postgres.Config) {
 			gormConfig.NowFunc = func() time.Time { return time.Now().UTC() }
 		},
-		db.WithGormLogLevel(glogger.Warn),
 	)
 	if err != nil {
 		panic(err)

--- a/collector/repo/repository.go
+++ b/collector/repo/repository.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/lib/pq"
 	pkgerrors "github.com/pkg/errors"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -40,12 +39,7 @@ type repository struct {
 var _ Repository = (*repository)(nil)
 
 func New(dbConfig configs.RdbConfig) Repository {
-	pqDB := db.PostgresDb{}
-	if err := pqDB.Init(dbConfig); err != nil {
-		panic(err)
-	}
-
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{Conn: pqDB.Db}), &gorm.Config{})
+	gormDB, err := db.OpenGormPostgres(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/collector/repo/repository_test.go
+++ b/collector/repo/repository_test.go
@@ -9,13 +9,13 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 func newMockRepo(t *testing.T) (*repository, sqlmock.Sqlmock) {
@@ -23,10 +23,12 @@ func newMockRepo(t *testing.T) (*repository, sqlmock.Sqlmock) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = sqlDB.Close() })
 
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn:                 sqlDB,
-		PreferSimpleProtocol: true,
-	}), &gorm.Config{Logger: logger.Default.LogMode(logger.Silent)})
+	gormDB, err := db.OpenGormPostgresWithConn(
+		sqlDB,
+		func(_ *gorm.Config, postgresConfig *postgres.Config) {
+			postgresConfig.PreferSimpleProtocol = true
+		},
+	)
 	require.NoError(t, err)
 
 	return NewWithDB(gormDB).(*repository), mock

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -34,6 +34,7 @@ func Test_RdbConfig_EnvVars(t *testing.T) {
 	t.Setenv("APP_RDB_USERNAME", "user1")
 	t.Setenv("APP_RDB_PASSWORD", "secret")
 	t.Setenv("APP_RDB_SSLMODE", "require")
+	t.Setenv("APP_RDB_GORMLOGLEVEL", "error")
 
 	tmp := t.TempDir()
 	defer withTestBasepath(t, tmp)()
@@ -45,6 +46,7 @@ func Test_RdbConfig_EnvVars(t *testing.T) {
 	require.Equal(t, "user1", cfg.Rdb.Username)
 	require.Equal(t, "secret", cfg.Rdb.Password)
 	require.Equal(t, "require", cfg.Rdb.SslMode)
+	require.Equal(t, "error", cfg.Rdb.GormLogLevel)
 }
 
 func Test_RdbConfig_Defaults(t *testing.T) {
@@ -61,6 +63,7 @@ func Test_RdbConfig_Defaults(t *testing.T) {
 	require.Equal(t, defaultRdbConfig.Username, cfg.Rdb.Username)
 	require.Equal(t, defaultRdbConfig.Password, cfg.Rdb.Password)
 	require.Equal(t, defaultRdbConfig.SslMode, cfg.Rdb.SslMode)
+	require.Equal(t, defaultRdbConfig.GormLogLevel, cfg.Rdb.GormLogLevel)
 }
 
 func Test_RdbConfig_PostgresURL(t *testing.T) {

--- a/configs/rdb.config.go
+++ b/configs/rdb.config.go
@@ -9,12 +9,13 @@ import (
 
 // db contains configs for other services
 type RdbConfig struct {
-	Host     string `mapstructure:"host"`
-	Port     int    `mapstructure:"port"`
-	Database string `mapstructure:"database"`
-	Username string `mapstructure:"username"`
-	Password string `mapstructure:"password"`
-	SslMode  string `mapstructure:"sslmode"`
+	Host         string `mapstructure:"host"`
+	Port         int    `mapstructure:"port"`
+	Database     string `mapstructure:"database"`
+	Username     string `mapstructure:"username"`
+	Password     string `mapstructure:"password"`
+	SslMode      string `mapstructure:"sslmode"`
+	GormLogLevel string `mapstructure:"gormloglevel"`
 }
 
 var defaultRdbConfig = RdbConfig{
@@ -68,4 +69,5 @@ func SetDefaultRdbConfig(v *viper.Viper) {
 	v.SetDefault("rdb.username", defaultRdbConfig.Username)
 	v.SetDefault("rdb.password", defaultRdbConfig.Password)
 	v.SetDefault("rdb.sslmode", defaultRdbConfig.SslMode)
+	v.SetDefault("rdb.gormloglevel", defaultRdbConfig.GormLogLevel)
 }

--- a/db/migrations/parser/migration_test.go
+++ b/db/migrations/parser/migration_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 const batch_size = 100
@@ -23,7 +22,7 @@ func Test_ParserMigration(t *testing.T) {
 	c := configs.New()
 	faker.MigFakerInit()
 	p_dex.FakerCustomGenerator()
-	dbCon, err := db.OpenGormPostgres(c.Rdb, db.WithGormLogLevel(logger.Error))
+	dbCon, err := db.OpenGormPostgres(c.Rdb)
 	if err != nil {
 		panic(err)
 	}

--- a/db/migrations/parser/migration_test.go
+++ b/db/migrations/parser/migration_test.go
@@ -4,8 +4,6 @@
 package main
 
 import (
-	"log"
-	"os"
 	"testing"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
@@ -15,10 +13,8 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/faker"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	"gorm.io/driver/postgres"
-	"gorm.io/gorm/logger"
-
 	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
 
 const batch_size = 100
@@ -27,22 +23,7 @@ func Test_ParserMigration(t *testing.T) {
 	c := configs.New()
 	faker.MigFakerInit()
 	p_dex.FakerCustomGenerator()
-	pdb := db.PostgresDb{}
-	if err := pdb.Init(c.Rdb); err != nil {
-		panic(err)
-	}
-	myLogger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
-		logger.Config{
-			LogLevel:                  logger.Error, // Log level
-			IgnoreRecordNotFoundError: true,         // Ignore ErrRecordNotFound error for logger
-		},
-	)
-	dbCon, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: pdb.Db,
-	}), &gorm.Config{
-		Logger: myLogger,
-	})
+	dbCon, err := db.OpenGormPostgres(c.Rdb, db.WithGormLogLevel(logger.Error))
 	if err != nil {
 		panic(err)
 	}

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -70,6 +70,8 @@ rdb:
   database:
   username:
   password:
+  # optional: silent, error, warn, info
+  gormLogLevel:
 
 s3:
   bucket:

--- a/parser/dex/repo/repository.go
+++ b/parser/dex/repo/repository.go
@@ -9,7 +9,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/pkg/errors"
 
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -20,16 +19,7 @@ type repoImpl struct {
 }
 
 func New(chainId string, dbConfig configs.RdbConfig) dex.Repo {
-	pq := db.PostgresDb{}
-	err := pq.Init(dbConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{})
-
+	gormDB, err := db.OpenGormPostgres(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/parser/dex/repo/repository_test.go
+++ b/parser/dex/repo/repository_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -35,7 +36,12 @@ func (s *baseSuite) SetupSuite() {
 	db, s.Mock, err = sqlmock.New()
 	require.NoError(s.T(), err)
 
-	s.DB, err = rootdb.OpenGormPostgresWithConn(db)
+	s.DB, err = rootdb.OpenGormPostgresWithConn(
+		db,
+		func(_ *gorm.Config, postgresConfig *postgres.Config) {
+			postgresConfig.PreferSimpleProtocol = true
+		},
+	)
 	require.NoError(s.T(), err)
 
 	s.Repo = repoImpl{mapper: &parserMapperImpl{}, db: s.DB, chainId: "local"}

--- a/parser/dex/repo/repository_test.go
+++ b/parser/dex/repo/repository_test.go
@@ -9,11 +9,11 @@ import (
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	rootdb "github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/faker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -35,9 +35,7 @@ func (s *baseSuite) SetupSuite() {
 	db, s.Mock, err = sqlmock.New()
 	require.NoError(s.T(), err)
 
-	s.DB, err = gorm.Open(postgres.New(postgres.Config{
-		Conn: db,
-	}), &gorm.Config{})
+	s.DB, err = rootdb.OpenGormPostgresWithConn(db)
 	require.NoError(s.T(), err)
 
 	s.Repo = repoImpl{mapper: &parserMapperImpl{}, db: s.DB, chainId: "local"}

--- a/pkg/db/gorm.go
+++ b/pkg/db/gorm.go
@@ -1,0 +1,57 @@
+package db
+
+import (
+	"database/sql"
+	"log"
+	"os"
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"gorm.io/driver/postgres"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+// GormOption customizes the GORM and Postgres driver configuration before opening a database.
+type GormOption func(*gorm.Config, *postgres.Config)
+
+// OpenGormPostgres opens a GORM Postgres connection from repository database configuration.
+func OpenGormPostgres(dbConfig configs.RdbConfig, opts ...GormOption) (*gorm.DB, error) {
+	pq := PostgresDb{}
+	if err := pq.Init(dbConfig); err != nil {
+		return nil, err
+	}
+	return OpenGormPostgresWithConn(pq.Db, opts...)
+}
+
+// OpenGormPostgresWithConn opens a GORM Postgres connection using an existing sql.DB.
+func OpenGormPostgresWithConn(conn *sql.DB, opts ...GormOption) (*gorm.DB, error) {
+	postgresConfig := &postgres.Config{Conn: conn}
+	gormConfig := &gorm.Config{
+		Logger: NewGormLogger(logger.Silent),
+	}
+	for _, opt := range opts {
+		opt(gormConfig, postgresConfig)
+	}
+	return gorm.Open(postgres.New(*postgresConfig), gormConfig)
+}
+
+// WithGormLogLevel configures the shared GORM logger with the given log level.
+func WithGormLogLevel(logLevel logger.LogLevel) GormOption {
+	return func(gormConfig *gorm.Config, _ *postgres.Config) {
+		gormConfig.Logger = NewGormLogger(logLevel)
+	}
+}
+
+// NewGormLogger creates the standard GORM logger used by database repositories.
+func NewGormLogger(logLevel logger.LogLevel) logger.Interface {
+	return logger.New(
+		log.New(os.Stdout, "\r\n", log.LstdFlags),
+		logger.Config{
+			SlowThreshold:             time.Second,
+			LogLevel:                  logLevel,
+			IgnoreRecordNotFoundError: true,
+			Colorful:                  false,
+		},
+	)
+}

--- a/pkg/db/gorm.go
+++ b/pkg/db/gorm.go
@@ -2,8 +2,10 @@ package db
 
 import (
 	"database/sql"
+	"fmt"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
@@ -17,18 +19,27 @@ type GormOption func(*gorm.Config, *postgres.Config)
 
 // OpenGormPostgres opens a GORM Postgres connection from repository database configuration.
 func OpenGormPostgres(dbConfig configs.RdbConfig, opts ...GormOption) (*gorm.DB, error) {
+	logLevel, err := GormLogLevelFromConfig(dbConfig.GormLogLevel)
+	if err != nil {
+		return nil, err
+	}
+
 	pq := PostgresDb{}
 	if err := pq.Init(dbConfig); err != nil {
 		return nil, err
 	}
-	return OpenGormPostgresWithConn(pq.Db, opts...)
+	return openGormPostgresWithConn(pq.Db, logLevel, opts...)
 }
 
 // OpenGormPostgresWithConn opens a GORM Postgres connection using an existing sql.DB.
 func OpenGormPostgresWithConn(conn *sql.DB, opts ...GormOption) (*gorm.DB, error) {
+	return openGormPostgresWithConn(conn, logger.Silent, opts...)
+}
+
+func openGormPostgresWithConn(conn *sql.DB, logLevel logger.LogLevel, opts ...GormOption) (*gorm.DB, error) {
 	postgresConfig := &postgres.Config{Conn: conn}
 	gormConfig := &gorm.Config{
-		Logger: NewGormLogger(logger.Silent),
+		Logger: NewGormLogger(logLevel),
 	}
 	for _, opt := range opts {
 		opt(gormConfig, postgresConfig)
@@ -36,10 +47,19 @@ func OpenGormPostgresWithConn(conn *sql.DB, opts ...GormOption) (*gorm.DB, error
 	return gorm.Open(postgres.New(*postgresConfig), gormConfig)
 }
 
-// WithGormLogLevel configures the shared GORM logger with the given log level.
-func WithGormLogLevel(logLevel logger.LogLevel) GormOption {
-	return func(gormConfig *gorm.Config, _ *postgres.Config) {
-		gormConfig.Logger = NewGormLogger(logLevel)
+// GormLogLevelFromConfig parses an optional GORM log level from config.
+func GormLogLevelFromConfig(value string) (logger.LogLevel, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", "silent":
+		return logger.Silent, nil
+	case "error":
+		return logger.Error, nil
+	case "warn", "warning":
+		return logger.Warn, nil
+	case "info":
+		return logger.Info, nil
+	default:
+		return logger.Silent, fmt.Errorf("invalid gorm log level %q", value)
 	}
 }
 

--- a/pkg/db/gorm_test.go
+++ b/pkg/db/gorm_test.go
@@ -23,16 +23,45 @@ func TestOpenGormPostgresWithConn_DefaultLoggerIsSilent(t *testing.T) {
 	require.Empty(t, strings.TrimSpace(output))
 }
 
-func TestOpenGormPostgresWithConn_LogLevelOptionOverridesDefault(t *testing.T) {
-	output := triggerGormQueryError(t, func() GormOption {
-		return WithGormLogLevel(logger.Error)
-	})
+func TestOpenGormPostgresWithConn_ConfiguredLoggerLogsErrors(t *testing.T) {
+	output := triggerGormQueryError(t, logger.Error)
 
 	require.Contains(t, output, "boom")
 	require.Contains(t, output, `SELECT * FROM "gorm_log_probes"`)
 }
 
-func triggerGormQueryError(t *testing.T, optFactories ...func() GormOption) string {
+func TestGormLogLevelFromConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		want      logger.LogLevel
+		wantError bool
+	}{
+		{name: "empty defaults to silent", value: "", want: logger.Silent},
+		{name: "silent", value: "silent", want: logger.Silent},
+		{name: "error", value: "error", want: logger.Error},
+		{name: "warn", value: "warn", want: logger.Warn},
+		{name: "warning", value: "warning", want: logger.Warn},
+		{name: "info", value: "info", want: logger.Info},
+		{name: "case insensitive", value: " ERROR ", want: logger.Error},
+		{name: "invalid", value: "debug", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GormLogLevelFromConfig(tt.value)
+			if tt.wantError {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func triggerGormQueryError(t *testing.T, logLevels ...logger.LogLevel) string {
 	t.Helper()
 
 	sqlDB, mock, err := sqlmock.New()
@@ -43,12 +72,12 @@ func triggerGormQueryError(t *testing.T, optFactories ...func() GormOption) stri
 		WillReturnError(errors.New("boom"))
 
 	output := captureStdout(t, func() {
-		opts := make([]GormOption, 0, len(optFactories))
-		for _, factory := range optFactories {
-			opts = append(opts, factory())
+		logLevel := logger.Silent
+		if len(logLevels) > 0 {
+			logLevel = logLevels[0]
 		}
 
-		gormDB, err := OpenGormPostgresWithConn(sqlDB, opts...)
+		gormDB, err := openGormPostgresWithConn(sqlDB, logLevel)
 		require.NoError(t, err)
 
 		err = gormDB.Find(&[]gormLogProbe{}).Error

--- a/pkg/db/gorm_test.go
+++ b/pkg/db/gorm_test.go
@@ -1,0 +1,82 @@
+package db
+
+import (
+	"errors"
+	"io"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm/logger"
+)
+
+type gormLogProbe struct {
+	ID int
+}
+
+func TestOpenGormPostgresWithConn_DefaultLoggerIsSilent(t *testing.T) {
+	output := triggerGormQueryError(t)
+
+	require.Empty(t, strings.TrimSpace(output))
+}
+
+func TestOpenGormPostgresWithConn_LogLevelOptionOverridesDefault(t *testing.T) {
+	output := triggerGormQueryError(t, func() GormOption {
+		return WithGormLogLevel(logger.Error)
+	})
+
+	require.Contains(t, output, "boom")
+	require.Contains(t, output, `SELECT * FROM "gorm_log_probes"`)
+}
+
+func triggerGormQueryError(t *testing.T, optFactories ...func() GormOption) string {
+	t.Helper()
+
+	sqlDB, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer func() { _ = sqlDB.Close() }()
+
+	mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "gorm_log_probes"`)).
+		WillReturnError(errors.New("boom"))
+
+	output := captureStdout(t, func() {
+		opts := make([]GormOption, 0, len(optFactories))
+		for _, factory := range optFactories {
+			opts = append(opts, factory())
+		}
+
+		gormDB, err := OpenGormPostgresWithConn(sqlDB, opts...)
+		require.NoError(t, err)
+
+		err = gormDB.Find(&[]gormLogProbe{}).Error
+		require.Error(t, err)
+	})
+
+	require.NoError(t, mock.ExpectationsWereMet())
+	return output
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+
+	require.NoError(t, writer.Close())
+	output, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	return string(output)
+}

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 type ReadRepository interface {
@@ -54,7 +53,7 @@ type readRepoImpl struct {
 var _ ReadRepository = &readRepoImpl{}
 
 func NewReadRepo(chainId string, dbConfig configs.RdbConfig) ReadRepository {
-	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
+	gormDB, err := db.OpenGormPostgres(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -3,10 +3,7 @@ package parser
 import (
 	"database/sql"
 	"fmt"
-	"log"
-	"os"
 	"strings"
-	"time"
 
 	"github.com/dezswap/cosmwasm-etl/pkg/util"
 
@@ -15,7 +12,6 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/pkg/errors"
 
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -58,27 +54,7 @@ type readRepoImpl struct {
 var _ ReadRepository = &readRepoImpl{}
 
 func NewReadRepo(chainId string, dbConfig configs.RdbConfig) ReadRepository {
-	newLogger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
-		logger.Config{
-			SlowThreshold:             time.Second,  // Slow SQL threshold
-			LogLevel:                  logger.Error, // Log level
-			IgnoreRecordNotFoundError: true,         // Ignore ErrRecordNotFound error for logger
-			Colorful:                  false,        // Disable color
-		},
-	)
-
-	pq := db.PostgresDb{}
-	err := pq.Init(dbConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{
-		Logger: newLogger,
-	})
+	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/db/parser/repository_test.go
+++ b/pkg/db/parser/repository_test.go
@@ -13,14 +13,13 @@ import (
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
-	"github.com/dezswap/cosmwasm-etl/pkg/db"
+	pkgdb "github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/dezswap/cosmwasm-etl/pkg/faker"
 	"github.com/dezswap/cosmwasm-etl/pkg/util"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -180,9 +179,7 @@ func (s *baseSuite) SetupSuite() {
 	db, s.Mock, err = sqlmock.New()
 	require.NoError(s.T(), err)
 
-	s.DB, err = gorm.Open(postgres.New(postgres.Config{
-		Conn: db,
-	}), &gorm.Config{})
+	s.DB, err = pkgdb.OpenGormPostgresWithConn(db)
 	require.NoError(s.T(), err)
 
 	s.Repo = readRepoImpl{db: s.DB, chainId: "local"}
@@ -341,13 +338,11 @@ func (s *aggregatorReadRepoSuite) SetupSuite() {
 	s.C = configs.NewWithFileName(configName).Aggregator.SrcDb
 	s.Repo = NewReadRepo(chainName, s.C)
 
-	pq := db.PostgresDb{}
+	pq := pkgdb.PostgresDb{}
 	err := pq.Init(s.C)
 	require.NoError(s.T(), err)
 
-	s.DB, err = gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{})
+	s.DB, err = pkgdb.OpenGormPostgresWithConn(pq.Db)
 	require.NoError(s.T(), err)
 }
 

--- a/pkg/dex/price/repository.go
+++ b/pkg/dex/price/repository.go
@@ -1,16 +1,11 @@
 package price
 
 import (
-	"log"
-	"os"
-	"time"
-
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/logger"
 )
@@ -36,27 +31,7 @@ type srcRepoImpl struct {
 }
 
 func NewRepo(chainId string, dbConfig configs.RdbConfig) SrcRepo {
-	newLogger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
-		logger.Config{
-			SlowThreshold:             time.Second,  // Slow SQL threshold
-			LogLevel:                  logger.Error, // Log level
-			IgnoreRecordNotFoundError: true,         // Ignore ErrRecordNotFound error for logger
-			Colorful:                  false,        // Disable color
-		},
-	)
-
-	pq := db.PostgresDb{}
-	err := pq.Init(dbConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{
-		Logger: newLogger,
-	})
+	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/dex/price/repository.go
+++ b/pkg/dex/price/repository.go
@@ -7,7 +7,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
 type SrcRepo interface {
@@ -31,7 +30,7 @@ type srcRepoImpl struct {
 }
 
 func NewRepo(chainId string, dbConfig configs.RdbConfig) SrcRepo {
-	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
+	gormDB, err := db.OpenGormPostgres(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/dex/router/repository.go
+++ b/pkg/dex/router/repository.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pkg/errors"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
-	"gorm.io/gorm/logger"
 )
 
 type SrcRepo interface {
@@ -24,7 +23,7 @@ type srcRepoImpl struct {
 }
 
 func NewSrcRepo(chainId string, dbConfig configs.RdbConfig) SrcRepo {
-	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
+	gormDB, err := db.OpenGormPostgres(dbConfig)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/dex/router/repository.go
+++ b/pkg/dex/router/repository.go
@@ -1,16 +1,11 @@
 package router
 
 import (
-	"log"
-	"os"
-	"time"
-
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
@@ -29,27 +24,7 @@ type srcRepoImpl struct {
 }
 
 func NewSrcRepo(chainId string, dbConfig configs.RdbConfig) SrcRepo {
-	newLogger := logger.New(
-		log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
-		logger.Config{
-			SlowThreshold:             time.Second,  // Slow SQL threshold
-			LogLevel:                  logger.Error, // Log level
-			IgnoreRecordNotFoundError: true,         // Ignore ErrRecordNotFound error for logger
-			Colorful:                  false,        // Disable color
-		},
-	)
-
-	pq := db.PostgresDb{}
-	err := pq.Init(dbConfig)
-	if err != nil {
-		panic(err)
-	}
-
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: pq.Db,
-	}), &gorm.Config{
-		Logger: newLogger,
-	})
+	gormDB, err := db.OpenGormPostgres(dbConfig, db.WithGormLogLevel(logger.Error))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/dex/router/repository_test.go
+++ b/pkg/dex/router/repository_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	rootdb "github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
 )
 
@@ -17,9 +17,7 @@ func setupMockDB(t *testing.T) (*gorm.DB, sqlmock.Sqlmock) {
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 
-	gormDB, err := gorm.Open(postgres.New(postgres.Config{
-		Conn: db,
-	}), &gorm.Config{})
+	gormDB, err := rootdb.OpenGormPostgresWithConn(db)
 	require.NoError(t, err)
 
 	return gormDB, mock


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
GORM connection setup and logger configuration were duplicated across repositories. Each service used slightly different GORM logger levels, which made SQL logging behavior inconsistent and harder to reason about in production.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
Centralized GORM Postgres setup and added optional GORM log-level configuration.
- Added shared GORM Postgres open helpers in `pkg/db`.
- Added optional `rdb.gormLogLevel` / `APP_RDB_GORMLOGLEVEL` config.
- Defaults GORM logging to `silent` when the config value is empty.
- Updated service repositories to use the shared GORM setup path.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration**
  * Added optional `rdb.gormLogLevel` configuration setting to control database logging verbosity (supported levels: silent, error, warn, info).

* **Chores**
  * Refactored database connection initialization across the application to use a centralized, shared helper for consistency and maintainability.

* **Tests**
  * Added comprehensive test coverage for GORM logging functionality and log-level configuration parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->