### PR TITLE
fix(parser): filter price lookups by price token

### DIFF
--- a/db/migrations/aggregator/20260625120000_price_token_price_index.down.sql
+++ b/db/migrations/aggregator/20260625120000_price_token_price_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS price_chain_id_token_id_price_token_id_height_idx;

--- a/db/migrations/aggregator/20260625120000_price_token_price_index.up.sql
+++ b/db/migrations/aggregator/20260625120000_price_token_price_index.up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS price_chain_id_token_id_price_token_id_height_idx
+    ON price (chain_id, token_id, price_token_id, height DESC);

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -219,13 +219,13 @@ seed_price as (
 	    join price_token pt on tt.id = pt.id
 ),
 start_height as (
-	select p.token_id, max(p.height) height
-	from price p
-	    join price_token pt on p.price_token_id = pt.id
-	    join target_tokens tt on p.token_id = tt.id
-	where p.chain_id = ?
-	  and p.height <= ?
-	group by p.token_id
+	select tt.id token_id, coalesce(max(p.height), ?) height
+	from target_tokens tt
+	    left join price p on p.token_id = tt.id
+	        and p.price_token_id = (select id from price_token)
+	        and p.chain_id = ?
+			and p.height <= ?
+	group by tt.id
 )
 select height,
        token_id,
@@ -243,7 +243,7 @@ where p.chain_id = ?
 order by token_id, height
 	`
 	var res []schemas.Price
-	if tx := r.db.Raw(query, r.chainId, priceToken, pq.Array(targetTokens), r.chainId, r.chainId, startHeight, r.chainId, endHeight).Scan(&res); tx.Error != nil {
+	if tx := r.db.Raw(query, r.chainId, priceToken, pq.Array(targetTokens), r.chainId, startHeight, r.chainId, startHeight, r.chainId, endHeight).Scan(&res); tx.Error != nil {
 		return nil, errors.Wrap(tx.Error, "repo.RecentPrices")
 	}
 

--- a/pkg/db/parser/repository.go
+++ b/pkg/db/parser/repository.go
@@ -2,7 +2,6 @@ package parser
 
 import (
 	"database/sql"
-	"fmt"
 	"strings"
 
 	"github.com/dezswap/cosmwasm-etl/pkg/util"
@@ -10,6 +9,7 @@ import (
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/pkg/db"
 	"github.com/dezswap/cosmwasm-etl/pkg/db/schemas"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 
 	"gorm.io/gorm"
@@ -197,30 +197,53 @@ where pt.chain_id = ?
 	return res, nil
 }
 
+// RecentPrices returns prices ordered by token and height because searchPrice scans each token's slice in order.
 func (r *readRepoImpl) RecentPrices(startHeight uint64, endHeight uint64, targetTokens []string, priceToken string) (map[uint64][]schemas.Price, error) {
 	query := `
-select 0 height,
-       id as token_id,
-       1 as price
-from tokens where address = ?
-union
+with price_token as (
+	select id
+	from tokens
+	where chain_id = ? and address = ?
+),
+target_tokens as (
+	select t.id
+	from tokens t
+	    join unnest(?::bigint[]) target(id) on t.id = target.id
+	where t.chain_id = ?
+),
+seed_price as (
+	select 0 height,
+	       tt.id token_id,
+	       1 price
+	from target_tokens tt
+	    join price_token pt on tt.id = pt.id
+),
+start_height as (
+	select p.token_id, max(p.height) height
+	from price p
+	    join price_token pt on p.price_token_id = pt.id
+	    join target_tokens tt on p.token_id = tt.id
+	where p.chain_id = ?
+	  and p.height <= ?
+	group by p.token_id
+)
+select height,
+       token_id,
+       price
+from seed_price
+union all
 select p.height,
        p.token_id,
        p.price
 from price p
-    join (
-    	select token_id, max(height) height
-    	from price p join tokens t on t.id = p.token_id
-    	where p.chain_id = ?
-    	  and p.height <= ?
-    	  %s
-    	group by p.token_id) t on p.token_id = t.token_id and p.height >= t.height
-where p.height <= ?
-order by height
-`
-	query = fmt.Sprintf(query, "and t.id in ("+strings.Join(targetTokens, ",")+")")
+    join start_height sh on p.token_id = sh.token_id and p.height >= sh.height
+    join price_token pt on p.price_token_id = pt.id
+where p.chain_id = ?
+  and p.height <= ?
+order by token_id, height
+	`
 	var res []schemas.Price
-	if tx := r.db.Raw(query, priceToken, r.chainId, startHeight, endHeight).Scan(&res); tx.Error != nil {
+	if tx := r.db.Raw(query, r.chainId, priceToken, pq.Array(targetTokens), r.chainId, r.chainId, startHeight, r.chainId, endHeight).Scan(&res); tx.Error != nil {
 		return nil, errors.Wrap(tx.Error, "repo.RecentPrices")
 	}
 
@@ -243,15 +266,16 @@ func (r *readRepoImpl) GetParsedTxsWithPriceOfPair(pairId uint64, priceToken str
 		"join pair p on parsed_tx.chain_id = p.chain_id and parsed_tx.contract = p.contract "+
 			"join tokens t0 on parsed_tx.chain_id = t0.chain_id and parsed_tx.asset0 = t0.address "+
 			"join tokens t1 on parsed_tx.chain_id = t1.chain_id and parsed_tx.asset1 = t1.address "+
-			"left outer join price p0 on t0.id = p0.token_id and p0.height <= parsed_tx.height "+
-			"left outer join price p1 on t1.id = p1.token_id and p1.height <= parsed_tx.height").Where(
+			"join tokens price_token on parsed_tx.chain_id = price_token.chain_id and price_token.address = ? "+
+			"left outer join price p0 on t0.id = p0.token_id and p0.price_token_id = price_token.id and p0.chain_id = parsed_tx.chain_id and p0.height <= parsed_tx.height "+
+			"left outer join price p1 on t1.id = p1.token_id and p1.price_token_id = price_token.id and p1.chain_id = parsed_tx.chain_id and p1.height <= parsed_tx.height",
+		priceToken).Where(
 		"parsed_tx.chain_id = ? and p.id = ? and parsed_tx.timestamp >= ? and parsed_tx.timestamp < ? and type in ('swap', 'provide', 'withdraw')", r.chainId, pairId, startTs, endTs).Order(
 		"parsed_tx.height, p0.height desc, p1.height desc").Select(
-		"distinct on (parsed_tx.height) parsed_tx.asset0_amount, parsed_tx.asset1_amount,"+
-			"parsed_tx.commission0_amount, parsed_tx.commission1_amount,"+
-			"CASE WHEN t0.address = ? THEN '1' ELSE coalesce(p0.price, '0') END price0, CASE WHEN t1.address = ? THEN '1' ELSE coalesce(p1.price, '0') END price1,"+
-			"t0.decimals decimals0, t1.decimals decimals1",
-		priceToken, priceToken).Find(&res); tx.Error != nil {
+		"distinct on (parsed_tx.height) parsed_tx.asset0_amount, parsed_tx.asset1_amount," +
+			"parsed_tx.commission0_amount, parsed_tx.commission1_amount," +
+			"CASE WHEN t0.id = price_token.id THEN '1' ELSE coalesce(p0.price, '0') END price0, CASE WHEN t1.id = price_token.id THEN '1' ELSE coalesce(p1.price, '0') END price1," +
+			"t0.decimals decimals0, t1.decimals decimals1").Find(&res); tx.Error != nil {
 		return nil, errors.Wrap(tx.Error, "repo.GetParsedTxsWithPriceOfPair")
 	}
 
@@ -288,14 +312,15 @@ from (select distinct -- processed asset0 values
                 pt.type,
                 pt.asset0_amount as volume,
                 pt.commission0_amount as commission,
-                coalesce(pr.price, case when t.address = ? then 1 else 0 end) as price,
+                case when t.id = price_token.id then 1 else coalesce(pr.price, 0) end as price,
                 t.decimals
             from parsed_tx pt
                 join pair p on pt.chain_id = p.chain_id and pt.contract = p.contract
                 join tokens t on pt.chain_id = t.chain_id and pt.asset0 = t.address
+                join tokens price_token on pt.chain_id = price_token.chain_id and price_token.address = ?
                 left join lateral (
                     select price from price
-                    where token_id = t.id and height <= pt.height and chain_id = ?
+                    where token_id = t.id and price_token_id = price_token.id and height <= pt.height and chain_id = ?
                     order by height desc limit 1
                 ) pr on true
             where pt.chain_id = ?
@@ -334,14 +359,15 @@ from (select distinct -- processed asset1 values
                 type,
                 pt.asset1_amount as volume,
                 pt.commission1_amount as commission,
-                coalesce(pr.price, case when t.address = ? then 1 else 0 end) as price,
+                coalesce(pr.price, case when t.id = price_token.id then 1 else 0 end) as price,
                 t.decimals
             from parsed_tx pt
                 join pair p on pt.chain_id = p.chain_id and pt.contract = p.contract
                 join tokens t on pt.chain_id = t.chain_id and pt.asset1 = t.address
+                join tokens price_token on pt.chain_id = price_token.chain_id and price_token.address = ?
                 left join lateral (
                     select price from price
-                    where token_id = t.id and height <= pt.height and chain_id = ?
+                    where token_id = t.id and price_token_id = price_token.id and height <= pt.height and chain_id = ?
                     order by height desc limit 1
                 ) pr on true
             where pt.chain_id = ?
@@ -515,7 +541,12 @@ GROUP BY address, pair_id;
 
 func (r *readRepoImpl) LiquiditiesOfPairStats(startTs float64, endTs float64, priceToken string) (pairIdLpMap map[uint64]schemas.PairStats30m, err error) {
 	query := `
-WITH latest_lp AS (
+WITH price_token AS (
+    SELECT id
+    FROM tokens
+    WHERE chain_id = ? AND address = ?
+),
+latest_lp AS (
     SELECT pair_id, MAX(height) AS height
     FROM lp_history
     WHERE chain_id = ?
@@ -539,10 +570,13 @@ token_price_by_height AS (
         rht.token_decimals,
         rht.height
     FROM required_height_by_token rht
+    CROSS JOIN price_token
     LEFT JOIN LATERAL (
         SELECT p.price
         FROM price p
         WHERE p.token_id = rht.token_id
+          AND p.price_token_id = price_token.id
+          AND p.chain_id = ?
           AND p.height <= rht.height
         ORDER BY p.height DESC, p.id DESC
         LIMIT 1
@@ -561,7 +595,7 @@ FROM lp_history lh
 `
 
 	var pairLps []schemas.PairStats30m
-	if tx := r.db.Raw(query, r.chainId, startTs, endTs, priceToken).Scan(&pairLps); tx.Error != nil {
+	if tx := r.db.Raw(query, r.chainId, priceToken, r.chainId, startTs, endTs, priceToken, r.chainId).Scan(&pairLps); tx.Error != nil {
 		return nil, errors.Wrap(tx.Error, "repo.LiquiditiesOfPairStats")
 	}
 

--- a/pkg/db/parser/repository_test.go
+++ b/pkg/db/parser/repository_test.go
@@ -744,6 +744,126 @@ func (s *aggregatorReadRepoSuite) Test_AccountStats_CountsDistinctHashesButSumsR
 	assert.Equal("3", actual[0].NetAsset1Amount)
 }
 
+func (s *aggregatorReadRepoSuite) Test_RecentPrices_FiltersByPriceTokenId() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	otherPriceToken := "ukrw"
+	asset := "terra0asset"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE price, tokens CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES
+         (3000, $1, $2, 0),
+         (3001, $1, $3, 0),
+         (3002, $1, $4, 0)`,
+		chainName, priceToken, otherPriceToken, asset,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES
+         (99, $1, 3002, '2', 3001, 0),
+         (90, $1, 3002, '7', 3000, 0),
+         (110, $1, 3002, '9', 3000, 0)`,
+		chainName,
+	).Error)
+
+	actual, err := s.Repo.RecentPrices(100, 120, []string{"3002"}, priceToken)
+
+	require.NoError(err)
+	require.Contains(actual, uint64(3002))
+	require.Len(actual[3002], 2)
+	assert.Equal(uint64(90), actual[3002][0].Height)
+	assert.Equal("7", actual[3002][0].Price)
+	assert.Equal(uint64(110), actual[3002][1].Height)
+	assert.Equal("9", actual[3002][1].Price)
+}
+
+func (s *aggregatorReadRepoSuite) Test_GetParsedTxsWithPriceOfPair_FiltersByPriceTokenId() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	otherPriceToken := "ukrw"
+	asset := "terra0asset"
+	contract := "terra0pricefilterpair"
+	pairId := uint64(300)
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, contract, asset, priceToken, "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES
+         (3100, $1, $2, 0),
+         (3101, $1, $3, 0),
+         (3102, $1, $4, 0)`,
+		chainName, priceToken, otherPriceToken, asset,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES
+         (99, $1, 3102, '2', 3101, 0),
+         (90, $1, 3102, '7', 3100, 0)`,
+		chainName,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES ($1, 100, $2, 'price-filter-pair', 'swap', 'terra0wallet', $3, $4, '-10', $5, '1', 'terra0lp', '0', '0', '0', '0')`,
+		chainName, start, contract, asset, priceToken,
+	).Error)
+
+	actual, err := s.Repo.GetParsedTxsWithPriceOfPair(pairId, priceToken, start, end)
+
+	require.NoError(err)
+	require.Len(actual, 1)
+	assert.Equal("7", actual[0].Price0)
+	assert.Equal("1", actual[0].Price1)
+}
+
+func (s *aggregatorReadRepoSuite) Test_PairStats_FiltersByPriceTokenId() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	otherPriceToken := "ukrw"
+	asset := "terra0asset"
+	contract := "terra0pairstatsfilter"
+	pairId := uint64(301)
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE parsed_tx, price, tokens, pair CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO pair(id, chain_id, contract, asset0, asset1, lp) VALUES($1, $2, $3, $4, $5, $6)`,
+		pairId, chainName, contract, asset, priceToken, "terra0lp",
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES
+         (3200, $1, $2, 0),
+         (3201, $1, $3, 0),
+         (3202, $1, $4, 0)`,
+		chainName, priceToken, otherPriceToken, asset,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES
+         (99, $1, 3202, '2', 3201, 0),
+         (90, $1, 3202, '7', 3200, 0)`,
+		chainName,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO parsed_tx(chain_id, height, timestamp, hash, type, sender, contract, asset0, asset0_amount, asset1, asset1_amount, lp, lp_amount, commission_amount, commission0_amount, commission1_amount)
+         VALUES ($1, 100, $2, 'pair-stats-price-filter', 'swap', 'terra0wallet', $3, $4, '-10', $5, '1', 'terra0lp', '0', '0', '0', '0')`,
+		chainName, start, contract, asset, priceToken,
+	).Error)
+
+	actual, err := s.Repo.PairStats(start, end, priceToken, map[uint64]schemas.PairStats30m{})
+
+	require.NoError(err)
+	require.Len(actual, 1)
+	volume0InPrice, err := strconv.ParseFloat(actual[0].Volume0InPrice, 64)
+	require.NoError(err)
+	assert.Equal(70.0, volume0InPrice)
+}
+
 func (s *aggregatorReadRepoSuite) Test_CommissionAmountInPair() {
 	assert := assert.New(s.T())
 
@@ -774,13 +894,17 @@ func (s *aggregatorReadRepoSuite) Test_LiquiditiesOfPairStats_UsesOneForPriceTok
 		pairId, chainName, "terra0pricepair", priceToken, "terra0asset", "terra0lp",
 	).Error)
 	require.NoError(s.DB.Exec(
-		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, $4), ($5, $6, $7, $8)`,
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES($1, $2, $3, $4), ($5, $6, $7, $8), ($9, $10, $11, $12)`,
 		1000, chainName, priceToken, 6,
 		1001, chainName, "terra0asset", 6,
+		1002, chainName, "ukrw", 6,
 	).Error)
 	require.NoError(s.DB.Exec(
-		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES($1, $2, $3, $4, $5, $6)`,
-		99, chainName, 1001, "2", 1000, 0,
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES
+         ($1, $2, $3, $4, $5, $6),
+         ($7, $8, $9, $10, $11, $12)`,
+		99, chainName, 1001, "9", 1002, 0,
+		90, chainName, 1001, "2", 1000, 0,
 	).Error)
 	require.NoError(s.DB.Exec(
 		`INSERT INTO lp_history(height, pair_id, chain_id, liquidity0, liquidity1, timestamp) VALUES($1, $2, $3, $4, $5, $6)`,

--- a/pkg/db/parser/repository_test.go
+++ b/pkg/db/parser/repository_test.go
@@ -779,6 +779,35 @@ func (s *aggregatorReadRepoSuite) Test_RecentPrices_FiltersByPriceTokenId() {
 	assert.Equal("9", actual[3002][1].Price)
 }
 
+func (s *aggregatorReadRepoSuite) Test_RecentPrices_ReturnsFirstInWindowPriceWithoutPreStartPrice() {
+	assert := assert.New(s.T())
+	require := require.New(s.T())
+
+	priceToken := "uusd"
+	asset := "terra0asset"
+
+	require.NoError(s.DB.Exec(`TRUNCATE TABLE price, tokens CASCADE`).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO tokens(id, chain_id, address, decimals) VALUES
+         (3100, $1, $2, 0),
+         (3101, $1, $3, 0)`,
+		chainName, priceToken, asset,
+	).Error)
+	require.NoError(s.DB.Exec(
+		`INSERT INTO price(height, chain_id, token_id, price, price_token_id, route_id) VALUES
+         (110, $1, 3101, '9', 3100, 0)`,
+		chainName,
+	).Error)
+
+	actual, err := s.Repo.RecentPrices(100, 120, []string{"3101"}, priceToken)
+
+	require.NoError(err)
+	require.Contains(actual, uint64(3101))
+	require.Len(actual[3101], 1)
+	assert.Equal(uint64(110), actual[3101][0].Height)
+	assert.Equal("9", actual[3101][0].Price)
+}
+
 func (s *aggregatorReadRepoSuite) Test_GetParsedTxsWithPriceOfPair_FiltersByPriceTokenId() {
 	assert := assert.New(s.T())
 	require := require.New(s.T())


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Account stats aggregation depends on price-derived data being available for the same target height. Without waiting for the price task, account stats can run before the required upstream aggregation has caught up.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Make the account stats update task depend on the price update task.
- Resolve the target end height once before aggregation and wait for parent tasks to reach that height.
- Add regression coverage for parent-task coordination before account stats completes.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a concurrent, idempotent database index to speed up recent price lookups.

* **Bug Fixes**
  * Updated price-related queries to consistently filter and compute results using the selected price-token identifier.
  * Improved joins and price selection for parsed transactions, pair statistics, and liquidity calculations to ensure values come from the correct token source.

* **Tests**
  * Expanded automated test coverage to verify price-token filtering across recent prices, parsed transactions, pair stats, and liquidity-in-price behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->