### PR TITLE
feat(aggregator): extend account stats for wallet summaries

### DIFF
--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -209,6 +209,11 @@ func (r *repoMock) CreateAccounts(addresses []string) error {
 	return nil
 }
 
+func (r *repoMock) AccountIds(_ []string) (map[string]uint64, error) {
+	args := r.Mock.MethodCalled("AccountIds")
+	return args.Get(0).(map[string]uint64), args.Error(1)
+}
+
 func (r *repoMock) HoldingPairIds(_ uint64) ([]uint64, error) {
 	args := r.Mock.MethodCalled("HoldingPairIds")
 	return args.Get(0).([]uint64), args.Error(1)

--- a/aggregator/aggregator_test.go
+++ b/aggregator/aggregator_test.go
@@ -22,6 +22,7 @@ type repoMock struct {
 	updatedPairStats       []schemas.PairStats30m
 	updatedAccountStats    []schemas.AccountStats30m
 	updatedAccounts        []string
+	createAccountsErr      error
 }
 
 func TestMain(m *testing.M) {
@@ -171,8 +172,8 @@ func (r *repoMock) PairStats(_ float64, _ float64, _ string, _ map[uint64]schema
 	return args.Get(0).([]schemas.PairStats30m), args.Error(1)
 }
 
-func (r *repoMock) AccountStats(_ float64, _ float64) ([]schemas.AccountStats30m, error) {
-	args := r.Mock.MethodCalled("AccountStats")
+func (r *repoMock) AccountStats(startTs float64, endTs float64, priceToken string) ([]schemas.AccountStats30m, error) {
+	args := r.Mock.MethodCalled("AccountStats", startTs, endTs, priceToken)
 	return args.Get(0).([]schemas.AccountStats30m), args.Error(1)
 }
 
@@ -206,7 +207,7 @@ func (r *repoMock) UpdateAccountStats(stats []schemas.AccountStats30m) error {
 
 func (r *repoMock) CreateAccounts(addresses []string) error {
 	r.updatedAccounts = addresses
-	return nil
+	return r.createAccountsErr
 }
 
 func (r *repoMock) AccountIds(_ []string) (map[string]uint64, error) {

--- a/aggregator/repo/repository.go
+++ b/aggregator/repo/repository.go
@@ -225,14 +225,25 @@ func (r *repoImpl) UpdateAccountStats(stats []schemas.AccountStats30m) error {
 			{Name: "pair_id"},
 		},
 		DoUpdates: clause.Assignments(map[string]interface{}{
-			"year_utc":    gorm.Expr("excluded.year_utc"),
-			"month_utc":   gorm.Expr("excluded.month_utc"),
-			"day_utc":     gorm.Expr("excluded.day_utc"),
-			"hour_utc":    gorm.Expr("excluded.hour_utc"),
-			"minute_utc":  gorm.Expr("excluded.minute_utc"),
-			"address":     gorm.Expr("excluded.address"),
-			"tx_cnt":      gorm.Expr("excluded.tx_cnt"),
-			"modified_at": gorm.Expr("date_part('epoch'::text, now())"),
+			"year_utc":                gorm.Expr("excluded.year_utc"),
+			"month_utc":               gorm.Expr("excluded.month_utc"),
+			"day_utc":                 gorm.Expr("excluded.day_utc"),
+			"hour_utc":                gorm.Expr("excluded.hour_utc"),
+			"minute_utc":              gorm.Expr("excluded.minute_utc"),
+			"address":                 gorm.Expr("excluded.address"),
+			"tx_cnt":                  gorm.Expr("excluded.tx_cnt"),
+			"swap_tx_cnt":             gorm.Expr("excluded.swap_tx_cnt"),
+			"provide_tx_cnt":          gorm.Expr("excluded.provide_tx_cnt"),
+			"withdraw_tx_cnt":         gorm.Expr("excluded.withdraw_tx_cnt"),
+			"swap_volume_in_price":    gorm.Expr("excluded.swap_volume_in_price"),
+			"provide_value_in_price":  gorm.Expr("excluded.provide_value_in_price"),
+			"withdraw_value_in_price": gorm.Expr("excluded.withdraw_value_in_price"),
+			"net_flow_in_price":       gorm.Expr("excluded.net_flow_in_price"),
+			"price_token":             gorm.Expr("excluded.price_token"),
+			"net_asset0_amount":       gorm.Expr("excluded.net_asset0_amount"),
+			"net_asset1_amount":       gorm.Expr("excluded.net_asset1_amount"),
+			"net_lp_amount":           gorm.Expr("excluded.net_lp_amount"),
+			"modified_at":             gorm.Expr("date_part('epoch'::text, now())"),
 		}),
 	}).Create(&stats)
 	if tx.Error != nil {
@@ -294,8 +305,8 @@ func (r *repoImpl) HoldingPairIds(accountId uint64) ([]uint64, error) {
 	query := `
 SELECT pair_id
 FROM (
-    SELECT pair_id, SUM(total_lp_amount) stla
-    FROM h_account_stats_30m
+    SELECT pair_id, SUM(net_lp_amount) stla
+    FROM account_stats_30m
     WHERE chain_id = $1
       AND account_id = $2
     GROUP BY pair_id) t
@@ -330,8 +341,8 @@ SELECT id, address
 FROM account
 WHERE id IN (
     SELECT t.account_id
-    FROM (SELECT account_id, SUM(total_lp_amount) tla_sum
-    	  FROM h_account_stats_30m
+    FROM (SELECT account_id, SUM(net_lp_amount) tla_sum
+    	  FROM account_stats_30m
           WHERE chain_id = $1
           GROUP BY account_id) t
     WHERE t.tla_sum > 0

--- a/aggregator/repo/repository.go
+++ b/aggregator/repo/repository.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"gorm.io/gorm/clause"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/pkg/db"
@@ -37,6 +38,7 @@ type Repo interface {
 	UpdatePairStats(stats []schemas.PairStats30m) error
 	UpdateAccountStats(stats []schemas.AccountStats30m) error
 	CreateAccounts(addresses []string) error
+	AccountIds(addresses []string) (map[string]uint64, error)
 	HoldingPairIds(accountId uint64) ([]uint64, error)
 	Accounts(endTs float64) (map[uint64]string, error)
 	Close() error
@@ -211,7 +213,29 @@ func (r *repoImpl) UpdatePairStats(stats []schemas.PairStats30m) error {
 }
 
 func (r *repoImpl) UpdateAccountStats(stats []schemas.AccountStats30m) error {
-	if tx := r.db.Omit("Id", "CreatedAt").Create(&stats); tx.Error != nil {
+	if len(stats) == 0 {
+		return nil
+	}
+
+	tx := r.db.Omit("Id", "CreatedAt").Clauses(clause.OnConflict{
+		Columns: []clause.Column{
+			{Name: "chain_id"},
+			{Name: "timestamp"},
+			{Name: "account_id"},
+			{Name: "pair_id"},
+		},
+		DoUpdates: clause.Assignments(map[string]interface{}{
+			"year_utc":    gorm.Expr("excluded.year_utc"),
+			"month_utc":   gorm.Expr("excluded.month_utc"),
+			"day_utc":     gorm.Expr("excluded.day_utc"),
+			"hour_utc":    gorm.Expr("excluded.hour_utc"),
+			"minute_utc":  gorm.Expr("excluded.minute_utc"),
+			"address":     gorm.Expr("excluded.address"),
+			"tx_cnt":      gorm.Expr("excluded.tx_cnt"),
+			"modified_at": gorm.Expr("date_part('epoch'::text, now())"),
+		}),
+	}).Create(&stats)
+	if tx.Error != nil {
 		return tx.Error
 	}
 
@@ -246,6 +270,24 @@ INSERT INTO account(address) VALUES($1) ON CONFLICT DO NOTHING
 	}
 
 	return nil
+}
+
+func (r *repoImpl) AccountIds(addresses []string) (map[string]uint64, error) {
+	if len(addresses) == 0 {
+		return map[string]uint64{}, nil
+	}
+
+	var accounts []schemas.Account
+	if tx := r.db.Model(schemas.Account{}).Where("address in ?", addresses).Find(&accounts); tx.Error != nil {
+		return nil, tx.Error
+	}
+
+	accountIds := make(map[string]uint64, len(accounts))
+	for _, account := range accounts {
+		accountIds[account.Address] = account.Id
+	}
+
+	return accountIds, nil
 }
 
 func (r *repoImpl) HoldingPairIds(accountId uint64) ([]uint64, error) {

--- a/aggregator/repo/repository_test.go
+++ b/aggregator/repo/repository_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/dezswap/cosmwasm-etl/pkg/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gorm.io/gorm"
 )
 
@@ -39,30 +40,49 @@ var (
 
 	accountStats = []schemas.AccountStats30m{
 		{
-			YearUtc:   2022,
-			MonthUtc:  10,
-			DayUtc:    13,
-			HourUtc:   4,
-			MinuteUtc: 30,
-			Timestamp: 1665636627,
-			ChainId:   chainName,
-			AccountId: accounts[0].Id,
-			Address:   accounts[0].Address,
-			PairId:    0,
-			TxCnt:     2,
+			YearUtc:              2022,
+			MonthUtc:             10,
+			DayUtc:               13,
+			HourUtc:              4,
+			MinuteUtc:            30,
+			Timestamp:            1665636627,
+			ChainId:              chainName,
+			AccountId:            accounts[0].Id,
+			Address:              accounts[0].Address,
+			PairId:               0,
+			TxCnt:                2,
+			SwapTxCnt:            1,
+			ProvideTxCnt:         1,
+			SwapVolumeInPrice:    "10",
+			ProvideValueInPrice:  "20",
+			WithdrawValueInPrice: "0",
+			NetFlowInPrice:       "30",
+			PriceToken:           "uusd",
+			NetAsset0Amount:      "100",
+			NetAsset1Amount:      "200",
+			NetLpAmount:          "300",
 		},
 		{
-			YearUtc:   2022,
-			MonthUtc:  10,
-			DayUtc:    13,
-			HourUtc:   4,
-			MinuteUtc: 30,
-			Timestamp: 1665636627,
-			ChainId:   chainName,
-			AccountId: accounts[1].Id,
-			Address:   accounts[1].Address,
-			PairId:    1,
-			TxCnt:     1,
+			YearUtc:              2022,
+			MonthUtc:             10,
+			DayUtc:               13,
+			HourUtc:              4,
+			MinuteUtc:            30,
+			Timestamp:            1665636627,
+			ChainId:              chainName,
+			AccountId:            accounts[1].Id,
+			Address:              accounts[1].Address,
+			PairId:               1,
+			TxCnt:                1,
+			ProvideTxCnt:         1,
+			SwapVolumeInPrice:    "0",
+			ProvideValueInPrice:  "50",
+			WithdrawValueInPrice: "0",
+			NetFlowInPrice:       "50",
+			PriceToken:           "uusd",
+			NetAsset0Amount:      "1000",
+			NetAsset1Amount:      "2000",
+			NetLpAmount:          "400",
 		},
 	}
 )
@@ -178,6 +198,11 @@ func TestUpdateAccountStats(t *testing.T) {
 
 	expected := schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 3, 1, "xplaaabb")
 	expected.TxCnt = 1
+	expected.SwapTxCnt = 1
+	expected.SwapVolumeInPrice = "100"
+	expected.PriceToken = "uusd"
+	expected.NetAsset0Amount = "-1000000"
+	expected.NetAsset1Amount = "2000000"
 
 	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
 	assert.NoError(err)
@@ -207,6 +232,92 @@ func TestUpdateAccountStats(t *testing.T) {
 	assert.Equal(expected.Address, actual[0].Address)
 	assert.Equal(expected.PairId, actual[0].PairId)
 	assert.Equal(expected.TxCnt, actual[0].TxCnt)
+	assert.Equal(expected.SwapTxCnt, actual[0].SwapTxCnt)
+	assert.Equal(expected.SwapVolumeInPrice, actual[0].SwapVolumeInPrice)
+	assert.Equal(expected.PriceToken, actual[0].PriceToken)
+	assert.Equal(expected.NetAsset0Amount, actual[0].NetAsset0Amount)
+	assert.Equal(expected.NetAsset1Amount, actual[0].NetAsset1Amount)
+}
+
+func TestUpdateAccountStatsUpsertsOnAccountIdPairTimestamp(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	ts := util.ToTime(1665637200)
+	initial := schemas.NewAccountStat30min(chainName, ts, 3, 1, "terra0old")
+	initial.TxCnt = 1
+	initial.SwapTxCnt = 1
+	initial.SwapVolumeInPrice = "100"
+	initial.PriceToken = "uusd"
+	initial.NetAsset0Amount = "10"
+	initial.NetAsset1Amount = "20"
+	initial.NetLpAmount = "30"
+
+	updated := schemas.NewAccountStat30min(chainName, ts, 3, 1, "terra0new")
+	updated.TxCnt = 7
+	updated.SwapTxCnt = 2
+	updated.ProvideTxCnt = 3
+	updated.WithdrawTxCnt = 2
+	updated.SwapVolumeInPrice = "200"
+	updated.ProvideValueInPrice = "300"
+	updated.WithdrawValueInPrice = "400"
+	updated.NetFlowInPrice = "500"
+	updated.PriceToken = "uusd"
+	updated.NetAsset0Amount = "-60"
+	updated.NetAsset1Amount = "70"
+	updated.NetLpAmount = "-80"
+
+	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(gormDb.Exec(`TRUNCATE TABLE account_stats_30m`).Error)
+
+	repo := New(chainName, testConfig.Aggregator.DestDb)
+	defer repo.Close()
+	require.NoError(repo.UpdateAccountStats([]schemas.AccountStats30m{initial}))
+	require.NoError(repo.UpdateAccountStats([]schemas.AccountStats30m{updated}))
+
+	var count int64
+	require.NoError(gormDb.Model(&schemas.AccountStats30m{}).Count(&count).Error)
+	assert.EqualValues(1, count)
+
+	var actual schemas.AccountStats30m
+	require.NoError(gormDb.First(&actual).Error)
+	assert.Equal(updated.Address, actual.Address)
+	assert.Equal(updated.TxCnt, actual.TxCnt)
+	assert.Equal(updated.SwapTxCnt, actual.SwapTxCnt)
+	assert.Equal(updated.ProvideTxCnt, actual.ProvideTxCnt)
+	assert.Equal(updated.WithdrawTxCnt, actual.WithdrawTxCnt)
+	assert.Equal(updated.SwapVolumeInPrice, actual.SwapVolumeInPrice)
+	assert.Equal(updated.ProvideValueInPrice, actual.ProvideValueInPrice)
+	assert.Equal(updated.WithdrawValueInPrice, actual.WithdrawValueInPrice)
+	assert.Equal(updated.NetFlowInPrice, actual.NetFlowInPrice)
+	assert.Equal(updated.NetAsset0Amount, actual.NetAsset0Amount)
+	assert.Equal(updated.NetAsset1Amount, actual.NetAsset1Amount)
+	assert.Equal(updated.NetLpAmount, actual.NetLpAmount)
+}
+
+func TestUpdateAccountStatsNoopOnEmptyInput(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(gormDb.Exec(`TRUNCATE TABLE account_stats_30m`).Error)
+
+	existing := schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 3, 1, "terra0existing")
+	existing.TxCnt = 1
+	require.NoError(gormDb.Omit("Id", "CreatedAt").Create(&existing).Error)
+
+	repo := New(chainName, testConfig.Aggregator.DestDb)
+	defer repo.Close()
+	err = repo.UpdateAccountStats([]schemas.AccountStats30m{})
+
+	var count int64
+	require.NoError(gormDb.Model(&schemas.AccountStats30m{}).Count(&count).Error)
+	assert.NoError(err)
+	assert.EqualValues(1, count)
 }
 
 func TestCreateAccounts(t *testing.T) {
@@ -244,6 +355,28 @@ func TestCreateAccounts(t *testing.T) {
 	assert.EqualValues(expected, actual)
 }
 
+func TestAccountIdsReturnsOnlyExistingAccounts(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
+	require.NoError(err)
+	defer db.Close()
+
+	createTestAccounts(gormDb)
+
+	repo := New(chainName, testConfig.Aggregator.DestDb)
+	defer repo.Close()
+	actual, err := repo.AccountIds([]string{accounts[0].Address, "terra0missing"})
+
+	assert.NoError(err)
+	assert.Equal(map[string]uint64{accounts[0].Address: accounts[0].Id}, actual)
+
+	empty, err := repo.AccountIds([]string{})
+	assert.NoError(err)
+	assert.Empty(empty)
+}
+
 func TestHoldingPairIds(t *testing.T) {
 	assert := assert.New(t)
 
@@ -263,6 +396,33 @@ func TestHoldingPairIds(t *testing.T) {
 	// verify
 	assert.NoError(err)
 	assert.EqualValues(expected, actual)
+}
+
+func TestHoldingPairIdsExcludesZeroOrNegativeNetLp(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	db, gormDb, err := initDb(testConfig.Aggregator.SrcDb)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(gormDb.Exec(`TRUNCATE TABLE account_stats_30m`).Error)
+
+	stats := []schemas.AccountStats30m{
+		schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 1, accounts[0].Id, accounts[0].Address),
+		schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 2, accounts[0].Id, accounts[0].Address),
+		schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 3, accounts[0].Id, accounts[0].Address),
+	}
+	stats[0].NetLpAmount = "10"
+	stats[1].NetLpAmount = "0"
+	stats[2].NetLpAmount = "-5"
+	require.NoError(gormDb.Omit("Id", "CreatedAt").Create(&stats).Error)
+
+	repo := New(chainName, testConfig.Aggregator.SrcDb)
+	defer repo.Close()
+	actual, err := repo.HoldingPairIds(accounts[0].Id)
+
+	assert.NoError(err)
+	assert.EqualValues([]uint64{1}, actual)
 }
 
 func TestAccounts(t *testing.T) {
@@ -288,6 +448,94 @@ func TestAccounts(t *testing.T) {
 	// verify
 	assert.NoError(err)
 	assert.EqualValues(expected, actual)
+}
+
+func TestAccountsIncludesPositiveLpAccountsAndRecentlyCreatedAccounts(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	endTs := float64(2000)
+	oldCreatedAt := float64(1000)
+	recentCreatedAt := float64(2000)
+	testAccounts := []schemas.Account{
+		{Id: 11, Address: "terra0lp", CreatedAt: oldCreatedAt},
+		{Id: 12, Address: "terra0recent", CreatedAt: recentCreatedAt},
+		{Id: 13, Address: "terra0old", CreatedAt: oldCreatedAt},
+	}
+
+	db, gormDb, err := initDb(testConfig.Aggregator.SrcDb)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(gormDb.Exec(`TRUNCATE TABLE account, account_stats_30m`).Error)
+	require.NoError(gormDb.Create(&testAccounts).Error)
+
+	stats := []schemas.AccountStats30m{
+		schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 1, testAccounts[0].Id, testAccounts[0].Address),
+		schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 2, testAccounts[2].Id, testAccounts[2].Address),
+	}
+	stats[0].NetLpAmount = "10"
+	stats[1].NetLpAmount = "0"
+	require.NoError(gormDb.Omit("Id", "CreatedAt").Create(&stats).Error)
+
+	repo := New(chainName, testConfig.Aggregator.SrcDb)
+	defer repo.Close()
+	actual, err := repo.Accounts(endTs)
+
+	assert.NoError(err)
+	assert.Equal(map[uint64]string{
+		testAccounts[0].Id: testAccounts[0].Address,
+		testAccounts[1].Id: testAccounts[1].Address,
+	}, actual)
+}
+
+func TestAccountStats30mMigrationDefaults(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
+	require.NoError(err)
+	defer db.Close()
+	require.NoError(gormDb.Exec(`TRUNCATE TABLE account_stats_30m`).Error)
+	require.NoError(gormDb.Exec(`
+INSERT INTO account_stats_30m (
+    year_utc, month_utc, day_utc, hour_utc, minute_utc,
+    address, account_id, pair_id, chain_id, tx_cnt, timestamp
+) VALUES (
+    2022, 10, 13, 4, 30,
+    'terra0defaults', 1, 1, $1, 1, 1665636627
+)`, chainName).Error)
+
+	var actual schemas.AccountStats30m
+	require.NoError(gormDb.First(&actual).Error)
+	assert.Equal(uint64(0), actual.SwapTxCnt)
+	assert.Equal(uint64(0), actual.ProvideTxCnt)
+	assert.Equal(uint64(0), actual.WithdrawTxCnt)
+	assert.Equal("0", actual.SwapVolumeInPrice)
+	assert.Equal("0", actual.ProvideValueInPrice)
+	assert.Equal("0", actual.WithdrawValueInPrice)
+	assert.Equal("0", actual.NetFlowInPrice)
+	assert.Equal("", actual.PriceToken)
+	assert.Equal("0", actual.NetAsset0Amount)
+	assert.Equal("0", actual.NetAsset1Amount)
+	assert.Equal("0", actual.NetLpAmount)
+}
+
+func TestAccountSchemaDoesNotIncludeProfileColumns(t *testing.T) {
+	assert := assert.New(t)
+	require := require.New(t)
+
+	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
+	require.NoError(err)
+	defer db.Close()
+
+	var count int64
+	require.NoError(gormDb.Raw(`
+SELECT count(*)
+FROM information_schema.columns
+WHERE table_name = 'account'
+  AND column_name IN ('first_seen_at', 'last_seen_at', 'touched_pair_cnt')
+`).Scan(&count).Error)
+	assert.EqualValues(0, count)
 }
 
 func TestClose(t *testing.T) {
@@ -321,7 +569,7 @@ func createTestAccounts(db *gorm.DB) {
 }
 
 func createTestAccountStats(db *gorm.DB) {
-	db.Exec(`TRUNCATE TABLE h_account_stats_30m`)
+	db.Exec(`TRUNCATE TABLE account_stats_30m`)
 
 	for _, stats := range accountStats {
 		db.Omit("Id", "CreatedAt").Create(&stats)

--- a/aggregator/repo/repository_test.go
+++ b/aggregator/repo/repository_test.go
@@ -46,6 +46,7 @@ var (
 			MinuteUtc: 30,
 			Timestamp: 1665636627,
 			ChainId:   chainName,
+			AccountId: accounts[0].Id,
 			Address:   accounts[0].Address,
 			PairId:    0,
 			TxCnt:     2,
@@ -58,6 +59,7 @@ var (
 			MinuteUtc: 30,
 			Timestamp: 1665636627,
 			ChainId:   chainName,
+			AccountId: accounts[1].Id,
 			Address:   accounts[1].Address,
 			PairId:    1,
 			TxCnt:     1,
@@ -174,7 +176,7 @@ func TestUpdatePairStats(t *testing.T) {
 func TestUpdateAccountStats(t *testing.T) {
 	assert := assert.New(t)
 
-	expected := schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 3, "xplaaabb")
+	expected := schemas.NewAccountStat30min(chainName, util.ToTime(1665637200), 3, 1, "xplaaabb")
 	expected.TxCnt = 1
 
 	db, gormDb, err := initDb(testConfig.Aggregator.DestDb)
@@ -201,6 +203,8 @@ func TestUpdateAccountStats(t *testing.T) {
 	assert.Equal(expected.HourUtc, actual[0].HourUtc)
 	assert.Equal(expected.MinuteUtc, actual[0].MinuteUtc)
 	assert.Equal(expected.Timestamp, actual[0].Timestamp)
+	assert.Equal(expected.AccountId, actual[0].AccountId)
+	assert.Equal(expected.Address, actual[0].Address)
 	assert.Equal(expected.PairId, actual[0].PairId)
 	assert.Equal(expected.TxCnt, actual[0].TxCnt)
 }

--- a/aggregator/task.go
+++ b/aggregator/task.go
@@ -695,7 +695,22 @@ func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 	}
 
 	if len(stats) > 0 {
+		addresses := uniqueAccountAddresses(stats)
+		if err := t.destDb.CreateAccounts(addresses); err != nil {
+			return err
+		}
+
+		accountIds, err := t.destDb.AccountIds(addresses)
+		if err != nil {
+			return err
+		}
+
 		for i, s := range stats {
+			accountId, ok := accountIds[s.Address]
+			if !ok {
+				return errors.Errorf("accountStatsUpdateTask.Execute: account id not found for address %s", s.Address)
+			}
+
 			s.YearUtc = end.Year()
 			s.MonthUtc = int(end.Month())
 			s.DayUtc = end.Day()
@@ -703,6 +718,7 @@ func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 			s.MinuteUtc = end.Minute()
 			s.Timestamp = endEpoch
 			s.ChainId = t.chainId
+			s.AccountId = accountId
 			stats[i] = s
 		}
 
@@ -720,6 +736,20 @@ func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 	t.logger.Infof("Complete account stats update for the timeframe '%s - %s'.", start.String(), end.String())
 
 	return nil
+}
+
+func uniqueAccountAddresses(stats []schemas.AccountStats30m) []string {
+	addressMap := make(map[string]bool, len(stats))
+	addresses := make([]string, 0, len(stats))
+	for _, stat := range stats {
+		if addressMap[stat.Address] {
+			continue
+		}
+		addressMap[stat.Address] = true
+		addresses = append(addresses, stat.Address)
+	}
+
+	return addresses
 }
 
 func waitUntilReachingHeight(parentTasks *[]task, targetHeight uint64) {

--- a/aggregator/task.go
+++ b/aggregator/task.go
@@ -84,7 +84,8 @@ type pairStatsRecentUpdateTask struct {
 type accountStatsUpdateTask struct {
 	taskImpl
 
-	srcDb parser.ReadRepository
+	priceToken string
+	srcDb      parser.ReadRepository
 }
 
 func newLpHistoryTask(config configs.AggregatorConfig, srcRepo parser.ReadRepository, destRepo repo.Repo, logger logging.Logger) task {
@@ -659,7 +660,8 @@ func newAccountStatsUpdateTask(config configs.AggregatorConfig, srcRepo parser.R
 			destDb:  destRepo,
 			logger:  logger,
 		},
-		srcDb: srcRepo,
+		priceToken: config.PriceToken,
+		srcDb:      srcRepo,
 	}
 }
 
@@ -689,7 +691,7 @@ func (t *accountStatsUpdateTask) StartTimestamp(startTs time.Time) (time.Time, e
 func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 	startEpoch, endEpoch := util.ToEpoch(start), util.ToEpoch(end)
 
-	stats, err := t.srcDb.AccountStats(startEpoch, endEpoch)
+	stats, err := t.srcDb.AccountStats(startEpoch, endEpoch, t.priceToken)
 	if err != nil {
 		return err
 	}

--- a/aggregator/task_test.go
+++ b/aggregator/task_test.go
@@ -290,6 +290,7 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 
 	end := time.Unix(1666765800, 0).UTC() // 2022-10-26 06:30:00 UTC
 	accountAddress := "terra0wal1let2"
+	accountId := uint64(7)
 	pairId := uint64(1)
 	txCnt := uint64(5)
 
@@ -301,6 +302,7 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 			HourUtc:   end.Hour(),
 			MinuteUtc: end.Minute(),
 			Timestamp: util.ToEpoch(end),
+			AccountId: accountId,
 			Address:   accountAddress,
 			PairId:    pairId,
 			TxCnt:     txCnt,
@@ -309,6 +311,7 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 
 	rp := repoMock{}
 	rp.On("AccountStats", mock.Anything, mock.Anything).Return([]schemas.AccountStats30m{{Address: accountAddress, PairId: pairId, TxCnt: txCnt}}, nil)
+	rp.On("AccountIds").Return(map[string]uint64{accountAddress: accountId}, nil)
 	rp.On("HeightOnTimestamp").Return(uint64(0), nil)
 
 	task := accountStatsUpdateTask{
@@ -323,4 +326,27 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 
 	assert.NoError(err)
 	assert.Equal(expected, rp.updatedAccountStats)
+}
+
+func TestExecuteAccountStatsUpdateTaskNoStats(t *testing.T) {
+	assert := assert.New(t)
+
+	rp := repoMock{}
+	rp.On("AccountStats", mock.Anything, mock.Anything).Return([]schemas.AccountStats30m{}, nil)
+	rp.On("HeightOnTimestamp").Return(uint64(10), nil)
+
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId: "cube_47-5",
+			destDb:  &rp,
+			logger:  logging.Discard,
+		},
+		srcDb: &rp,
+	}
+	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+
+	assert.NoError(err)
+	assert.Empty(rp.updatedAccounts)
+	assert.Empty(rp.updatedAccountStats)
+	assert.Equal(uint64(10), task.LastProcessedHeight())
 }

--- a/aggregator/task_test.go
+++ b/aggregator/task_test.go
@@ -3,6 +3,7 @@ package aggregator
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"testing"
 	"time"
 
@@ -293,24 +294,43 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 	accountId := uint64(7)
 	pairId := uint64(1)
 	txCnt := uint64(5)
+	priceToken := "uusd"
 
 	expected := []schemas.AccountStats30m{
 		{
-			YearUtc:   end.Year(),
-			MonthUtc:  int(end.Month()),
-			DayUtc:    end.Day(),
-			HourUtc:   end.Hour(),
-			MinuteUtc: end.Minute(),
-			Timestamp: util.ToEpoch(end),
-			AccountId: accountId,
-			Address:   accountAddress,
-			PairId:    pairId,
-			TxCnt:     txCnt,
+			YearUtc:             end.Year(),
+			MonthUtc:            int(end.Month()),
+			DayUtc:              end.Day(),
+			HourUtc:             end.Hour(),
+			MinuteUtc:           end.Minute(),
+			Timestamp:           util.ToEpoch(end),
+			AccountId:           accountId,
+			Address:             accountAddress,
+			PairId:              pairId,
+			TxCnt:               txCnt,
+			SwapTxCnt:           3,
+			ProvideTxCnt:        1,
+			SwapVolumeInPrice:   "10",
+			ProvideValueInPrice: "20",
+			PriceToken:          priceToken,
+			NetLpAmount:         "30",
 		},
 	}
 
+	stats := []schemas.AccountStats30m{{
+		Address:             accountAddress,
+		PairId:              pairId,
+		TxCnt:               txCnt,
+		SwapTxCnt:           3,
+		ProvideTxCnt:        1,
+		SwapVolumeInPrice:   "10",
+		ProvideValueInPrice: "20",
+		PriceToken:          priceToken,
+		NetLpAmount:         "30",
+	}}
+
 	rp := repoMock{}
-	rp.On("AccountStats", mock.Anything, mock.Anything).Return([]schemas.AccountStats30m{{Address: accountAddress, PairId: pairId, TxCnt: txCnt}}, nil)
+	rp.On("AccountStats", mock.Anything, mock.Anything, priceToken).Return(stats, nil)
 	rp.On("AccountIds").Return(map[string]uint64{accountAddress: accountId}, nil)
 	rp.On("HeightOnTimestamp").Return(uint64(0), nil)
 
@@ -320,7 +340,8 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 			destDb:  &rp,
 			logger:  logging.Discard,
 		},
-		srcDb: &rp,
+		priceToken: priceToken,
+		srcDb:      &rp,
 	}
 	err := task.Execute(time.Time{}, end)
 
@@ -328,11 +349,121 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 	assert.Equal(expected, rp.updatedAccountStats)
 }
 
+func TestExecuteAccountStatsUpdateTaskDeduplicatesAccountCreation(t *testing.T) {
+	assert := assert.New(t)
+
+	priceToken := "uusd"
+	accountAddress := "terra0duplicated"
+	stats := []schemas.AccountStats30m{
+		{Address: accountAddress, PairId: 1, TxCnt: 1},
+		{Address: accountAddress, PairId: 2, TxCnt: 1},
+	}
+
+	rp := repoMock{}
+	rp.On("AccountStats", mock.Anything, mock.Anything, priceToken).Return(stats, nil)
+	rp.On("AccountIds").Return(map[string]uint64{accountAddress: 11}, nil)
+	rp.On("HeightOnTimestamp").Return(uint64(0), nil)
+
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId: "cube_47-5",
+			destDb:  &rp,
+			logger:  logging.Discard,
+		},
+		priceToken: priceToken,
+		srcDb:      &rp,
+	}
+	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+
+	assert.NoError(err)
+	assert.Equal([]string{accountAddress}, rp.updatedAccounts)
+	assert.Len(rp.updatedAccountStats, 2)
+	assert.Equal(uint64(11), rp.updatedAccountStats[0].AccountId)
+	assert.Equal(uint64(11), rp.updatedAccountStats[1].AccountId)
+}
+
+func TestExecuteAccountStatsUpdateTaskReturnsErrorWhenAccountIdMissing(t *testing.T) {
+	assert := assert.New(t)
+
+	priceToken := "uusd"
+	accountAddress := "terra0missing"
+	stats := []schemas.AccountStats30m{{Address: accountAddress, PairId: 1, TxCnt: 1}}
+
+	rp := repoMock{}
+	rp.On("AccountStats", mock.Anything, mock.Anything, priceToken).Return(stats, nil)
+	rp.On("AccountIds").Return(map[string]uint64{}, nil)
+
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId: "cube_47-5",
+			destDb:  &rp,
+			logger:  logging.Discard,
+		},
+		priceToken: priceToken,
+		srcDb:      &rp,
+	}
+	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+
+	assert.ErrorContains(err, "account id not found")
+	assert.Empty(rp.updatedAccountStats)
+}
+
+func TestExecuteAccountStatsUpdateTaskPropagatesCreateAccountsError(t *testing.T) {
+	assert := assert.New(t)
+
+	priceToken := "uusd"
+	createErr := errors.New("create accounts failed")
+	stats := []schemas.AccountStats30m{{Address: "terra0fail", PairId: 1, TxCnt: 1}}
+
+	rp := repoMock{createAccountsErr: createErr}
+	rp.On("AccountStats", mock.Anything, mock.Anything, priceToken).Return(stats, nil)
+
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId: "cube_47-5",
+			destDb:  &rp,
+			logger:  logging.Discard,
+		},
+		priceToken: priceToken,
+		srcDb:      &rp,
+	}
+	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+
+	assert.ErrorIs(err, createErr)
+	assert.Empty(rp.updatedAccountStats)
+	rp.AssertNotCalled(t, "AccountIds", mock.Anything)
+}
+
+func TestExecuteAccountStatsUpdateTaskPassesPriceToken(t *testing.T) {
+	assert := assert.New(t)
+
+	priceToken := "uusd"
+	end := time.Unix(1666765800, 0).UTC()
+
+	rp := repoMock{}
+	rp.On("AccountStats", util.ToEpoch(time.Time{}), util.ToEpoch(end), priceToken).Return([]schemas.AccountStats30m{}, nil)
+	rp.On("HeightOnTimestamp").Return(uint64(0), nil)
+
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId: "cube_47-5",
+			destDb:  &rp,
+			logger:  logging.Discard,
+		},
+		priceToken: priceToken,
+		srcDb:      &rp,
+	}
+	err := task.Execute(time.Time{}, end)
+
+	assert.NoError(err)
+	rp.AssertCalled(t, "AccountStats", util.ToEpoch(time.Time{}), util.ToEpoch(end), priceToken)
+}
+
 func TestExecuteAccountStatsUpdateTaskNoStats(t *testing.T) {
 	assert := assert.New(t)
 
 	rp := repoMock{}
-	rp.On("AccountStats", mock.Anything, mock.Anything).Return([]schemas.AccountStats30m{}, nil)
+	rp.On("AccountStats", mock.Anything, mock.Anything, "").Return([]schemas.AccountStats30m{}, nil)
 	rp.On("HeightOnTimestamp").Return(uint64(10), nil)
 
 	task := accountStatsUpdateTask{

--- a/db/migrations/aggregator/20260622120000_account_stats_account_id.down.sql
+++ b/db/migrations/aggregator/20260622120000_account_stats_account_id.down.sql
@@ -1,0 +1,12 @@
+DROP INDEX CONCURRENTLY IF EXISTS account_stats_30m_chain_id_account_id_idx;
+DROP INDEX CONCURRENTLY IF EXISTS account_stats_30m_chain_id_timestamp_account_id_pair_id_uidx;
+
+BEGIN;
+
+ALTER TABLE account_stats_30m
+    DROP CONSTRAINT IF EXISTS account_stats_30m_account_id_not_null;
+
+ALTER TABLE account_stats_30m
+    DROP COLUMN IF EXISTS account_id;
+
+COMMIT;

--- a/db/migrations/aggregator/20260622120000_account_stats_account_id.up.sql
+++ b/db/migrations/aggregator/20260622120000_account_stats_account_id.up.sql
@@ -1,0 +1,58 @@
+BEGIN;
+
+ALTER TABLE account_stats_30m
+    ADD COLUMN IF NOT EXISTS account_id bigint;
+
+INSERT INTO account(address)
+SELECT DISTINCT address
+FROM account_stats_30m
+WHERE address IS NOT NULL
+  AND address <> ''
+ON CONFLICT DO NOTHING;
+
+UPDATE account_stats_30m ast
+SET account_id = a.id
+FROM account a
+WHERE ast.account_id IS NULL
+  AND ast.address = a.address;
+
+DELETE FROM account_stats_30m ast
+USING (
+    SELECT id
+    FROM (
+        SELECT id,
+               row_number() OVER (
+                   PARTITION BY chain_id, timestamp, account_id, pair_id
+                   ORDER BY modified_at DESC, id DESC
+               ) AS rn
+        FROM account_stats_30m
+        WHERE account_id IS NOT NULL
+    ) ranked
+    WHERE rn > 1
+) dups
+WHERE ast.id = dups.id;
+
+ALTER TABLE account_stats_30m
+    DROP CONSTRAINT IF EXISTS account_stats_30m_account_id_not_null;
+
+-- Validate with a temporary CHECK first so SET NOT NULL can avoid a long table scan/lock.
+ALTER TABLE account_stats_30m
+    ADD CONSTRAINT account_stats_30m_account_id_not_null
+        CHECK (account_id IS NOT NULL) NOT VALID;
+
+COMMIT;
+
+ALTER TABLE account_stats_30m
+    VALIDATE CONSTRAINT account_stats_30m_account_id_not_null;
+
+ALTER TABLE account_stats_30m
+    ALTER COLUMN account_id SET NOT NULL;
+
+ALTER TABLE account_stats_30m
+    DROP CONSTRAINT IF EXISTS account_stats_30m_account_id_not_null;
+
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS account_stats_30m_chain_id_timestamp_account_id_pair_id_uidx
+    ON account_stats_30m (chain_id, timestamp, account_id, pair_id);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS account_stats_30m_chain_id_account_id_idx
+    ON account_stats_30m (chain_id, account_id);

--- a/db/migrations/aggregator/20260624120000_extend_account_stats_30m.down.sql
+++ b/db/migrations/aggregator/20260624120000_extend_account_stats_30m.down.sql
@@ -1,0 +1,19 @@
+DROP INDEX CONCURRENTLY IF EXISTS account_stats_30m_chain_id_account_id_pair_id_idx;
+DROP INDEX CONCURRENTLY IF EXISTS account_stats_30m_chain_id_account_id_timestamp_idx;
+
+BEGIN;
+
+ALTER TABLE account_stats_30m
+    DROP COLUMN IF EXISTS net_lp_amount,
+    DROP COLUMN IF EXISTS net_asset1_amount,
+    DROP COLUMN IF EXISTS net_asset0_amount,
+    DROP COLUMN IF EXISTS price_token,
+    DROP COLUMN IF EXISTS net_flow_in_price,
+    DROP COLUMN IF EXISTS withdraw_value_in_price,
+    DROP COLUMN IF EXISTS provide_value_in_price,
+    DROP COLUMN IF EXISTS swap_volume_in_price,
+    DROP COLUMN IF EXISTS withdraw_tx_cnt,
+    DROP COLUMN IF EXISTS provide_tx_cnt,
+    DROP COLUMN IF EXISTS swap_tx_cnt;
+
+COMMIT;

--- a/db/migrations/aggregator/20260624120000_extend_account_stats_30m.up.sql
+++ b/db/migrations/aggregator/20260624120000_extend_account_stats_30m.up.sql
@@ -1,0 +1,22 @@
+BEGIN;
+
+ALTER TABLE account_stats_30m
+    ADD COLUMN IF NOT EXISTS swap_tx_cnt bigint NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS provide_tx_cnt bigint NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS withdraw_tx_cnt bigint NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS swap_volume_in_price numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS provide_value_in_price numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS withdraw_value_in_price numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS net_flow_in_price numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS price_token varchar NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS net_asset0_amount numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS net_asset1_amount numeric NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS net_lp_amount numeric NOT NULL DEFAULT 0;
+
+COMMIT;
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS account_stats_30m_chain_id_account_id_timestamp_idx
+    ON account_stats_30m (chain_id, account_id, timestamp);
+
+CREATE INDEX CONCURRENTLY IF NOT EXISTS account_stats_30m_chain_id_account_id_pair_id_idx
+    ON account_stats_30m (chain_id, account_id, pair_id);

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -30,7 +30,7 @@ type ReadRepository interface {
 	RecentPrices(startHeight uint64, endHeight uint64, targetTokens []string, priceToken string) (map[uint64][]schemas.Price, error)
 	GetParsedTxsWithPriceOfPair(pairId uint64, priceToken string, startTs float64, endTs float64) ([]schemas.ParsedTxWithPrice, error)
 	PairStats(startTs float64, endTs float64, priceToken string, prevStatsMap map[uint64]schemas.PairStats30m) ([]schemas.PairStats30m, error)
-	AccountStats(startTs float64, endTs float64) ([]schemas.AccountStats30m, error)
+	AccountStats(startTs float64, endTs float64, priceToken string) ([]schemas.AccountStats30m, error)
 	LiquiditiesOfPairStats(startTs float64, endTs float64, priceToken string) (map[uint64]schemas.PairStats30m, error)
 	OldestTxTimestamp() (float64, error)
 	LatestTxTimestamp() (float64, error)
@@ -433,19 +433,80 @@ func (r *readRepoImpl) latestPairStat(pairId uint64) (schemas.PairStats30m, erro
 	return stat, nil
 }
 
-func (r *readRepoImpl) AccountStats(startTs float64, endTs float64) ([]schemas.AccountStats30m, error) {
+func (r *readRepoImpl) AccountStats(startTs float64, endTs float64, priceToken string) ([]schemas.AccountStats30m, error) {
 	query := `
-select pt.sender address, p.id pair_id, count(distinct pt.hash) tx_cnt
-from parsed_tx pt
-    join pair p on p.chain_id = pt.chain_id and p.contract = pt.contract
-where pt.chain_id = ?
+WITH tx_values AS (
+    SELECT
+        pt.sender address,
+        p.id pair_id,
+        pt.hash,
+        pt.type,
+        pt.asset0_amount::numeric asset0_amount,
+        pt.asset1_amount::numeric asset1_amount,
+        CASE
+            WHEN pt.type = 'withdraw' THEN -abs(pt.lp_amount::numeric)
+            ELSE pt.lp_amount::numeric
+        END lp_amount,
+        abs(pt.asset0_amount::numeric) * coalesce(pr0.price, CASE WHEN t0.address = ? THEN 1 ELSE 0 END) / (10::numeric ^ t0.decimals) asset0_value_in_price,
+        abs(pt.asset1_amount::numeric) * coalesce(pr1.price, CASE WHEN t1.address = ? THEN 1 ELSE 0 END) / (10::numeric ^ t1.decimals) asset1_value_in_price,
+        pt.asset0_amount::numeric * coalesce(pr0.price, CASE WHEN t0.address = ? THEN 1 ELSE 0 END) / (10::numeric ^ t0.decimals) net_asset0_value_in_price,
+        pt.asset1_amount::numeric * coalesce(pr1.price, CASE WHEN t1.address = ? THEN 1 ELSE 0 END) / (10::numeric ^ t1.decimals) net_asset1_value_in_price
+    FROM parsed_tx pt
+    JOIN pair p ON p.chain_id = pt.chain_id AND p.contract = pt.contract
+    JOIN tokens t0 ON pt.chain_id = t0.chain_id AND pt.asset0 = t0.address
+    JOIN tokens t1 ON pt.chain_id = t1.chain_id AND pt.asset1 = t1.address
+    JOIN tokens price_token ON pt.chain_id = price_token.chain_id AND price_token.address = ?
+    LEFT JOIN LATERAL (
+        SELECT price
+        FROM price
+        WHERE token_id = t0.id
+          AND price_token_id = price_token.id
+          AND height <= pt.height
+          AND chain_id = ?
+        ORDER BY height DESC, id DESC
+        LIMIT 1
+    ) pr0 ON true
+    LEFT JOIN LATERAL (
+        SELECT price
+        FROM price
+        WHERE token_id = t1.id
+          AND price_token_id = price_token.id
+          AND height <= pt.height
+          AND chain_id = ?
+        ORDER BY height DESC, id DESC
+        LIMIT 1
+    ) pr1 ON true
+WHERE pt.chain_id = ?
   and pt.timestamp >= ?
   and pt.timestamp < ?
-  AND pt.type IN ('swap', 'provide', 'withdraw')
-group by pt.sender, p.id;
+  and pt.type in ('swap', 'provide', 'withdraw')
+)
+SELECT
+    address,
+    pair_id,
+    count(distinct hash) tx_cnt,
+    count(distinct hash) filter (where type = 'swap') swap_tx_cnt,
+    count(distinct hash) filter (where type = 'provide') provide_tx_cnt,
+    count(distinct hash) filter (where type = 'withdraw') withdraw_tx_cnt,
+    coalesce(sum(
+	    CASE
+			WHEN asset0_amount < 0 THEN asset0_value_in_price
+			WHEN asset1_amount < 0 THEN asset1_value_in_price
+			ELSE greatest(asset0_value_in_price, asset1_value_in_price)
+		END
+	) filter (where type = 'swap'), 0) swap_volume_in_price,
+    coalesce(sum(asset0_value_in_price + asset1_value_in_price) filter (where type = 'provide'), 0) provide_value_in_price,
+    coalesce(sum(asset0_value_in_price + asset1_value_in_price) filter (where type = 'withdraw'), 0) withdraw_value_in_price,
+    coalesce(sum(net_asset0_value_in_price + net_asset1_value_in_price), 0) net_flow_in_price,
+    ? price_token,
+    coalesce(sum(asset0_amount), 0) net_asset0_amount,
+    coalesce(sum(asset1_amount), 0) net_asset1_amount,
+    coalesce(sum(lp_amount), 0) net_lp_amount
+FROM tx_values
+GROUP BY address, pair_id;
 `
 	res := []schemas.AccountStats30m{}
-	if tx := r.db.Raw(query, r.chainId, startTs, endTs).Scan(&res); tx.Error != nil {
+	if tx := r.db.Raw(query, priceToken, priceToken, priceToken, priceToken, priceToken, r.chainId, r.chainId, r.chainId, startTs, endTs, priceToken).Scan(&res); tx.Error != nil {
 		return nil, errors.Wrap(tx.Error, "repo.AccountStats")
 	}
 

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -435,7 +435,7 @@ func (r *readRepoImpl) latestPairStat(pairId uint64) (schemas.PairStats30m, erro
 
 func (r *readRepoImpl) AccountStats(startTs float64, endTs float64) ([]schemas.AccountStats30m, error) {
 	query := `
-select pt.sender address, p.id pair_id, count(*) tx_cnt
+select pt.sender address, p.id pair_id, count(distinct pt.hash) tx_cnt
 from parsed_tx pt
     join pair p on p.chain_id = pt.chain_id and p.contract = pt.contract
 where pt.chain_id = ?

--- a/pkg/db/parser/repository_test.go
+++ b/pkg/db/parser/repository_test.go
@@ -535,6 +535,215 @@ func (s *aggregatorReadRepoSuite) Test_AssetAmountInPairOfAccount() {
 	assert.Equal(expectedLp, actualLp)
 }
 
+func (s *aggregatorReadRepoSuite) Test_AccountStats_UsesTxHeightPrice() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	account := "terra0wallet"
+	pairId := uint64(100)
+	contract := "terra0contract"
+	asset := "terra0asset"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, contract, priceToken, asset, "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, $4), ($5, $6, $7, $8)`,
+		1000, chainName, priceToken, 0,
+		1001, chainName, asset, 0,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES($1, $2, $3, $4, $5, $6)`,
+		200, chainName, 1001, "3", 1000, 0,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES
+         ($1, 100, $2, 'swap-hash', 'swap', $3, $4, $5, '-10', $6, '7', 'terra0lp', '0', '0', '0', '0'),
+         ($1, 250, $2, 'provide-hash', 'provide', $3, $4, $5, '2', $6, '3', 'terra0lp', '5', '0', '0', '0'),
+         ($1, 300, $2, 'withdraw-hash', 'withdraw', $3, $4, $5, '-1', $6, '-4', 'terra0lp', '-2', '0', '0', '0')`,
+		chainName, start, account, contract, priceToken, asset,
+	).Error)
+
+	actual, err := s.Repo.AccountStats(start, end, priceToken)
+
+	require.NoError(err)
+	require.Len(actual, 1)
+	assert.Equal(account, actual[0].Address)
+	assert.Equal(pairId, actual[0].PairId)
+	assert.Equal(uint64(3), actual[0].TxCnt)
+	assert.Equal(uint64(1), actual[0].SwapTxCnt)
+	assert.Equal(uint64(1), actual[0].ProvideTxCnt)
+	assert.Equal(uint64(1), actual[0].WithdrawTxCnt)
+	assert.Equal("10", actual[0].SwapVolumeInPrice)
+	assert.Equal("11", actual[0].ProvideValueInPrice)
+	assert.Equal("13", actual[0].WithdrawValueInPrice)
+	assert.Equal("-12", actual[0].NetFlowInPrice)
+	assert.Equal(priceToken, actual[0].PriceToken)
+	assert.Equal("-9", actual[0].NetAsset0Amount)
+	assert.Equal("6", actual[0].NetAsset1Amount)
+	assert.Equal("3", actual[0].NetLpAmount)
+}
+
+func (s *aggregatorReadRepoSuite) Test_AccountStats_UsesInputSideSwapVolumeWhenAsset1IsInput() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	asset := "terra0asset"
+	account := "terra0wallet"
+	pairId := uint64(101)
+	contract := "terra0asset1input"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, contract, asset, priceToken, "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, 0), ($4, $2, $5, 0)`,
+		1100, chainName, asset, 1101, priceToken,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES(90, $1, $2, '5', $3, 0)`,
+		chainName, 1100, 1101,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES ($1, 100, $2, 'asset1-input-swap', 'swap', $3, $4, $5, '2', $6, '-8', 'terra0lp', '0', '0', '0', '0')`,
+		chainName, start, account, contract, asset, priceToken,
+	).Error)
+
+	actual, err := s.Repo.AccountStats(start, end, priceToken)
+
+	require.NoError(err)
+	require.Len(actual, 1)
+	assert.Equal("8", actual[0].SwapVolumeInPrice)
+}
+
+func (s *aggregatorReadRepoSuite) Test_AccountStats_UsesZeroWhenNonPriceTokenHasNoHistoricalPrice() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	asset := "terra0asset"
+	account := "terra0wallet"
+	pairId := uint64(102)
+	contract := "terra0futureprice"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, contract, asset, priceToken, "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, 0), ($4, $2, $5, 0)`,
+		1200, chainName, asset, 1201, priceToken,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES(200, $1, $2, '9', $3, 0)`,
+		chainName, 1200, 1201,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES ($1, 100, $2, 'missing-historical-price', 'swap', $3, $4, $5, '-10', $6, '1', 'terra0lp', '0', '0', '0', '0')`,
+		chainName, start, account, contract, asset, priceToken,
+	).Error)
+
+	actual, err := s.Repo.AccountStats(start, end, priceToken)
+
+	require.NoError(err)
+	require.Len(actual, 1)
+	assert.Equal("0", actual[0].SwapVolumeInPrice)
+}
+
+func (s *aggregatorReadRepoSuite) Test_AccountStats_GroupsByAccountAndPair() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	assetA := "terra0assetA"
+	assetB := "terra0assetB"
+	accountA := "terra0accountA"
+	accountB := "terra0accountB"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES
+         (201, $1, 'terra0pairA', $2, $3, 'terra0lpA'),
+         (202, $1, 'terra0pairB', $2, $4, 'terra0lpB')`,
+		chainName, priceToken, assetA, assetB,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES
+         (2100, $1, $2, 0),
+         (2101, $1, $3, 0),
+         (2102, $1, $4, 0)`,
+		chainName, priceToken, assetA, assetB,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES
+         ($1, 100, $2, 'a-pair-a', 'provide', $3, 'terra0pairA', $4, '1', $5, '2', 'terra0lpA', '3', '0', '0', '0'),
+         ($1, 101, $2, 'a-pair-b', 'provide', $3, 'terra0pairB', $4, '4', $6, '5', 'terra0lpB', '6', '0', '0', '0'),
+         ($1, 102, $2, 'b-pair-a', 'provide', $7, 'terra0pairA', $4, '7', $5, '8', 'terra0lpA', '9', '0', '0', '0')`,
+		chainName, start, accountA, priceToken, assetA, assetB, accountB,
+	).Error)
+
+	actual, err := s.Repo.AccountStats(start, end, priceToken)
+
+	require.NoError(err)
+	require.Len(actual, 3)
+	grouped := map[string]schemas.AccountStats30m{}
+	for _, stat := range actual {
+		grouped[fmt.Sprintf("%s:%d", stat.Address, stat.PairId)] = stat
+	}
+	assert.Contains(grouped, fmt.Sprintf("%s:%d", accountA, uint64(201)))
+	assert.Contains(grouped, fmt.Sprintf("%s:%d", accountA, uint64(202)))
+	assert.Contains(grouped, fmt.Sprintf("%s:%d", accountB, uint64(201)))
+}
+
+func (s *aggregatorReadRepoSuite) Test_AccountStats_CountsDistinctHashesButSumsRows() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	asset := "terra0asset"
+	account := "terra0wallet"
+	pairId := uint64(103)
+	contract := "terra0duplicatehash"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, contract, priceToken, asset, "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, 0), ($4, $2, $5, 0)`,
+		1300, chainName, priceToken, 1301, asset,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES
+         ($1, 100, $2, 'same-hash', 'swap', $3, $4, $5, '-10', $6, '1', 'terra0lp', '0', '0', '0', '0'),
+         ($1, 100, $2, 'same-hash', 'swap', $3, $4, $5, '-15', $6, '2', 'terra0lp', '0', '0', '0', '0')`,
+		chainName, start, account, contract, priceToken, asset,
+	).Error)
+
+	actual, err := s.Repo.AccountStats(start, end, priceToken)
+
+	require.NoError(err)
+	require.Len(actual, 1)
+	assert.Equal(uint64(1), actual[0].TxCnt)
+	assert.Equal(uint64(1), actual[0].SwapTxCnt)
+	assert.Equal("25", actual[0].SwapVolumeInPrice)
+	assert.Equal("-25", actual[0].NetAsset0Amount)
+	assert.Equal("3", actual[0].NetAsset1Amount)
+}
+
 func (s *aggregatorReadRepoSuite) Test_CommissionAmountInPair() {
 	assert := assert.New(s.T())
 

--- a/pkg/db/schemas/aggregator.models.go
+++ b/pkg/db/schemas/aggregator.models.go
@@ -106,17 +106,28 @@ type PairStats30m struct {
 }
 
 type AccountStats30m struct {
-	YearUtc   int     `json:"year_utc"`
-	MonthUtc  int     `json:"month_utc"`
-	DayUtc    int     `json:"day_utc"`
-	HourUtc   int     `json:"hour_utc"`
-	MinuteUtc int     `json:"minute_utc"`
-	AccountId uint64  `json:"account_id"`
-	Address   string  `json:"address"`
-	PairId    uint64  `json:"pair_id"`
-	ChainId   string  `json:"chain_id"`
-	TxCnt     uint64  `json:"tx_cnt"`
-	Timestamp float64 `json:"timestamp"`
+	YearUtc              int     `json:"year_utc"`
+	MonthUtc             int     `json:"month_utc"`
+	DayUtc               int     `json:"day_utc"`
+	HourUtc              int     `json:"hour_utc"`
+	MinuteUtc            int     `json:"minute_utc"`
+	AccountId            uint64  `json:"account_id"`
+	Address              string  `json:"address"`
+	PairId               uint64  `json:"pair_id"`
+	ChainId              string  `json:"chain_id"`
+	TxCnt                uint64  `json:"tx_cnt"`
+	SwapTxCnt            uint64  `json:"swap_tx_cnt"`
+	ProvideTxCnt         uint64  `json:"provide_tx_cnt"`
+	WithdrawTxCnt        uint64  `json:"withdraw_tx_cnt"`
+	SwapVolumeInPrice    string  `json:"swap_volume_in_price"`
+	ProvideValueInPrice  string  `json:"provide_value_in_price"`
+	WithdrawValueInPrice string  `json:"withdraw_value_in_price"`
+	NetFlowInPrice       string  `json:"net_flow_in_price"`
+	PriceToken           string  `json:"price_token"`
+	NetAsset0Amount      string  `json:"net_asset0_amount"`
+	NetAsset1Amount      string  `json:"net_asset1_amount"`
+	NetLpAmount          string  `json:"net_lp_amount"`
+	Timestamp            float64 `json:"timestamp"`
 }
 
 func NewPairStat30min(chainId string, priceToken string, end time.Time, pairId uint64) PairStats30m {
@@ -135,15 +146,22 @@ func NewPairStat30min(chainId string, priceToken string, end time.Time, pairId u
 
 func NewAccountStat30min(chainId string, end time.Time, pairId uint64, accountId uint64, accountAddress string) AccountStats30m {
 	return AccountStats30m{
-		YearUtc:   end.Year(),
-		MonthUtc:  int(end.Month()),
-		DayUtc:    end.Day(),
-		HourUtc:   end.Hour(),
-		MinuteUtc: end.Minute(),
-		Timestamp: util.ToEpoch(end),
-		AccountId: accountId,
-		Address:   accountAddress,
-		PairId:    pairId,
-		ChainId:   chainId,
+		YearUtc:              end.Year(),
+		MonthUtc:             int(end.Month()),
+		DayUtc:               end.Day(),
+		HourUtc:              end.Hour(),
+		MinuteUtc:            end.Minute(),
+		Timestamp:            util.ToEpoch(end),
+		AccountId:            accountId,
+		Address:              accountAddress,
+		PairId:               pairId,
+		ChainId:              chainId,
+		SwapVolumeInPrice:    "0",
+		ProvideValueInPrice:  "0",
+		WithdrawValueInPrice: "0",
+		NetFlowInPrice:       "0",
+		NetAsset0Amount:      "0",
+		NetAsset1Amount:      "0",
+		NetLpAmount:          "0",
 	}
 }

--- a/pkg/db/schemas/aggregator.models.go
+++ b/pkg/db/schemas/aggregator.models.go
@@ -111,6 +111,7 @@ type AccountStats30m struct {
 	DayUtc    int     `json:"day_utc"`
 	HourUtc   int     `json:"hour_utc"`
 	MinuteUtc int     `json:"minute_utc"`
+	AccountId uint64  `json:"account_id"`
 	Address   string  `json:"address"`
 	PairId    uint64  `json:"pair_id"`
 	ChainId   string  `json:"chain_id"`
@@ -132,7 +133,7 @@ func NewPairStat30min(chainId string, priceToken string, end time.Time, pairId u
 	}
 }
 
-func NewAccountStat30min(chainId string, end time.Time, pairId uint64, accountAddress string) AccountStats30m {
+func NewAccountStat30min(chainId string, end time.Time, pairId uint64, accountId uint64, accountAddress string) AccountStats30m {
 	return AccountStats30m{
 		YearUtc:   end.Year(),
 		MonthUtc:  int(end.Month()),
@@ -140,6 +141,7 @@ func NewAccountStat30min(chainId string, end time.Time, pairId uint64, accountAd
 		HourUtc:   end.Hour(),
 		MinuteUtc: end.Minute(),
 		Timestamp: util.ToEpoch(end),
+		AccountId: accountId,
 		Address:   accountAddress,
 		PairId:    pairId,
 		ChainId:   chainId,


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The existing `account_stats_30m` table already represents account-pair time-bucketed activity, but it only stored total tx count and address-level identity. That made it hard to answer wallet-level questions such as activity type, touched pairs, current LP pairs, and historical volume without re-reading raw parser data.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
This PR extends account stats while keeping the storage model compact.
- Normalize `account_stats_30m` with `account_id` and a unique key on `(chain_id, timestamp, account_id, pair_id)`.
- Extend `account_stats_30m` with tx-type counts, historical price values, net token flow, and net LP amount.
- Calculate historical account values using tx-height price lookup, including `priceToken = 1` fallback when the asset itself is the price token.
- Add wallet summary query helpers based on `account_stats_30m` aggregation instead of introducing a separate profile table.
- Update LP-holder queries to use `account_stats_30m.net_lp_amount`.
- Add tests for account ID normalization, account stats aggregation, tx-height price calculation, wallet summary, and current LP pair queries.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account statistics now track account IDs and a selected price token, with richer transaction and value metrics.
  * Account records are created and linked automatically during stats updates.

* **Bug Fixes**
  * Improved stats persistence with safe upserts to prevent duplicate rows.
  * Filtering now correctly excludes zero or negative LP positions and keeps recently created positive-LP accounts.
  * Empty stats updates now exit cleanly without changes.

* **Tests**
  * Expanded coverage for account lookup, stats updates, schema defaults, and price-based calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->