### PR TITLE
feat: add quarantine retry mode to store and skip erroneous transactions

### DIFF
--- a/configs/config.go
+++ b/configs/config.go
@@ -21,6 +21,7 @@ var defaultConfig = Config{
 	Collector: defaultCollectorConfig(),
 	Parser: ParserConfig{
 		DexConfig: ParserDexConfig{
+			QuarantineRetryMode: QuarantineRetryDisabled,
 			NodeConfig: NodeConfig{
 				HttpClientConfig: defaultHttpClientConfig,
 			},

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -307,6 +307,7 @@ func Test_ParserConfig_EnvVars(t *testing.T) {
 	t.Setenv("APP_PARSER_DEX_FACTORYADDRESS", "terra1factory")
 	t.Setenv("APP_PARSER_DEX_SAMEHEIGHTTOLERANCE", "5")
 	t.Setenv("APP_PARSER_DEX_ERRTOLERANCE", "2")
+	t.Setenv("APP_PARSER_DEX_QUARANTINERETRYMODE", "every_run")
 	t.Setenv("APP_PARSER_DEX_NODE_GRPC_HOST", "grpc.example.com")
 	t.Setenv("APP_PARSER_DEX_NODE_GRPC_PORT", "9090")
 	t.Setenv("APP_PARSER_DEX_NODE_FAILOVER_LCD_HOST", "lcd-failover.example.com")
@@ -322,11 +323,45 @@ func Test_ParserConfig_EnvVars(t *testing.T) {
 	require.Equal(t, "terra1factory", p.FactoryAddress)
 	require.Equal(t, uint(5), p.SameHeightTolerance)
 	require.Equal(t, uint(2), p.ErrTolerance)
+	require.Equal(t, QuarantineRetryEveryRun, p.QuarantineRetryMode)
 	require.Equal(t, "grpc.example.com", p.NodeConfig.GrpcConfig.Host)
 	require.Equal(t, 9090, p.NodeConfig.GrpcConfig.Port)
 	require.Equal(t, "lcd-failover.example.com", p.NodeConfig.FailoverLcdHost)
 	require.Equal(t, "https://lcd.example.com", p.NodeConfig.RestClientConfig.LcdHost)
 	require.Equal(t, "https://rpc.example.com", p.NodeConfig.RestClientConfig.RpcHost)
+}
+
+func Test_ParserConfig_QuarantineRetryMode(t *testing.T) {
+	base := ParserDexConfig{
+		ChainId:        "phoenix-1",
+		FactoryAddress: "terra1factory",
+		TargetApp:      "terraswap",
+	}
+
+	for _, mode := range []QuarantineRetryMode{
+		"",
+		QuarantineRetryDisabled,
+		QuarantineRetryStartup,
+		QuarantineRetryEveryRun,
+	} {
+		config := base
+		config.QuarantineRetryMode = mode
+		require.NoError(t, config.Validate())
+	}
+
+	config := base
+	config.QuarantineRetryMode = "sometimes"
+	require.EqualError(t, config.Validate(), "invalid quarantine retry mode(sometimes)")
+}
+
+func Test_ParserConfig_QuarantineRetryModeDefault(t *testing.T) {
+	t.Setenv("APP_LOG_ENV", "local")
+	t.Setenv("APP_LOG_CHAINID", "testnet-1")
+
+	tmp := t.TempDir()
+	defer withTestBasepath(t, tmp)()
+
+	require.Equal(t, QuarantineRetryDisabled, New().Parser.DexConfig.QuarantineRetryMode)
 }
 
 func Test_HttpClientConfig_EnvVars(t *testing.T) {

--- a/configs/parser.config.go
+++ b/configs/parser.config.go
@@ -11,24 +11,41 @@ const (
 	PARSER_VALIDATION_INTERVAL    = 1000
 )
 
+type QuarantineRetryMode string
+
+const (
+	QuarantineRetryDisabled QuarantineRetryMode = "disabled"
+	QuarantineRetryStartup  QuarantineRetryMode = "startup"
+	QuarantineRetryEveryRun QuarantineRetryMode = "every_run"
+)
+
 type ParserConfig struct {
 	DexConfig ParserDexConfig `mapstructure:"dex"`
 }
 
 type ParserDexConfig struct {
-	ChainId              string      `mapstructure:"chainid"`
-	FactoryAddress       string      `mapstructure:"factoryaddress"`
-	TargetApp            dex.DexType `mapstructure:"targetapp"`
-	SameHeightTolerance  uint        `mapstructure:"sameheighttolerance"`
-	ErrTolerance         uint        `mapstructure:"errtolerance"`
-	PoolSnapshotInterval uint        `mapstructure:"poolsnapshotinterval"`
-	ValidationInterval   uint        `mapstructure:"validationinterval"`
-	NodeConfig           NodeConfig  `mapstructure:"node"`
+	ChainId              string              `mapstructure:"chainid"`
+	FactoryAddress       string              `mapstructure:"factoryaddress"`
+	TargetApp            dex.DexType         `mapstructure:"targetapp"`
+	SameHeightTolerance  uint                `mapstructure:"sameheighttolerance"`
+	ErrTolerance         uint                `mapstructure:"errtolerance"`
+	PoolSnapshotInterval uint                `mapstructure:"poolsnapshotinterval"`
+	ValidationInterval   uint                `mapstructure:"validationinterval"`
+	QuarantineRetryMode  QuarantineRetryMode `mapstructure:"quarantineretrymode"`
+	NodeConfig           NodeConfig          `mapstructure:"node"`
 }
 
 func (c ParserDexConfig) Validate() error {
 	if c.ChainId == "" || c.FactoryAddress == "" || c.TargetApp == dex.Unknown {
 		return errors.New("required field is missing.")
+	}
+	if c.QuarantineRetryMode == "" {
+		return nil
+	}
+	switch c.QuarantineRetryMode {
+	case QuarantineRetryDisabled, QuarantineRetryStartup, QuarantineRetryEveryRun:
+	default:
+		return errors.Errorf("invalid quarantine retry mode(%s)", c.QuarantineRetryMode)
 	}
 
 	return nil

--- a/db/migrations/parser/20260608120000_parse_quarantine.down.sql
+++ b/db/migrations/parser/20260608120000_parse_quarantine.down.sql
@@ -1,0 +1,3 @@
+BEGIN;
+DROP TABLE IF EXISTS "parse_quarantine";
+COMMIT;

--- a/db/migrations/parser/20260608120000_parse_quarantine.up.sql
+++ b/db/migrations/parser/20260608120000_parse_quarantine.up.sql
@@ -1,0 +1,24 @@
+BEGIN;
+
+CREATE TABLE "parse_quarantine" (
+  "id"          BIGSERIAL NOT NULL PRIMARY KEY,
+  "chain_id"    VARCHAR NOT NULL, CHECK("chain_id" <> ''),
+  "height"      BIGINT NOT NULL, CHECK("height" >= 0),
+  "hash"        VARCHAR NOT NULL, CHECK("hash" <> ''),
+  "stage"       VARCHAR NOT NULL, CHECK("stage" <> ''),
+  "contract"    VARCHAR NOT NULL DEFAULT '',
+  "action"      VARCHAR NOT NULL DEFAULT '',
+  "error"       TEXT NOT NULL, CHECK("error" <> ''),
+  "raw_tx"      JSONB NOT NULL,
+  "status"      VARCHAR NOT NULL DEFAULT 'pending',
+  "resolved_at" DOUBLE PRECISION,
+  "created_at"  DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+  "updated_at"  DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
+  CONSTRAINT parse_quarantine_chain_hash_unique UNIQUE ("chain_id", "hash"),
+  CONSTRAINT parse_quarantine_status_check CHECK ("status" IN ('pending', 'resolved'))
+);
+
+CREATE INDEX parse_quarantine_pending_height_idx
+  ON parse_quarantine ("chain_id", "status", "height");
+
+COMMIT;

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -22,6 +22,7 @@ parser:
     targetApp: # dezswap, terraswap
     poolSnapshotInterval: # uint save pools' status every interval default 1000
     validationInterval: # uint validate every interval default 1000
+    quarantineRetryMode: disabled # disabled, startup, every_run
     node:
       rest:
         lcd:

--- a/parser/checkpoint/builder_test.go
+++ b/parser/checkpoint/builder_test.go
@@ -56,6 +56,18 @@ func (m *MockRepo) ClearValidationHeight() error {
 	return nil
 }
 
+func (m *MockRepo) UpsertParseQuarantine(_ dex.ParseQuarantine) error {
+	return nil
+}
+
+func (m *MockRepo) PendingParseQuarantines() ([]dex.ParseQuarantine, error) {
+	return nil, nil
+}
+
+func (m *MockRepo) ResolveParseQuarantine(_ uint64, _ uint64, _ []dex.ParsedTx) error {
+	return nil
+}
+
 // MockSourceDataStore implements pdex.SourceDataStore for testing
 type MockSourceDataStore struct {
 	syncedHeight uint64

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -84,6 +84,9 @@ func (app *dexApp) Run() error {
 		if err := app.retryPendingQuarantines(tokenExceptions); err != nil {
 			return fmt.Errorf("app.Run retry quarantine: %w", err)
 		}
+		if app.quarantineRetryMode == configs.QuarantineRetryStartup {
+			app.startupRetryAttempted = true
+		}
 	}
 
 	localSynced, err := app.GetSyncedHeight()
@@ -179,11 +182,7 @@ func (app *dexApp) shouldRetryQuarantine() bool {
 	case configs.QuarantineRetryEveryRun:
 		return true
 	case configs.QuarantineRetryStartup:
-		if app.startupRetryAttempted {
-			return false
-		}
-		app.startupRetryAttempted = true
-		return true
+		return !app.startupRetryAttempted
 	default:
 		return false
 	}

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 )
 
@@ -45,6 +46,9 @@ type dexApp struct {
 	validationMu                 sync.Mutex
 	validationSignal             chan struct{}
 	latestValidationSyncedHeight uint64
+
+	quarantineRetryMode   configs.QuarantineRetryMode
+	startupRetryAttempted bool
 }
 
 type DexMixin struct{}
@@ -53,6 +57,10 @@ var _ parser.ParserApp[ParsedTx] = &dexApp{}
 var _ DexParserApp = &dexApp{}
 
 func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger logging.Logger, c configs.ParserDexConfig) parser.ParserApp[ParsedTx] {
+	retryMode := c.QuarantineRetryMode
+	if retryMode == "" {
+		retryMode = configs.QuarantineRetryDisabled
+	}
 	return &dexApp{
 		TargetApp:            app,
 		SourceDataStore:      srcStore,
@@ -63,6 +71,7 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 		poolSnapshotInterval: c.PoolSnapshotInterval,
 		validationInterval:   c.ValidationInterval,
 		validationSignal:     make(chan struct{}, 1),
+		quarantineRetryMode:  retryMode,
 	}
 }
 
@@ -70,6 +79,11 @@ func (app *dexApp) Run() error {
 	tokenExceptions, err := app.GetTokenExceptions()
 	if err != nil {
 		return fmt.Errorf("app.Run: %w", err)
+	}
+	if app.shouldRetryQuarantine() {
+		if err := app.retryPendingQuarantines(tokenExceptions); err != nil {
+			return fmt.Errorf("app.Run retry quarantine: %w", err)
+		}
 	}
 
 	localSynced, err := app.GetSyncedHeight()
@@ -116,6 +130,23 @@ func (app *dexApp) Run() error {
 		for _, tx := range txs {
 			txs, err := app.ParseTxs(tx, cur)
 			if err != nil {
+				var ambiguity *eventlog.AmbiguousEventError
+				if errors.As(err, &ambiguity) && !rawTxContainsCreatePair(tx) {
+					// Raw transactions remain available, so parser progress does not prevent deterministic replay.
+					if err := app.UpsertParseQuarantine(ParseQuarantine{
+						Height:   cur,
+						Hash:     tx.Hash,
+						Stage:    parseStage(err),
+						Contract: ambiguity.Contract,
+						Action:   ambiguity.Action,
+						Error:    err.Error(),
+						RawTx:    tx,
+					}); err != nil {
+						return fmt.Errorf("app.Run quarantine tx_hash=%s: %w", tx.Hash, err)
+					}
+					app.logger.Errorf("quarantined ambiguous transaction height=%d tx_hash=%s err=%s", cur, tx.Hash, err)
+					continue
+				}
 				return fmt.Errorf("app.Run: %w", err)
 			}
 			parsedTxs = append(parsedTxs, txs...)
@@ -140,6 +171,83 @@ func (app *dexApp) Run() error {
 	app.lastSrcHeight = srcHeight
 
 	return nil
+}
+
+// shouldRetryQuarantine applies the configured retry mode to each parser run.
+func (app *dexApp) shouldRetryQuarantine() bool {
+	switch app.quarantineRetryMode {
+	case configs.QuarantineRetryEveryRun:
+		return true
+	case configs.QuarantineRetryStartup:
+		if app.startupRetryAttempted {
+			return false
+		}
+		app.startupRetryAttempted = true
+		return true
+	default:
+		return false
+	}
+}
+
+// retryPendingQuarantines replays unresolved raw transactions and resolves only successful parses.
+func (app *dexApp) retryPendingQuarantines(tokenExceptions map[string]bool) error {
+	quarantines, err := app.PendingParseQuarantines()
+	if err != nil {
+		return err
+	}
+
+	for _, quarantine := range quarantines {
+		if err := app.UpdateParsers(tokenExceptions, quarantine.Height); err != nil {
+			return fmt.Errorf("update parsers for quarantine id=%d: %w", quarantine.ID, err)
+		}
+		txs, err := app.ParseTxs(quarantine.RawTx, quarantine.Height)
+		if err != nil {
+			var ambiguity *eventlog.AmbiguousEventError
+			if errors.As(err, &ambiguity) {
+				continue
+			}
+			return fmt.Errorf("reparse quarantine id=%d tx_hash=%s: %w", quarantine.ID, quarantine.Hash, err)
+		}
+		if err := app.ResolveParseQuarantine(quarantine.ID, quarantine.Height, txs); err != nil {
+			return err
+		}
+		app.logger.Infof("resolved quarantined transaction height=%d tx_hash=%s", quarantine.Height, quarantine.Hash)
+	}
+	return nil
+}
+
+// rawTxContainsCreatePair guards parser state changes from being skipped into quarantine.
+func rawTxContainsCreatePair(tx parser.RawTx) bool {
+	for _, log := range tx.LogResults {
+		for _, attr := range log.Attributes {
+			if attr.Key == "action" && attr.Value == string(CreatePair) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// parseStage extracts the explicit ParseTxs wrapper stage for quarantine diagnostics.
+func parseStage(err error) string {
+	for _, candidate := range []struct {
+		marker string
+		stage  string
+	}{
+		{marker: "ParseTxs create_pair", stage: "create_pair"},
+		{marker: "ParseTxs pair_action", stage: "pair_action"},
+		{marker: "ParseTxs initial_provide", stage: "initial_provide"},
+		{marker: "ParseTxs wasm_transfer", stage: "wasm_transfer"},
+		{marker: "ParseTxs tax_payment", stage: "tax_payment"},
+		{marker: "ParseTxs sort_transfer_attrs", stage: "sort_transfer_attrs"},
+		{marker: "ParseTxs transfer", stage: "transfer"},
+		{marker: "ParseTxs burn", stage: "burn"},
+	} {
+		if strings.Contains(err.Error(), candidate.marker) {
+			return candidate.stage
+		}
+	}
+	return "unknown"
 }
 
 // insert implements parser

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -6,11 +6,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
+
+type quarantineTargetApp struct {
+	parse func(tx parser.RawTx, height uint64) ([]ParsedTx, error)
+}
+
+func (a *quarantineTargetApp) ParseTxs(tx parser.RawTx, height uint64) ([]ParsedTx, error) {
+	return a.parse(tx, height)
+}
+
+func (*quarantineTargetApp) IsValidationExceptionCandidate(string) bool {
+	return false
+}
+
+func (*quarantineTargetApp) UpdateParsers(map[string]bool, uint64) error {
+	return nil
+}
 
 // insert implements parser
 func Test_insert(t *testing.T) {
@@ -94,6 +114,173 @@ func Test_srcHeightCheck(t *testing.T) {
 			app.lastSrcHeight = tc.srcHeight
 		}
 	}
+}
+
+func Test_shouldRetryQuarantine(t *testing.T) {
+	testCases := []struct {
+		name     string
+		mode     configs.QuarantineRetryMode
+		expected []bool
+	}{
+		{name: "disabled", mode: configs.QuarantineRetryDisabled, expected: []bool{false, false}},
+		{name: "startup", mode: configs.QuarantineRetryStartup, expected: []bool{true, false}},
+		{name: "every run", mode: configs.QuarantineRetryEveryRun, expected: []bool{true, true}},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			app := dexApp{quarantineRetryMode: testCase.mode}
+			for _, expected := range testCase.expected {
+				assert.Equal(t, expected, app.shouldRetryQuarantine())
+			}
+		})
+	}
+}
+
+func Test_Run_QuarantinesAmbiguousTransactionAndAdvancesHeight(t *testing.T) {
+	ambiguousTx := parser.RawTx{Hash: "ambiguous"}
+	normalTx := parser.RawTx{Hash: "normal"}
+	expectedTx := ParsedTx{
+		Hash:         normalTx.Hash,
+		Type:         Transfer,
+		Sender:       "sender",
+		ContractAddr: "pair",
+		Assets:       [2]Asset{{Addr: "asset0", Amount: "1"}, {Addr: "asset1", Amount: "0"}},
+	}
+
+	target := &quarantineTargetApp{parse: func(tx parser.RawTx, _ uint64) ([]ParsedTx, error) {
+		if tx.Hash == ambiguousTx.Hash {
+			return nil, &eventlog.AmbiguousEventError{
+				Contract: "token",
+				Action:   "transfer",
+				Key:      "amount",
+				Values:   []string{"1", "2"},
+			}
+		}
+		return []ParsedTx{expectedTx}, nil
+	}}
+	repo := &RepoMock{}
+	srcStore := &RawStoreMock{}
+	app := &dexApp{
+		TargetApp:            target,
+		Repo:                 repo,
+		SourceDataStore:      srcStore,
+		logger:               logging.Discard,
+		poolSnapshotInterval: 100,
+		sameHeightTolerance:  3,
+		quarantineRetryMode:  configs.QuarantineRetryDisabled,
+	}
+
+	repo.On("GetTokenExceptions").Return(map[string]bool{}, nil)
+	repo.On("GetSyncedHeight").Return(uint64(0), nil)
+	srcStore.On("GetSourceSyncedHeight").Return(uint64(1), nil)
+	srcStore.On("GetSourceTxs", uint64(1)).Return(parser.RawTxs{ambiguousTx, normalTx}, nil)
+	repo.On("UpsertParseQuarantine", mock.MatchedBy(func(q ParseQuarantine) bool {
+		return q.Height == 1 &&
+			q.Hash == ambiguousTx.Hash &&
+			q.Stage == "unknown" &&
+			q.Contract == "token" &&
+			q.Action == "transfer"
+	})).Return(nil)
+	repo.On("Insert", uint64(0), uint64(1), []ParsedTx{expectedTx}, []PoolInfo{}, []Pair{}).Return(nil)
+
+	require.NoError(t, app.Run())
+	repo.AssertExpectations(t)
+	srcStore.AssertExpectations(t)
+}
+
+func Test_Run_DoesNotQuarantineCreatePairTransaction(t *testing.T) {
+	tx := parser.RawTx{
+		Hash: "create-pair",
+		LogResults: eventlog.LogResults{{
+			Type: eventlog.WasmType,
+			Attributes: eventlog.Attributes{
+				{Key: "action", Value: string(CreatePair)},
+			},
+		}},
+	}
+	target := &quarantineTargetApp{parse: func(parser.RawTx, uint64) ([]ParsedTx, error) {
+		return nil, &eventlog.AmbiguousEventError{Key: "pair", Values: []string{"a", "b"}}
+	}}
+	repo := &RepoMock{}
+	srcStore := &RawStoreMock{}
+	app := &dexApp{
+		TargetApp:            target,
+		Repo:                 repo,
+		SourceDataStore:      srcStore,
+		logger:               logging.Discard,
+		poolSnapshotInterval: 100,
+		sameHeightTolerance:  3,
+		quarantineRetryMode:  configs.QuarantineRetryDisabled,
+	}
+
+	repo.On("GetTokenExceptions").Return(map[string]bool{}, nil)
+	repo.On("GetSyncedHeight").Return(uint64(0), nil)
+	srcStore.On("GetSourceSyncedHeight").Return(uint64(1), nil)
+	srcStore.On("GetSourceTxs", uint64(1)).Return(parser.RawTxs{tx}, nil)
+
+	err := app.Run()
+	require.Error(t, err)
+	repo.AssertNotCalled(t, "UpsertParseQuarantine", mock.Anything)
+	repo.AssertNotCalled(t, "Insert", mock.Anything)
+}
+
+func Test_retryPendingQuarantines_ResolvesSuccessfulReplay(t *testing.T) {
+	rawTx := parser.RawTx{Hash: "replay"}
+	parsedTx := ParsedTx{
+		Hash:         rawTx.Hash,
+		Type:         Transfer,
+		Sender:       "sender",
+		ContractAddr: "pair",
+		Assets:       [2]Asset{{Addr: "asset0", Amount: "1"}, {Addr: "asset1", Amount: "0"}},
+	}
+	target := &quarantineTargetApp{parse: func(tx parser.RawTx, height uint64) ([]ParsedTx, error) {
+		require.Equal(t, rawTx, tx)
+		require.Equal(t, uint64(10), height)
+		return []ParsedTx{parsedTx}, nil
+	}}
+	repo := &RepoMock{}
+	app := &dexApp{
+		TargetApp: target,
+		Repo:      repo,
+		logger:    logging.Discard,
+	}
+	quarantine := ParseQuarantine{
+		ID:     7,
+		Height: 10,
+		Hash:   rawTx.Hash,
+		RawTx:  rawTx,
+	}
+	repo.On("PendingParseQuarantines").Return([]ParseQuarantine{quarantine}, nil)
+	repo.On("ResolveParseQuarantine", uint64(7), uint64(10), []ParsedTx{parsedTx}).Return(nil)
+
+	require.NoError(t, app.retryPendingQuarantines(map[string]bool{}))
+	repo.AssertExpectations(t)
+}
+
+func Test_retryPendingQuarantines_LeavesAmbiguousReplayPending(t *testing.T) {
+	rawTx := parser.RawTx{Hash: "still-ambiguous"}
+	target := &quarantineTargetApp{parse: func(parser.RawTx, uint64) ([]ParsedTx, error) {
+		return nil, &eventlog.AmbiguousEventError{
+			Key:    "amount",
+			Values: []string{"1", "2"},
+		}
+	}}
+	repo := &RepoMock{}
+	app := &dexApp{
+		TargetApp: target,
+		Repo:      repo,
+		logger:    logging.Discard,
+	}
+	repo.On("PendingParseQuarantines").Return([]ParseQuarantine{{
+		ID:     8,
+		Height: 11,
+		Hash:   rawTx.Hash,
+		RawTx:  rawTx,
+	}}, nil)
+
+	require.NoError(t, app.retryPendingQuarantines(map[string]bool{}))
+	repo.AssertNotCalled(t, "ResolveParseQuarantine", mock.Anything)
 }
 func Test_validate(t *testing.T) {
 	tcs := []struct {

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -116,27 +116,6 @@ func Test_srcHeightCheck(t *testing.T) {
 	}
 }
 
-func Test_shouldRetryQuarantine(t *testing.T) {
-	testCases := []struct {
-		name     string
-		mode     configs.QuarantineRetryMode
-		expected []bool
-	}{
-		{name: "disabled", mode: configs.QuarantineRetryDisabled, expected: []bool{false, false}},
-		{name: "startup", mode: configs.QuarantineRetryStartup, expected: []bool{true, false}},
-		{name: "every run", mode: configs.QuarantineRetryEveryRun, expected: []bool{true, true}},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			app := dexApp{quarantineRetryMode: testCase.mode}
-			for _, expected := range testCase.expected {
-				assert.Equal(t, expected, app.shouldRetryQuarantine())
-			}
-		})
-	}
-}
-
 func Test_Run_QuarantinesAmbiguousTransactionAndAdvancesHeight(t *testing.T) {
 	ambiguousTx := parser.RawTx{Hash: "ambiguous"}
 	normalTx := parser.RawTx{Hash: "normal"}

--- a/parser/dex/dezswap/pair.mappers.go
+++ b/parser/dex/dezswap/pair.mappers.go
@@ -96,7 +96,14 @@ func (m *pairMapperMixin) swapMatchedToParsedTx(res eventlog.MatchedResult, pair
 		return nil, errors.Wrap(err, "pairMapperMixin.swapMatchedToParsedTx")
 	}
 
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.PairSwapOfferAssetKey,
+		pdex.PairSwapOfferAmountKey,
+		pdex.PairSwapReturnAmountKey,
+		pdex.PairSwapSenderKey,
+		pdex.PairSwapCommissionAmountKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapperMixin.swapMatchedToParsedTx")
 	}

--- a/parser/dex/interface.go
+++ b/parser/dex/interface.go
@@ -26,6 +26,9 @@ type Repo interface {
 	GetValidationHeight() (uint64, error)
 	SetValidationHeight(height uint64) error
 	ClearValidationHeight() error
+	UpsertParseQuarantine(quarantine ParseQuarantine) error
+	PendingParseQuarantines() ([]ParseQuarantine, error)
+	ResolveParseQuarantine(id uint64, height uint64, txs []ParsedTx) error
 }
 
 type SourceDataStore interface {

--- a/parser/dex/mapper.go
+++ b/parser/dex/mapper.go
@@ -69,7 +69,13 @@ func (m *wasmCommonTransferMapper) MatchedToParsedTx(res eventlog.MatchedResult,
 		return nil, nil
 	}
 
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		m.cw20AddrKey,
+		pdex.WasmTransferFromKey,
+		pdex.WasmTransferToKey,
+		pdex.WasmTransferAmountKey,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("transferMapper.MatchedToParsedTx: %w (cw20=%s)", err, cw20Addr)
 	}
@@ -148,7 +154,12 @@ func NewTransferMapper(pairSet map[string]Pair) parser.Mapper[ParsedTx] {
 
 // match implements mapper
 func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...interface{}) ([]*ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.TransferSenderKey,
+		pdex.TransferRecipientKey,
+		pdex.TransferAmountKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
@@ -228,7 +239,12 @@ func (m *initialProvideMapper) MatchedToParsedTx(res eventlog.MatchedResult, opt
 	if err := m.CheckResult(res, pdex.PairInitialProvideMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "initialProvideMapper.MatchedToParsedTx")
 	}
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.PairInitialProvideToKey,
+		pdex.PairInitialProvideAddrKey,
+		pdex.PairInitialProvideAmountKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
@@ -252,7 +268,7 @@ func (m *taxPaymentMapper) MatchedToParsedTx(res eventlog.MatchedResult, optiona
 	if err := m.CheckResult(res, pdex.PairTaxPaymentTaxMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "taxPaymentMapper.MatchedToParsedTx")
 	}
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(res, pdex.PairTaxPaymentTaxAmountKey)
 	if err != nil {
 		return nil, errors.Wrap(err, "taxPaymentMapper.MatchedToParsedTx")
 	}
@@ -278,7 +294,12 @@ func (m *burnMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...
 	if err := m.CheckResult(res, pdex.BurnMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "burnMapper.MatchedToParsedTx")
 	}
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.BurnAmountKey,
+		pdex.BurnFromKey,
+		pdex.BurnAddrKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "burnMapper.MatchedToParsedTx")
 	}

--- a/parser/dex/mock.go
+++ b/parser/dex/mock.go
@@ -119,3 +119,18 @@ func (m *RepoMock) SetValidationHeight(_ uint64) error {
 func (m *RepoMock) ClearValidationHeight() error {
 	return nil
 }
+
+func (m *RepoMock) UpsertParseQuarantine(quarantine ParseQuarantine) error {
+	args := m.MethodCalled("UpsertParseQuarantine", quarantine)
+	return args.Error(0)
+}
+
+func (m *RepoMock) PendingParseQuarantines() ([]ParseQuarantine, error) {
+	args := m.MethodCalled("PendingParseQuarantines")
+	return args.Get(0).([]ParseQuarantine), args.Error(1)
+}
+
+func (m *RepoMock) ResolveParseQuarantine(id uint64, height uint64, txs []ParsedTx) error {
+	args := m.MethodCalled("ResolveParseQuarantine", id, height, txs)
+	return args.Error(0)
+}

--- a/parser/dex/quarantine.go
+++ b/parser/dex/quarantine.go
@@ -1,0 +1,21 @@
+package dex
+
+import (
+	"github.com/dezswap/cosmwasm-etl/parser"
+)
+
+const (
+	QuarantineStatusPending  = "pending"
+	QuarantineStatusResolved = "resolved"
+)
+
+type ParseQuarantine struct {
+	ID       uint64
+	Height   uint64
+	Hash     string
+	Stage    string
+	Contract string
+	Action   string
+	Error    string
+	RawTx    parser.RawTx
+}

--- a/parser/dex/repo/repository.go
+++ b/parser/dex/repo/repository.go
@@ -1,15 +1,18 @@
 package repo
 
 import (
+	"encoding/json"
 	"fmt"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
 	"github.com/pkg/errors"
 
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 )
 
 type repoImpl struct {
@@ -212,4 +215,100 @@ func (r *repoImpl) ClearValidationHeight() error {
 		return fmt.Errorf("ClearValidationHeight: no row found for chain_id %s", r.chainId)
 	}
 	return nil
+}
+
+func (r *repoImpl) UpsertParseQuarantine(quarantine dex.ParseQuarantine) error {
+	rawTx, err := json.Marshal(quarantine.RawTx)
+	if err != nil {
+		return errors.Wrap(err, "repo.UpsertParseQuarantine")
+	}
+
+	row := schemas.ParseQuarantine{
+		ChainId:  r.chainId,
+		Height:   quarantine.Height,
+		Hash:     quarantine.Hash,
+		Stage:    quarantine.Stage,
+		Contract: quarantine.Contract,
+		Action:   quarantine.Action,
+		Error:    quarantine.Error,
+		RawTx:    schemas.JSON(rawTx),
+		Status:   dex.QuarantineStatusPending,
+	}
+	tx := r.db.Clauses(clause.OnConflict{
+		Columns: []clause.Column{{Name: "chain_id"}, {Name: "hash"}},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"height":      row.Height,
+			"stage":       row.Stage,
+			"contract":    row.Contract,
+			"action":      row.Action,
+			"error":       row.Error,
+			"raw_tx":      row.RawTx,
+			"status":      row.Status,
+			"resolved_at": nil,
+			"updated_at":  gorm.Expr("EXTRACT(EPOCH FROM NOW())"),
+		}),
+	}).Create(&row)
+	if tx.Error != nil {
+		return errors.Wrap(tx.Error, "repo.UpsertParseQuarantine")
+	}
+	return nil
+}
+
+func (r *repoImpl) PendingParseQuarantines() ([]dex.ParseQuarantine, error) {
+	var rows []schemas.ParseQuarantine
+	tx := r.db.Where("chain_id = ? AND status = ?", r.chainId, dex.QuarantineStatusPending).
+		Order("height ASC, id ASC").
+		Find(&rows)
+	if tx.Error != nil {
+		return nil, errors.Wrap(tx.Error, "repo.PendingParseQuarantines")
+	}
+
+	result := make([]dex.ParseQuarantine, 0, len(rows))
+	for _, row := range rows {
+		var rawTx parser.RawTx
+		if err := json.Unmarshal(row.RawTx, &rawTx); err != nil {
+			return nil, errors.Wrapf(err, "repo.PendingParseQuarantines id=%d", row.Id)
+		}
+		result = append(result, dex.ParseQuarantine{
+			ID:       row.Id,
+			Height:   row.Height,
+			Hash:     row.Hash,
+			Stage:    row.Stage,
+			Contract: row.Contract,
+			Action:   row.Action,
+			Error:    row.Error,
+			RawTx:    rawTx,
+		})
+	}
+	return result, nil
+}
+
+func (r *repoImpl) ResolveParseQuarantine(id uint64, height uint64, txs []dex.ParsedTx) error {
+	parsedTxs := make([]schemas.ParsedTx, 0, len(txs))
+	for _, tx := range txs {
+		parsedTxs = append(parsedTxs, r.toParsedTxModel(r.chainId, height, tx))
+	}
+
+	return r.db.Transaction(func(tx *gorm.DB) error {
+		// The whole transaction is persisted here to avoid partial, non-idempotent replay results.
+		if len(parsedTxs) > 0 {
+			if err := tx.Model(schemas.ParsedTx{}).Omit("Id").CreateInBatches(parsedTxs, len(parsedTxs)).Error; err != nil {
+				return errors.Wrap(err, "repo.ResolveParseQuarantine.ParsedTx")
+			}
+		}
+		result := tx.Model(&schemas.ParseQuarantine{}).
+			Where("id = ? AND chain_id = ? AND status = ?", id, r.chainId, dex.QuarantineStatusPending).
+			Updates(map[string]interface{}{
+				"status":      dex.QuarantineStatusResolved,
+				"resolved_at": gorm.Expr("EXTRACT(EPOCH FROM NOW())"),
+				"updated_at":  gorm.Expr("EXTRACT(EPOCH FROM NOW())"),
+			})
+		if result.Error != nil {
+			return errors.Wrap(result.Error, "repo.ResolveParseQuarantine.Quarantine")
+		}
+		if result.RowsAffected != 1 {
+			return errors.Errorf("repo.ResolveParseQuarantine: pending quarantine not found id=%d", id)
+		}
+		return nil
+	})
 }

--- a/parser/dex/repo/repository_test.go
+++ b/parser/dex/repo/repository_test.go
@@ -2,14 +2,17 @@ package repo
 
 import (
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
 
 	sqlmock "github.com/DATA-DOG/go-sqlmock"
 	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
 	rootdb "github.com/dezswap/cosmwasm-etl/pkg/db"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/faker"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -320,6 +323,74 @@ func (s *validationHeightSuite) Test_ClearValidationHeight() {
 	s.NoError(s.Repo.ClearValidationHeight())
 }
 
+type parseQuarantineSuite struct {
+	baseSuite
+}
+
+func (s *parseQuarantineSuite) Test_UpsertParseQuarantine() {
+	quarantine := dex.ParseQuarantine{
+		Height:   10,
+		Hash:     "tx-hash",
+		Stage:    "wasm_transfer",
+		Contract: "token",
+		Action:   "transfer",
+		Error:    "ambiguous amount",
+		RawTx: parser.RawTx{
+			Hash: "tx-hash",
+		},
+	}
+
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectQuery(`INSERT INTO "parse_quarantine" (.+) ON CONFLICT (.+) DO UPDATE SET (.+)"updated_at"=EXTRACT\(EPOCH FROM NOW\(\)\)(.+)RETURNING "id"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	s.Mock.ExpectCommit()
+
+	s.NoError(s.Repo.UpsertParseQuarantine(quarantine))
+}
+
+func (s *parseQuarantineSuite) Test_PendingParseQuarantines() {
+	rawTx := parser.RawTx{
+		Hash:   "tx-hash",
+		Sender: "sender",
+		LogResults: eventlog.LogResults{{
+			Type: eventlog.WasmType,
+			Attributes: eventlog.Attributes{
+				{Key: "action", Value: "transfer"},
+			},
+		}},
+	}
+	rawTxJSON, err := json.Marshal(rawTx)
+	s.Require().NoError(err)
+
+	rows := sqlmock.NewRows([]string{
+		"id", "chain_id", "height", "hash", "stage", "contract", "action",
+		"error", "raw_tx", "status", "resolved_at",
+	}).AddRow(
+		1, s.Repo.chainId, 10, rawTx.Hash, "wasm_transfer", "token", "transfer",
+		"ambiguous amount", rawTxJSON, dex.QuarantineStatusPending, nil,
+	)
+	s.Mock.ExpectQuery(`SELECT \* FROM "parse_quarantine" WHERE chain_id = \$1 AND status = \$2 ORDER BY height ASC, id ASC`).
+		WithArgs(s.Repo.chainId, dex.QuarantineStatusPending).
+		WillReturnRows(rows)
+
+	quarantines, err := s.Repo.PendingParseQuarantines()
+	s.NoError(err)
+	s.Require().Len(quarantines, 1)
+	s.Equal(rawTx, quarantines[0].RawTx)
+	s.Equal(uint64(10), quarantines[0].Height)
+	s.Equal("wasm_transfer", quarantines[0].Stage)
+}
+
+func (s *parseQuarantineSuite) Test_ResolveParseQuarantine() {
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`UPDATE "parse_quarantine" SET "resolved_at"=EXTRACT\(EPOCH FROM NOW\(\)\),"status"=\$1,"updated_at"=EXTRACT\(EPOCH FROM NOW\(\)\) WHERE id = \$2 AND chain_id = \$3 AND status = \$4`).
+		WithArgs(dex.QuarantineStatusResolved, uint64(1), s.Repo.chainId, dex.QuarantineStatusPending).
+		WillReturnResult(sqlmock.NewResult(0, 1))
+	s.Mock.ExpectCommit()
+
+	s.NoError(s.Repo.ResolveParseQuarantine(1, 10, nil))
+}
+
 func Test_repo(t *testing.T) {
 	dex.FakerCustomGenerator()
 	faker.CustomGenerator()
@@ -328,4 +399,5 @@ func Test_repo(t *testing.T) {
 	suite.Run(t, new(insertSuite))
 	suite.Run(t, new(validationExceptionSuite))
 	suite.Run(t, new(validationHeightSuite))
+	suite.Run(t, new(parseQuarantineSuite))
 }

--- a/parser/dex/starfleit/pair.mappers.go
+++ b/parser/dex/starfleit/pair.mappers.go
@@ -96,7 +96,14 @@ func (m *pairMapperMixin) swapMatchedToParsedTx(res eventlog.MatchedResult, pair
 		return nil, errors.Wrap(err, "pairMapper.swapMatchedToParsedTx")
 	}
 
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.PairSwapOfferAssetKey,
+		pdex.PairSwapOfferAmountKey,
+		pdex.PairSwapReturnAmountKey,
+		pdex.PairSwapSenderKey,
+		pdex.PairSwapCommissionAmountKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapperMixin.swapMatchedToParsedTx")
 	}

--- a/parser/dex/terraswap/columbusv2/mappers.go
+++ b/parser/dex/terraswap/columbusv2/mappers.go
@@ -42,7 +42,16 @@ func (m *pairMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...
 }
 
 func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		columbusv2.PairAddrKey,
+		pdex.PairSwapOfferAssetKey,
+		pdex.PairSwapOfferAmountKey,
+		pdex.PairSwapReturnAmountKey,
+		pdex.PairSwapSenderKey,
+		pdex.PairSwapCommissionAmountKey,
+		pdex.PairSwapTaxAmountKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapper.swapMatchedToParsedTx")
 	}
@@ -81,7 +90,14 @@ func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.
 }
 
 func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		columbusv2.PairAddrKey,
+		columbusv2.PairProvideAssetsKey,
+		columbusv2.PairProvideSenderKey,
+		columbusv2.PairProvideShareKey,
+		columbusv2.PairProvideRefundAssetKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapper.provideMatchedToParsedTx")
 	}
@@ -124,7 +140,13 @@ func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair d
 }
 
 func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		columbusv2.PairAddrKey,
+		columbusv2.PairWithdrawRefundAssetsKey,
+		columbusv2.PairWithdrawSenderKey,
+		columbusv2.PairWithdrawWithdrawShareKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapper.withdrawMatchedToParsedTx")
 	}

--- a/parser/dex/terraswap/phoenix/mappers.go
+++ b/parser/dex/terraswap/phoenix/mappers.go
@@ -42,7 +42,15 @@ func (m *pairMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals ...
 }
 
 func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		phoenix.PairAddrKey,
+		pdex.PairSwapOfferAssetKey,
+		pdex.PairSwapOfferAmountKey,
+		pdex.PairSwapReturnAmountKey,
+		pdex.PairSwapSenderKey,
+		pdex.PairSwapCommissionAmountKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapper.swapMatchedToParsedTx")
 	}
@@ -73,7 +81,14 @@ func (m *pairMapper) swapMatchedToParsedTx(res eventlog.MatchedResult, pair dex.
 }
 
 func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		phoenix.PairAddrKey,
+		phoenix.PairProvideAssetsKey,
+		phoenix.PairProvideSenderKey,
+		phoenix.PairProvideShareKey,
+		phoenix.PairProvideRefundAssetKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapper.provideMatchedToParsedTx")
 	}
@@ -115,7 +130,13 @@ func (m *pairMapper) provideMatchedToParsedTx(res eventlog.MatchedResult, pair d
 }
 
 func (m *pairMapper) withdrawMatchedToParsedTx(res eventlog.MatchedResult, pair dex.Pair) ([]*dex.ParsedTx, error) {
-	matchMap, err := eventlog.ResultToItemMap(res)
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		phoenix.PairAddrKey,
+		phoenix.PairWithdrawRefundAssetsKey,
+		phoenix.PairWithdrawSenderKey,
+		phoenix.PairWithdrawWithdrawShareKey,
+	)
 	if err != nil {
 		return nil, errors.Wrap(err, "pairMapper.withdrawMatchedToParsedTx")
 	}

--- a/pkg/db/schemas/parser.models.go
+++ b/pkg/db/schemas/parser.models.go
@@ -1,6 +1,8 @@
 package schemas
 
-import "github.com/dezswap/cosmwasm-etl/parser/dex"
+import (
+	"github.com/dezswap/cosmwasm-etl/parser/dex"
+)
 
 type Meta map[string]interface{}
 
@@ -64,4 +66,18 @@ type PairValidationException struct {
 type TokenParseException struct {
 	ChainId  string `json:"chainId"`
 	Contract string `json:"contract"`
+}
+
+type ParseQuarantine struct {
+	Id         uint64   `json:"id"`
+	ChainId    string   `json:"chainId"`
+	Height     uint64   `json:"height"`
+	Hash       string   `json:"hash"`
+	Stage      string   `json:"stage"`
+	Contract   string   `json:"contract"`
+	Action     string   `json:"action"`
+	Error      string   `json:"error"`
+	RawTx      JSON     `json:"rawTx"`
+	Status     string   `json:"status"`
+	ResolvedAt *float64 `json:"resolvedAt"`
 }

--- a/pkg/db/schemas/parser.models.gorm.go
+++ b/pkg/db/schemas/parser.models.gorm.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 )
 
+type JSON json.RawMessage
+
 func (ParsedTx) TableName() string {
 	return "parsed_tx"
 }
@@ -24,6 +26,9 @@ func (PairValidationException) TableName() string {
 }
 func (TokenParseException) TableName() string {
 	return "token_parse_exception"
+}
+func (ParseQuarantine) TableName() string {
+	return "parse_quarantine"
 }
 
 func (Meta) GormDataType() string {
@@ -47,4 +52,24 @@ func (j Meta) Value() (driver.Value, error) {
 		return nil, nil
 	}
 	return json.Marshal(j)
+}
+
+func (JSON) GormDataType() string {
+	return "json"
+}
+
+func (j *JSON) Scan(value interface{}) error {
+	bytes, ok := value.([]byte)
+	if !ok {
+		return errors.New(fmt.Sprint("Failed to unmarshal JSON value:", value))
+	}
+	*j = append((*j)[:0], bytes...)
+	return nil
+}
+
+func (j JSON) Value() (driver.Value, error) {
+	if len(j) == 0 {
+		return nil, nil
+	}
+	return []byte(j), nil
 }

--- a/pkg/eventlog/util.go
+++ b/pkg/eventlog/util.go
@@ -3,6 +3,7 @@ package eventlog
 import (
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/pkg/errors"
 )
@@ -37,13 +38,71 @@ func SortAttributes(attrs Attributes, filter []string) (*Attributes, error) {
 	return &filtered, nil
 }
 
-func ResultToItemMap(res MatchedResult) (map[string]MatchedItem, error) {
-	m := make(map[string]MatchedItem)
-	for _, r := range res {
-		if _, ok := m[r.Key]; ok {
-			return nil, errors.New(fmt.Sprintf("duplicated key(%s)", r.Key))
-		}
-		m[r.Key] = r
+type AmbiguousEventError struct {
+	Contract string
+	Action   string
+	Key      string
+	Values   []string
+	MsgIndex int
+}
+
+func (e *AmbiguousEventError) Error() string {
+	return fmt.Sprintf(
+		"ambiguous event key(%s) contract(%s) action(%s) values(%s) msg_index(%d)",
+		e.Key, e.Contract, e.Action, strings.Join(e.Values, ","), e.MsgIndex,
+	)
+}
+
+// ResultToItemMapForKeys returns a single-value map for the event attributes a mapper actually reads.
+//
+// consumedKeys must contain only keys whose values are consumed by the caller. Duplicate attributes
+// outside this list are ignored because Cosmos events permit repeated keys. Duplicate values for a
+// consumed key are returned as AmbiguousEventError; selecting first or last is contract-specific and
+// must be implemented in the protocol mapper, not here.
+func ResultToItemMapForKeys(res MatchedResult, consumedKeys ...string) (map[string]MatchedItem, error) {
+	targets := make(map[string]struct{}, len(consumedKeys))
+	for _, key := range consumedKeys {
+		targets[key] = struct{}{}
 	}
-	return m, nil
+
+	items := make(map[string][]MatchedItem, len(consumedKeys))
+	for _, item := range res {
+		if _, ok := targets[item.Key]; !ok {
+			continue
+		}
+		items[item.Key] = append(items[item.Key], item)
+	}
+
+	result := make(map[string]MatchedItem, len(consumedKeys))
+	for _, key := range consumedKeys {
+		matches := items[key]
+		if len(matches) > 1 {
+			values := make([]string, 0, len(matches))
+			for _, item := range matches {
+				values = append(values, item.Value)
+			}
+			return nil, &AmbiguousEventError{
+				Contract: firstResultValue(res, "_contract_address", "contract_address"),
+				Action:   firstResultValue(res, "action"),
+				Key:      key,
+				Values:   values,
+				MsgIndex: matches[0].MsgIndex,
+			}
+		}
+		if len(matches) == 1 {
+			result[key] = matches[0]
+		}
+	}
+	return result, nil
+}
+
+func firstResultValue(res MatchedResult, keys ...string) string {
+	for _, item := range res {
+		for _, key := range keys {
+			if item.Key == key {
+				return item.Value
+			}
+		}
+	}
+	return ""
 }

--- a/pkg/eventlog/util_test.go
+++ b/pkg/eventlog/util_test.go
@@ -1,7 +1,9 @@
 package eventlog
 
 import (
+	"errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"testing"
 )
 
@@ -125,4 +127,36 @@ func TestSortAttributes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResultToItemMapForKeys(t *testing.T) {
+	t.Run("ignores duplicate unused keys", func(t *testing.T) {
+		result, err := ResultToItemMapForKeys(MatchedResult{
+			{Key: "_contract_address", Value: "token"},
+			{Key: "action", Value: "transfer"},
+			{Key: "metadata", Value: "first"},
+			{Key: "metadata", Value: "second"},
+			{Key: "amount", Value: "10"},
+		}, "amount")
+
+		require.NoError(t, err)
+		require.Equal(t, "10", result["amount"].Value)
+	})
+
+	t.Run("rejects duplicate consumed keys", func(t *testing.T) {
+		_, err := ResultToItemMapForKeys(MatchedResult{
+			{Key: "_contract_address", Value: "token"},
+			{Key: "action", Value: "transfer"},
+			{Key: "amount", Value: "10", MsgIndex: 3},
+			{Key: "amount", Value: "20", MsgIndex: 3},
+		}, "amount")
+
+		var ambiguity *AmbiguousEventError
+		require.True(t, errors.As(err, &ambiguity))
+		require.Equal(t, "token", ambiguity.Contract)
+		require.Equal(t, "transfer", ambiguity.Action)
+		require.Equal(t, "amount", ambiguity.Key)
+		require.Equal(t, []string{"10", "20"}, ambiguity.Values)
+		require.Equal(t, 3, ambiguity.MsgIndex)
+	})
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ambiguous duplicate event attributes can cause transaction parsing to fail. Previously, one such transaction stopped parser progress at that height and required manual intervention.

This change allows ambiguous transactions to be quarantined for diagnosis and later replay, while the parser continues processing other transactions.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Add the `parse_quarantine` table for storing failed raw transactions, parsing context, errors, and resolution status.
- Quarantine `AmbiguousEventError` transactions and continue processing the current block.
- Exclude create-pair transactions from quarantine because skipping them could leave parser pair state inconsistent.
- Add retry modes through `parser.dex.quarantineRetryMode`:
  - `disabled`: do not retry quarantined transactions.
  - `startup`: retry once after process startup.
  - `every_run`: retry at the start of every parser run.
- Resolve successfully replayed transactions atomically by inserting parsed transactions and updating quarantine status.
- Record the failing parse stage, contract, action, raw transaction, and error for diagnostics.

## Migration
Apply the new parser migration before enabling quarantine processing:

```bash
make parser-migrate-up
```

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable quarantine system for transaction parsing failures with retry modes: disabled, on startup, or every run.
  * Ambiguous parsing errors are now captured for diagnostic review instead of immediately failing.

* **Configuration**
  * New `quarantineRetryMode` setting in parser configuration to control how failed transactions are retried.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->