### PR TITLE
chore(parser): include tx hash and stage in ParseTxs errors

### DIFF
--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -56,7 +56,7 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "parseTxs")
+		return nil, errors.Wrapf(err, "dezswap.ParseTxs create_pair tx_hash=%s", tx.Hash)
 	}
 	for _, ctx := range createPairTxs {
 		p.pairs[ctx.ContractAddr] = dex.Pair{
@@ -76,7 +76,7 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 	for _, raw := range tx.LogResults {
 		ptxs, err := p.Parsers.PairActionParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "dezswap.ParseTxs pair_action tx_hash=%s", tx.Hash)
 		}
 		pairTxs = append(pairTxs, ptxs...)
 
@@ -84,26 +84,26 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 		if p.HasProvide(ptxs) {
 			ipTxs, err := p.Parsers.InitialProvide.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 			if err != nil {
-				return nil, errors.Wrap(err, "parseTxs")
+				return nil, errors.Wrapf(err, "dezswap.ParseTxs initial_provide tx_hash=%s", tx.Hash)
 			}
 			pairTxs = append(pairTxs, ipTxs...)
 		}
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "dezswap.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
 		}
 		wasmTransferTxs = append(wasmTransferTxs, wtxs...)
 
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "dezswap.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}
 		transferTxs = append(transferTxs, transfers...)
 
 		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "dezswap.ParseTxs burn tx_hash=%s", tx.Hash)
 		}
 		burnTxs = append(burnTxs, burns...)
 	}

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -109,28 +109,230 @@ func Test_ParseTxs(t *testing.T) {
 	}
 }
 
-func Test_ParseTxs_ReturnsStageAndTxHashOnError(t *testing.T) {
+func Test_ParseTxs_CreatePairUpdatesPairState(t *testing.T) {
 	createPairParser := dex.ParserMock{}
 	repo := dex.RepoMock{}
+	newPairAddr := "new_pair"
+	newLpAddr := "new_lp"
+	newAssets := [2]dex.Asset{{Addr: "new_asset_0"}, {Addr: "new_asset_1"}}
+	createPairTx := &dex.ParsedTx{
+		Hash:         txHash,
+		Type:         dex.CreatePair,
+		ContractAddr: newPairAddr,
+		LpAddr:       newLpAddr,
+		Assets:       newAssets,
+	}
+	createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{createPairTx}, nil)
 
 	app := dezswapApp{
 		PairRepo:    &repo,
 		Parsers:     &dex.PairParsers{CreatePairParser: &createPairParser},
 		DexMixin:    dex.DexMixin{},
 		chainId:     chainId,
-		pairs:       map[string]dex.Pair{pairAddr: testPair},
-		lpPairAddrs: map[string]string{lpAddr: pairAddr},
+		pairs:       map[string]dex.Pair{},
+		lpPairAddrs: map[string]string{},
 	}
 	tx := parser.RawTx{Sender: txSender, Hash: txHash}
 
-	createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-		Return([]*dex.ParsedTx{}, errors.New("parser failed"))
+	txs, err := app.ParseTxs(tx, 100)
 
-	_, err := app.ParseTxs(tx, 100)
+	assert.NoError(t, err)
+	assert.Equal(t, []dex.ParsedTx{{
+		Hash:         txHash,
+		Type:         dex.CreatePair,
+		Sender:       txSender,
+		ContractAddr: newPairAddr,
+		LpAddr:       newLpAddr,
+		Assets:       newAssets,
+	}}, txs)
+	assert.Equal(t, dex.Pair{
+		ContractAddr: newPairAddr,
+		LpAddr:       newLpAddr,
+		Assets:       []string{newAssets[0].Addr, newAssets[1].Addr},
+	}, app.pairs[newPairAddr])
+	assert.Equal(t, newPairAddr, app.lpPairAddrs[newLpAddr])
+}
 
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "dezswap.ParseTxs create_pair")
-	assert.Contains(t, err.Error(), "tx_hash="+txHash)
+func Test_ParseTxs_AppendsInitialProvideWhenPairActionHasProvide(t *testing.T) {
+	emptyParser := func() *dex.ParserMock {
+		p := dex.ParserMock{}
+		p.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return([]*dex.ParsedTx{}, nil)
+		return &p
+	}
+	pairActionParser := dex.ParserMock{}
+	pairActionTx := &dex.ParsedTx{
+		Hash:         txHash,
+		Type:         dex.Provide,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: asset1, Amount: "10"}, {Addr: asset2, Amount: "20"}},
+	}
+	pairActionParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{pairActionTx}, nil)
+	initialProvideParser := dex.ParserMock{}
+	initialProvideTx := &dex.ParsedTx{
+		Hash:         txHash,
+		Type:         dex.InitialProvide,
+		ContractAddr: pairAddr,
+		LpAddr:       lpAddr,
+		LpAmount:     "30",
+	}
+	initialProvideParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{initialProvideTx}, nil)
+	repo := dex.RepoMock{}
+	app := dezswapApp{
+		PairRepo: &repo,
+		Parsers: &dex.PairParsers{
+			CreatePairParser: emptyParser(),
+			PairActionParser: &pairActionParser,
+			InitialProvide:   &initialProvideParser,
+			WasmTransfer:     emptyParser(),
+			Transfer:         emptyParser(),
+			BurnParser:       emptyParser(),
+		},
+		DexMixin:    dex.DexMixin{},
+		chainId:     chainId,
+		pairs:       map[string]dex.Pair{pairAddr: testPair},
+		lpPairAddrs: map[string]string{lpAddr: pairAddr},
+	}
+	tx := parser.RawTx{
+		Sender:     txSender,
+		Hash:       txHash,
+		LogResults: eventlog.LogResults{{Type: eventlog.WasmType}},
+	}
+
+	txs, err := app.ParseTxs(tx, 100)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []dex.ParsedTx{
+		{
+			Hash:         txHash,
+			Type:         dex.Provide,
+			Sender:       txSender,
+			ContractAddr: pairAddr,
+			Assets:       [2]dex.Asset{{Addr: asset1, Amount: "10"}, {Addr: asset2, Amount: "20"}},
+		},
+		{
+			Hash:         txHash,
+			Type:         dex.InitialProvide,
+			Sender:       txSender,
+			ContractAddr: pairAddr,
+			LpAddr:       lpAddr,
+			LpAmount:     "30",
+		},
+	}, txs)
+}
+
+func Test_ParseTxs_ReturnsStageAndTxHashOnError(t *testing.T) {
+	type testcase struct {
+		stage       string
+		setup       func(*dex.PairParsers)
+		logResults  eventlog.LogResults
+		expectedMsg string
+	}
+
+	errParser := func() *dex.ParserMock {
+		p := dex.ParserMock{}
+		p.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return([]*dex.ParsedTx{}, errors.New("parser failed"))
+		return &p
+	}
+	emptyParser := func() *dex.ParserMock {
+		p := dex.ParserMock{}
+		p.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return([]*dex.ParsedTx{}, nil)
+		return &p
+	}
+	provideParser := func() *dex.ParserMock {
+		p := dex.ParserMock{}
+		p.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return([]*dex.ParsedTx{{Type: dex.Provide}}, nil)
+		return &p
+	}
+
+	logResults := eventlog.LogResults{{Type: eventlog.WasmType}}
+	tcs := []testcase{
+		{
+			stage:      "create_pair",
+			logResults: eventlog.LogResults{},
+			setup: func(parsers *dex.PairParsers) {
+				parsers.CreatePairParser = errParser()
+			},
+			expectedMsg: "dezswap.ParseTxs create_pair",
+		},
+		{
+			stage:      "pair_action",
+			logResults: logResults,
+			setup: func(parsers *dex.PairParsers) {
+				parsers.PairActionParser = errParser()
+			},
+			expectedMsg: "dezswap.ParseTxs pair_action",
+		},
+		{
+			stage:      "initial_provide",
+			logResults: logResults,
+			setup: func(parsers *dex.PairParsers) {
+				parsers.PairActionParser = provideParser()
+				parsers.InitialProvide = errParser()
+			},
+			expectedMsg: "dezswap.ParseTxs initial_provide",
+		},
+		{
+			stage:      "wasm_transfer",
+			logResults: logResults,
+			setup: func(parsers *dex.PairParsers) {
+				parsers.WasmTransfer = errParser()
+			},
+			expectedMsg: "dezswap.ParseTxs wasm_transfer",
+		},
+		{
+			stage:      "transfer",
+			logResults: logResults,
+			setup: func(parsers *dex.PairParsers) {
+				parsers.Transfer = errParser()
+			},
+			expectedMsg: "dezswap.ParseTxs transfer",
+		},
+		{
+			stage:      "burn",
+			logResults: logResults,
+			setup: func(parsers *dex.PairParsers) {
+				parsers.BurnParser = errParser()
+			},
+			expectedMsg: "dezswap.ParseTxs burn",
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.stage, func(t *testing.T) {
+			repo := dex.RepoMock{}
+			parsers := &dex.PairParsers{
+				CreatePairParser: emptyParser(),
+				PairActionParser: emptyParser(),
+				InitialProvide:   emptyParser(),
+				WasmTransfer:     emptyParser(),
+				Transfer:         emptyParser(),
+				BurnParser:       emptyParser(),
+			}
+			tc.setup(parsers)
+			app := dezswapApp{
+				PairRepo:    &repo,
+				Parsers:     parsers,
+				DexMixin:    dex.DexMixin{},
+				chainId:     chainId,
+				pairs:       map[string]dex.Pair{pairAddr: testPair},
+				lpPairAddrs: map[string]string{lpAddr: pairAddr},
+			}
+			tx := parser.RawTx{Sender: txSender, Hash: txHash, LogResults: tc.logResults}
+
+			_, err := app.ParseTxs(tx, 100)
+
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tc.expectedMsg)
+			assert.Contains(t, err.Error(), "tx_hash="+txHash)
+		})
+	}
 }
 
 func Test_IsValidationExceptionCandidate(t *testing.T) {

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -2,6 +2,7 @@ package dezswap
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -106,6 +107,30 @@ func Test_ParseTxs(t *testing.T) {
 		assert.NoError(err, msg)
 		assert.Equal(tc.expected, txs, msg)
 	}
+}
+
+func Test_ParseTxs_ReturnsStageAndTxHashOnError(t *testing.T) {
+	createPairParser := dex.ParserMock{}
+	repo := dex.RepoMock{}
+
+	app := dezswapApp{
+		PairRepo:    &repo,
+		Parsers:     &dex.PairParsers{CreatePairParser: &createPairParser},
+		DexMixin:    dex.DexMixin{},
+		chainId:     chainId,
+		pairs:       map[string]dex.Pair{pairAddr: testPair},
+		lpPairAddrs: map[string]string{lpAddr: pairAddr},
+	}
+	tx := parser.RawTx{Sender: txSender, Hash: txHash}
+
+	createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{}, errors.New("parser failed"))
+
+	_, err := app.ParseTxs(tx, 100)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "dezswap.ParseTxs create_pair")
+	assert.Contains(t, err.Error(), "tx_hash="+txHash)
 }
 
 func Test_IsValidationExceptionCandidate(t *testing.T) {

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -55,7 +55,7 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+		return nil, errors.Wrapf(err, "starfleit.ParseTxs create_pair tx_hash=%s", tx.Hash)
 	}
 	for _, ctx := range createPairTxs {
 		p.pairs[ctx.ContractAddr] = dex.Pair{
@@ -75,7 +75,7 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	for _, raw := range tx.LogResults {
 		ptxs, err := p.Parsers.PairActionParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+			return nil, errors.Wrapf(err, "starfleit.ParseTxs pair_action tx_hash=%s", tx.Hash)
 		}
 		pairTxs = append(pairTxs, ptxs...)
 
@@ -83,7 +83,7 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		if p.HasProvide(ptxs) {
 			ipTxs, err := p.Parsers.InitialProvide.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 			if err != nil {
-				return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+				return nil, errors.Wrapf(err, "starfleit.ParseTxs initial_provide tx_hash=%s", tx.Hash)
 			}
 			pairTxs = append(pairTxs, ipTxs...)
 		}
@@ -91,19 +91,19 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		// find transfer from user
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+			return nil, errors.Wrapf(err, "starfleit.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+			return nil, errors.Wrapf(err, "starfleit.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}
 		transferTxs = append(transferTxs, transfers...)
 
 		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "starfleit.starfleitApp.ParseTxs")
+			return nil, errors.Wrapf(err, "starfleit.ParseTxs burn tx_hash=%s", tx.Hash)
 		}
 		burnTxs = append(burnTxs, burns...)
 	}

--- a/parser/dex/starfleit/app_test.go
+++ b/parser/dex/starfleit/app_test.go
@@ -1,0 +1,61 @@
+package starfleit
+
+import (
+	"testing"
+
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func Test_ParseTxs_CreatePairUpdatesPairState(t *testing.T) {
+	const (
+		txHash     = "hash"
+		txSender   = "sender"
+		pairAddr   = "pair"
+		lpAddr     = "lp"
+		asset0Addr = "asset0"
+		asset1Addr = "asset1"
+	)
+
+	createPairParser := dex.ParserMock{}
+	repo := dex.RepoMock{}
+	assets := [2]dex.Asset{{Addr: asset0Addr}, {Addr: asset1Addr}}
+	createPairTx := &dex.ParsedTx{
+		Hash:         txHash,
+		Type:         dex.CreatePair,
+		ContractAddr: pairAddr,
+		LpAddr:       lpAddr,
+		Assets:       assets,
+	}
+	createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{createPairTx}, nil)
+
+	app := starfleitApp{
+		PairRepo:    &repo,
+		Parsers:     &dex.PairParsers{CreatePairParser: &createPairParser},
+		DexMixin:    dex.DexMixin{},
+		pairs:       map[string]dex.Pair{},
+		lpPairAddrs: map[string]string{},
+	}
+	tx := parser.RawTx{Sender: txSender, Hash: txHash}
+
+	txs, err := app.ParseTxs(tx, 100)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []dex.ParsedTx{{
+		Hash:         txHash,
+		Type:         dex.CreatePair,
+		Sender:       txSender,
+		ContractAddr: pairAddr,
+		LpAddr:       lpAddr,
+		Assets:       assets,
+	}}, txs)
+	assert.Equal(t, dex.Pair{
+		ContractAddr: pairAddr,
+		LpAddr:       lpAddr,
+		Assets:       []string{asset0Addr, asset1Addr},
+	}, app.pairs[pairAddr])
+	assert.Equal(t, pairAddr, app.lpPairAddrs[lpAddr])
+}

--- a/parser/dex/terraswap/columbusv1/app.go
+++ b/parser/dex/terraswap/columbusv1/app.go
@@ -51,7 +51,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 	txDtos := []p_dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "parseTxs")
+		return nil, errors.Wrapf(err, "columbusv1.ParseTxs create_pair tx_hash=%s", tx.Hash)
 	}
 	for _, ctx := range createPairTxs {
 		p.pairs[ctx.ContractAddr] = p_dex.Pair{
@@ -72,19 +72,19 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 		}
 		ptxs, err := p.Parsers.PairActionParser.Parse(eventlog.LogResults{raw}, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "columbusv1.ParseTxs pair_action tx_hash=%s", tx.Hash)
 		}
 		pairTxs = append(pairTxs, ptxs...)
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "columbusv1.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "parseTxs")
+			return nil, errors.Wrapf(err, "columbusv1.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}
 		transferTxs = append(transferTxs, transfers...)
 	}

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -64,7 +64,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+		return nil, errors.Wrapf(err, "columbusv2.ParseTxs create_pair tx_hash=%s", tx.Hash)
 	}
 	for _, ctx := range createPairTxs {
 		p.pairs[ctx.ContractAddr] = dex.Pair{
@@ -88,7 +88,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		ptxs, err := p.Parsers.PairActionParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "columbusv2.ParseTxs pair_action tx_hash=%s", tx.Hash)
 		}
 		pairTxs = append(pairTxs, ptxs...)
 
@@ -96,20 +96,20 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		if p.HasProvide(ptxs) {
 			ipTxs, err := p.Parsers.InitialProvide.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 			if err != nil {
-				return nil, errors.Wrap(err, "parseTxs")
+				return nil, errors.Wrapf(err, "columbusv2.ParseTxs initial_provide tx_hash=%s", tx.Hash)
 			}
 			pairTxs = append(pairTxs, ipTxs...)
 		}
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "columbusv2.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
 		tTxs, err := p.Parsers.TaxPaymentParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "columbusv2.ParseTxs tax_payment tx_hash=%s", tx.Hash)
 		}
 		taxTxs = append(taxTxs, tTxs...)
 
@@ -121,19 +121,19 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			}
 			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
 			if err != nil {
-				return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+				return nil, errors.Wrapf(err, "columbusv2.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
 			}
 			raw.Attributes = *attrs
 		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "columbusv2.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}
 		transferTxs = append(transferTxs, transfers...)
 
 		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "columbusv2.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "columbusv2.ParseTxs burn tx_hash=%s", tx.Hash)
 		}
 		burnTxs = append(burnTxs, burns...)
 	}

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -56,7 +56,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	txDtos := []dex.ParsedTx{}
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
-		return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+		return nil, errors.Wrapf(err, "phoenix.ParseTxs create_pair tx_hash=%s", tx.Hash)
 	}
 	for _, ctx := range createPairTxs {
 		p.pairs[ctx.ContractAddr] = dex.Pair{
@@ -79,21 +79,21 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		ptxs, err := p.Parsers.PairActionParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "phoenix.ParseTxs pair_action tx_hash=%s", tx.Hash)
 		}
 		pairTxs = append(pairTxs, ptxs...)
 		// find initial provide to a pair
 		if p.HasProvide(ptxs) {
 			ipTxs, err := p.Parsers.InitialProvide.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 			if err != nil {
-				return nil, errors.Wrap(err, "parseTxs")
+				return nil, errors.Wrapf(err, "phoenix.ParseTxs initial_provide tx_hash=%s", tx.Hash)
 			}
 			pairTxs = append(pairTxs, ipTxs...)
 		}
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "phoenix.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
@@ -105,19 +105,19 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			}
 			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
 			if err != nil {
-				return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+				return nil, errors.Wrapf(err, "phoenix.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
 			}
 			raw.Attributes = *attrs
 		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "phoenix.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}
 		transferTxs = append(transferTxs, transfers...)
 
 		burns, err := p.Parsers.BurnParser.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrap(err, "phoenix.terraswapApp.ParseTxs")
+			return nil, errors.Wrapf(err, "phoenix.ParseTxs burn tx_hash=%s", tx.Hash)
 		}
 		burnTxs = append(burnTxs, burns...)
 	}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Parser errors during `ParseTxs` did not include enough outer context to quickly identify the transaction and parser stage that caused the failure. This made production debugging slower because logs preserved the mapper error chain, but not the source tx hash or the `ParseTxs` stage that invoked it.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This PR adds `tx_hash` and stage context to all DEX-specific `ParseTxs` error returns.
Updated `ParseTxs` implementations now wrap errors with a consistent format: `<dex>.ParseTxs <stage> tx_hash=<hash>`

Covered stages include `create_pair`, `pair_action`, `initial_provide`, `wasm_transfer`, `tax_payment`, `sort_transfer_attrs`, `transfer`, and `burn` where applicable.

The existing lower-level error wrapping is preserved, so final errors still include mapper/parser details while also exposing the failing transaction hash and high-level parse stage.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messages with transaction hash and parsing stage details for improved diagnostics when transaction parsing fails across DEX modules.

* **Tests**
  * Added comprehensive unit tests for transaction parsing workflows, including pair state updates, initial provide logic, and error handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->