### PR TITLE
fix(aggregator): wait for price task before account stats

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -79,7 +79,7 @@ func initTaskSchedulers(config configs.AggregatorConfig, srcRepo parser.ReadRepo
 		newIntervalScheduler(pt, logger),
 		newIntervalScheduler(newPairStatsRecentUpdateTask(config, srcRepo, destRepo, logger, []task{pt}), logger),
 		newPredeterminedTimeScheduler(newPairStatsUpdateTask(config, srcRepo, destRepo, logger, []task{pt}), config.StartTs, logger),
-		newPredeterminedTimeScheduler(newAccountStatsUpdateTask(config, srcRepo, destRepo, logger), config.StartTs, logger),
+		newPredeterminedTimeScheduler(newAccountStatsUpdateTask(config, srcRepo, destRepo, logger, []task{pt}), config.StartTs, logger),
 	}, nil
 }
 

--- a/aggregator/task.go
+++ b/aggregator/task.go
@@ -653,12 +653,13 @@ func (t *pairStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 	return nil
 }
 
-func newAccountStatsUpdateTask(config configs.AggregatorConfig, srcRepo parser.ReadRepository, destRepo repo.Repo, logger logging.Logger) predeterminedTimeTask {
+func newAccountStatsUpdateTask(config configs.AggregatorConfig, srcRepo parser.ReadRepository, destRepo repo.Repo, logger logging.Logger, parentTasks []task) predeterminedTimeTask {
 	return &accountStatsUpdateTask{
 		taskImpl: taskImpl{
-			chainId: config.ChainId,
-			destDb:  destRepo,
-			logger:  logger,
+			chainId:     config.ChainId,
+			destDb:      destRepo,
+			parentTasks: parentTasks,
+			logger:      logger,
 		},
 		priceToken: config.PriceToken,
 		srcDb:      srcRepo,
@@ -690,6 +691,12 @@ func (t *accountStatsUpdateTask) StartTimestamp(startTs time.Time) (time.Time, e
 
 func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 	startEpoch, endEpoch := util.ToEpoch(start), util.ToEpoch(end)
+
+	endHeight, err := t.srcDb.HeightOnTimestamp(endEpoch)
+	if err != nil {
+		return err
+	}
+	waitUntilReachingHeight(&t.parentTasks, endHeight)
 
 	stats, err := t.srcDb.AccountStats(startEpoch, endEpoch, t.priceToken)
 	if err != nil {
@@ -730,10 +737,7 @@ func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 		}
 	}
 
-	t.lastProcessedHeight, err = t.srcDb.HeightOnTimestamp(util.ToEpoch(end))
-	if err != nil {
-		return err
-	}
+	t.lastProcessedHeight = endHeight
 
 	t.logger.Infof("Complete account stats update for the timeframe '%s - %s'.", start.String(), end.String())
 

--- a/aggregator/task_test.go
+++ b/aggregator/task_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -28,6 +29,22 @@ func (p ConnPool) QueryContext(_ context.Context, _ string, _ ...interface{}) (*
 func (p ConnPool) QueryRowContext(_ context.Context, _ string, _ ...interface{}) *sql.Row { return nil }
 func (p ConnPool) Commit() error                                                          { return nil }
 func (p ConnPool) Rollback() error                                                        { return nil }
+
+type completedTask struct {
+	height atomic.Uint64
+}
+
+func (t *completedTask) Execute(_ time.Time, _ time.Time) error {
+	return nil
+}
+
+func (t *completedTask) LastProcessedHeight() uint64 {
+	return t.height.Load()
+}
+
+func (t *completedTask) setLastProcessedHeight(height uint64) {
+	t.height.Store(height)
+}
 
 func TestLpHistoryTaskExecute(t *testing.T) {
 	assert := assert.New(t)
@@ -390,6 +407,7 @@ func TestExecuteAccountStatsUpdateTaskReturnsErrorWhenAccountIdMissing(t *testin
 	stats := []schemas.AccountStats30m{{Address: accountAddress, PairId: 1, TxCnt: 1}}
 
 	rp := repoMock{}
+	rp.On("HeightOnTimestamp").Return(uint64(0), nil)
 	rp.On("AccountStats", mock.Anything, mock.Anything, priceToken).Return(stats, nil)
 	rp.On("AccountIds").Return(map[string]uint64{}, nil)
 
@@ -416,6 +434,7 @@ func TestExecuteAccountStatsUpdateTaskPropagatesCreateAccountsError(t *testing.T
 	stats := []schemas.AccountStats30m{{Address: "terra0fail", PairId: 1, TxCnt: 1}}
 
 	rp := repoMock{createAccountsErr: createErr}
+	rp.On("HeightOnTimestamp").Return(uint64(0), nil)
 	rp.On("AccountStats", mock.Anything, mock.Anything, priceToken).Return(stats, nil)
 
 	task := accountStatsUpdateTask{
@@ -480,4 +499,54 @@ func TestExecuteAccountStatsUpdateTaskNoStats(t *testing.T) {
 	assert.Empty(rp.updatedAccounts)
 	assert.Empty(rp.updatedAccountStats)
 	assert.Equal(uint64(10), task.LastProcessedHeight())
+}
+
+func TestExecuteAccountStatsUpdateTaskWaitsForParentPriceTask(t *testing.T) {
+	assert := assert.New(t)
+
+	end := time.Unix(1666765800, 0).UTC()
+	endHeight := uint64(10)
+	accountStatsCalled := make(chan struct{}, 1)
+
+	rp := repoMock{}
+	rp.On("HeightOnTimestamp").Return(endHeight, nil)
+	rp.On("AccountStats", mock.Anything, mock.Anything, "").Run(func(_ mock.Arguments) {
+		accountStatsCalled <- struct{}{}
+	}).Return([]schemas.AccountStats30m{}, nil)
+
+	parent := &completedTask{}
+	parent.setLastProcessedHeight(endHeight - 1)
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId:     "cube_47-5",
+			destDb:      &rp,
+			parentTasks: []task{parent},
+			logger:      logging.Discard,
+		},
+		srcDb: &rp,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- task.Execute(time.Time{}, end)
+	}()
+
+	select {
+	case <-accountStatsCalled:
+		assert.Fail("AccountStats was called before the parent price task reached the target height")
+	case <-time.After(WaitPeriod / 2):
+	}
+
+	parent.setLastProcessedHeight(endHeight)
+
+	var err error
+	select {
+	case err = <-errCh:
+	case <-time.After(WaitPeriod * 2):
+		assert.Fail("account stats update task did not complete after the parent price task reached the target height")
+		return
+	}
+
+	assert.NoError(err)
+	assert.Equal(endHeight, task.LastProcessedHeight())
+	rp.AssertCalled(t, "AccountStats", util.ToEpoch(time.Time{}), util.ToEpoch(end), "")
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Account stats aggregation depends on price-derived data being available for the same target height. Without waiting for the price task, account stats can be calculated before the required upstream aggregation has caught up.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Make the account stats update task depend on the price update task.
- Resolve the target end height once before aggregation and wait for parent tasks to reach that height.
- Add test coverage to verify account stats waits for the parent price task before completing.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved account stats updates to wait for prerequisite pricing data before running, helping ensure stats are computed in the correct order.
  * Reduced the chance of premature or inconsistent account stats processing by aligning progress tracking with the completed update range.
  * Strengthened related checks so task execution behaves more predictably when required timing data is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->