### PR TITLE
feat: allow partial DEX parsing for ambiguous wasm transfers

### DIFF
--- a/parser/checkpoint/builder.go
+++ b/parser/checkpoint/builder.go
@@ -41,7 +41,7 @@ func (b *Builder) Build(targetHeight uint64) error {
 	}
 
 	// Save checkpoint data (transactions, pools, pairs) to database
-	if err := b.repo.Insert(dbHeight, targetHeight, txs, pools, pairs); err != nil {
+	if err := b.repo.Insert(dbHeight, targetHeight, txs, pools, pairs, []dex.ParseQuarantine{}); err != nil {
 		return errors.Wrap(err, "failed to insert data")
 	}
 

--- a/parser/checkpoint/builder_test.go
+++ b/parser/checkpoint/builder_test.go
@@ -56,10 +56,6 @@ func (m *MockRepo) ClearValidationHeight() error {
 	return nil
 }
 
-func (m *MockRepo) UpsertParseQuarantine(_ dex.ParseQuarantine) error {
-	return nil
-}
-
 func (m *MockRepo) PendingParseQuarantines() ([]dex.ParseQuarantine, error) {
 	return nil, nil
 }

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -133,8 +133,17 @@ func (app *dexApp) Run() error {
 		for _, tx := range txs {
 			txs, err := app.ParseTxs(tx, cur)
 			if err != nil {
+				var partial *PartialParseQuarantineError
+				if errors.As(err, &partial) {
+					if err := app.UpsertParseQuarantine(partial.Quarantine); err != nil {
+						return fmt.Errorf("app.Run partial quarantine tx_hash=%s: %w", tx.Hash, err)
+					}
+					app.logger.Errorf("partially quarantined ambiguous transaction height=%d tx_hash=%s err=%s", cur, tx.Hash, err)
+					parsedTxs = append(parsedTxs, partial.ParsedTxs...)
+					continue
+				}
 				var ambiguity *eventlog.AmbiguousEventError
-				if errors.As(err, &ambiguity) && !rawTxContainsCreatePair(tx) {
+				if errors.As(err, &ambiguity) && !RawTxContainsCreatePair(tx) {
 					// Raw transactions remain available, so parser progress does not prevent deterministic replay.
 					if err := app.UpsertParseQuarantine(ParseQuarantine{
 						Height:   cur,
@@ -196,6 +205,9 @@ func (app *dexApp) retryPendingQuarantines(tokenExceptions map[string]bool) erro
 	}
 
 	for _, quarantine := range quarantines {
+		if IsPartialQuarantineStage(quarantine.Stage) {
+			continue
+		}
 		if err := app.UpdateParsers(tokenExceptions, quarantine.Height); err != nil {
 			return fmt.Errorf("update parsers for quarantine id=%d: %w", quarantine.ID, err)
 		}
@@ -213,18 +225,6 @@ func (app *dexApp) retryPendingQuarantines(tokenExceptions map[string]bool) erro
 		app.logger.Infof("resolved quarantined transaction height=%d tx_hash=%s", quarantine.Height, quarantine.Hash)
 	}
 	return nil
-}
-
-// rawTxContainsCreatePair guards parser state changes from being skipped into quarantine.
-func rawTxContainsCreatePair(tx parser.RawTx) bool {
-	for _, log := range tx.LogResults {
-		for _, attr := range log.Attributes {
-			if attr.Key == "action" && attr.Value == string(CreatePair) {
-				return true
-			}
-		}
-	}
-	return false
 }
 
 // parseStage extracts the explicit ParseTxs wrapper stage for quarantine diagnostics.

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -130,14 +130,13 @@ func (app *dexApp) Run() error {
 		}
 
 		parsedTxs := []ParsedTx{}
+		parseQuarantines := []ParseQuarantine{}
 		for _, tx := range txs {
 			txs, err := app.ParseTxs(tx, cur)
 			if err != nil {
 				var partial *PartialParseQuarantineError
 				if errors.As(err, &partial) {
-					if err := app.UpsertParseQuarantine(partial.Quarantine); err != nil {
-						return fmt.Errorf("app.Run partial quarantine tx_hash=%s: %w", tx.Hash, err)
-					}
+					parseQuarantines = append(parseQuarantines, partial.Quarantine)
 					app.logger.Errorf("partially quarantined ambiguous transaction height=%d tx_hash=%s err=%s", cur, tx.Hash, err)
 					parsedTxs = append(parsedTxs, partial.ParsedTxs...)
 					continue
@@ -145,7 +144,7 @@ func (app *dexApp) Run() error {
 				var ambiguity *eventlog.AmbiguousEventError
 				if errors.As(err, &ambiguity) && !RawTxContainsCreatePair(tx) {
 					// Raw transactions remain available, so parser progress does not prevent deterministic replay.
-					if err := app.UpsertParseQuarantine(ParseQuarantine{
+					parseQuarantines = append(parseQuarantines, ParseQuarantine{
 						Height:   cur,
 						Hash:     tx.Hash,
 						Stage:    parseStage(err),
@@ -153,9 +152,7 @@ func (app *dexApp) Run() error {
 						Action:   ambiguity.Action,
 						Error:    err.Error(),
 						RawTx:    tx,
-					}); err != nil {
-						return fmt.Errorf("app.Run quarantine tx_hash=%s: %w", tx.Hash, err)
-					}
+					})
 					app.logger.Errorf("quarantined ambiguous transaction height=%d tx_hash=%s err=%s", cur, tx.Hash, err)
 					continue
 				}
@@ -172,7 +169,7 @@ func (app *dexApp) Run() error {
 			}
 		}
 
-		if err := app.insert(cur-1, cur, parsedTxs, poolInfos); err != nil {
+		if err := app.insert(cur-1, cur, parsedTxs, poolInfos, parseQuarantines); err != nil {
 			return fmt.Errorf("app.Run: %w", err)
 		}
 
@@ -250,7 +247,7 @@ func parseStage(err error) string {
 }
 
 // insert implements parser
-func (app *dexApp) insert(srcHeight uint64, targetHeight uint64, txs []ParsedTx, pools []PoolInfo) error {
+func (app *dexApp) insert(srcHeight uint64, targetHeight uint64, txs []ParsedTx, pools []PoolInfo, quarantines []ParseQuarantine) error {
 	pairDtos := []Pair{}
 	for _, tx := range txs {
 		if tx.Type == CreatePair {
@@ -263,7 +260,7 @@ func (app *dexApp) insert(srcHeight uint64, targetHeight uint64, txs []ParsedTx,
 		}
 	}
 
-	err := app.Insert(srcHeight, targetHeight, txs, pools, pairDtos)
+	err := app.Insert(srcHeight, targetHeight, txs, pools, pairDtos, quarantines)
 	if err != nil {
 		return fmt.Errorf("insert: %w", err)
 	}

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -204,6 +204,55 @@ func Test_Run_DoesNotQuarantineCreatePairTransaction(t *testing.T) {
 	repo.AssertNotCalled(t, "Insert", mock.Anything)
 }
 
+func Test_Run_UpsertsPartialQuarantineAndInsertsParsedTxs(t *testing.T) {
+	rawTx := parser.RawTx{Hash: "partial"}
+	parsedTx := ParsedTx{
+		Hash:         rawTx.Hash,
+		Type:         Transfer,
+		Sender:       "sender",
+		ContractAddr: "pair",
+		Assets:       [2]Asset{{Addr: "asset0", Amount: "1"}, {Addr: "asset1", Amount: "0"}},
+	}
+	quarantine := ParseQuarantine{
+		Height:   1,
+		Hash:     rawTx.Hash,
+		Stage:    PartialQuarantineStagePrefix + "wasm_transfer",
+		Contract: "token",
+		Action:   "transfer",
+		Error:    "ambiguous amount",
+		RawTx:    rawTx,
+	}
+	target := &quarantineTargetApp{parse: func(parser.RawTx, uint64) ([]ParsedTx, error) {
+		return nil, &PartialParseQuarantineError{
+			ParsedTxs:  []ParsedTx{parsedTx},
+			Quarantine: quarantine,
+			Err:        errors.New(quarantine.Error),
+		}
+	}}
+	repo := &RepoMock{}
+	srcStore := &RawStoreMock{}
+	app := &dexApp{
+		TargetApp:            target,
+		Repo:                 repo,
+		SourceDataStore:      srcStore,
+		logger:               logging.Discard,
+		poolSnapshotInterval: 100,
+		sameHeightTolerance:  3,
+		quarantineRetryMode:  configs.QuarantineRetryDisabled,
+	}
+
+	repo.On("GetTokenExceptions").Return(map[string]bool{}, nil)
+	repo.On("GetSyncedHeight").Return(uint64(0), nil)
+	srcStore.On("GetSourceSyncedHeight").Return(uint64(1), nil)
+	srcStore.On("GetSourceTxs", uint64(1)).Return(parser.RawTxs{rawTx}, nil)
+	repo.On("UpsertParseQuarantine", quarantine).Return(nil)
+	repo.On("Insert", uint64(0), uint64(1), []ParsedTx{parsedTx}, []PoolInfo{}, []Pair{}).Return(nil)
+
+	require.NoError(t, app.Run())
+	repo.AssertExpectations(t)
+	srcStore.AssertExpectations(t)
+}
+
 func Test_retryPendingQuarantines_ResolvesSuccessfulReplay(t *testing.T) {
 	rawTx := parser.RawTx{Hash: "replay"}
 	parsedTx := ParsedTx{
@@ -261,6 +310,31 @@ func Test_retryPendingQuarantines_LeavesAmbiguousReplayPending(t *testing.T) {
 	require.NoError(t, app.retryPendingQuarantines(map[string]bool{}))
 	repo.AssertNotCalled(t, "ResolveParseQuarantine", mock.Anything)
 }
+
+func Test_retryPendingQuarantines_SkipsPartialQuarantine(t *testing.T) {
+	rawTx := parser.RawTx{Hash: "partial"}
+	target := &quarantineTargetApp{parse: func(parser.RawTx, uint64) ([]ParsedTx, error) {
+		t.Fatal("partial quarantines must not be retried")
+		return nil, nil
+	}}
+	repo := &RepoMock{}
+	app := &dexApp{
+		TargetApp: target,
+		Repo:      repo,
+		logger:    logging.Discard,
+	}
+	repo.On("PendingParseQuarantines").Return([]ParseQuarantine{{
+		ID:     9,
+		Height: 12,
+		Hash:   rawTx.Hash,
+		Stage:  PartialQuarantineStagePrefix + "wasm_transfer",
+		RawTx:  rawTx,
+	}}, nil)
+
+	require.NoError(t, app.retryPendingQuarantines(map[string]bool{}))
+	repo.AssertNotCalled(t, "ResolveParseQuarantine", mock.Anything)
+}
+
 func Test_validate(t *testing.T) {
 	tcs := []struct {
 		actualPools []PoolInfo

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -74,10 +74,11 @@ func Test_insert(t *testing.T) {
 		if tc.errMsg != "" {
 			err = errors.New(tc.errMsg)
 		}
-		repoMock.On("Insert", height-1, height, tc.txs, tc.poolInfos, pairDtos).Return(err)
+		quarantines := []ParseQuarantine{}
+		repoMock.On("Insert", height-1, height, tc.txs, tc.poolInfos, pairDtos, quarantines).Return(err)
 
 		app := dexApp{Repo: &repoMock}
-		err = app.insert(height-1, height, tc.txs, tc.poolInfos)
+		err = app.insert(height-1, height, tc.txs, tc.poolInfos, quarantines)
 		if tc.errMsg != "" {
 			assert.Error(t, err, tc.errMsg)
 			repoMock.AssertExpectations(t)
@@ -154,14 +155,18 @@ func Test_Run_QuarantinesAmbiguousTransactionAndAdvancesHeight(t *testing.T) {
 	repo.On("GetSyncedHeight").Return(uint64(0), nil)
 	srcStore.On("GetSourceSyncedHeight").Return(uint64(1), nil)
 	srcStore.On("GetSourceTxs", uint64(1)).Return(parser.RawTxs{ambiguousTx, normalTx}, nil)
-	repo.On("UpsertParseQuarantine", mock.MatchedBy(func(q ParseQuarantine) bool {
+	expectedQuarantines := mock.MatchedBy(func(qs []ParseQuarantine) bool {
+		if len(qs) != 1 {
+			return false
+		}
+		q := qs[0]
 		return q.Height == 1 &&
 			q.Hash == ambiguousTx.Hash &&
 			q.Stage == "unknown" &&
 			q.Contract == "token" &&
 			q.Action == "transfer"
-	})).Return(nil)
-	repo.On("Insert", uint64(0), uint64(1), []ParsedTx{expectedTx}, []PoolInfo{}, []Pair{}).Return(nil)
+	})
+	repo.On("Insert", uint64(0), uint64(1), []ParsedTx{expectedTx}, []PoolInfo{}, []Pair{}, expectedQuarantines).Return(nil)
 
 	require.NoError(t, app.Run())
 	repo.AssertExpectations(t)
@@ -200,7 +205,6 @@ func Test_Run_DoesNotQuarantineCreatePairTransaction(t *testing.T) {
 
 	err := app.Run()
 	require.Error(t, err)
-	repo.AssertNotCalled(t, "UpsertParseQuarantine", mock.Anything)
 	repo.AssertNotCalled(t, "Insert", mock.Anything)
 }
 
@@ -245,8 +249,7 @@ func Test_Run_UpsertsPartialQuarantineAndInsertsParsedTxs(t *testing.T) {
 	repo.On("GetSyncedHeight").Return(uint64(0), nil)
 	srcStore.On("GetSourceSyncedHeight").Return(uint64(1), nil)
 	srcStore.On("GetSourceTxs", uint64(1)).Return(parser.RawTxs{rawTx}, nil)
-	repo.On("UpsertParseQuarantine", quarantine).Return(nil)
-	repo.On("Insert", uint64(0), uint64(1), []ParsedTx{parsedTx}, []PoolInfo{}, []Pair{}).Return(nil)
+	repo.On("Insert", uint64(0), uint64(1), []ParsedTx{parsedTx}, []PoolInfo{}, []Pair{}, []ParseQuarantine{quarantine}).Return(nil)
 
 	require.NoError(t, app.Run())
 	repo.AssertExpectations(t)

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -332,7 +332,7 @@ func Test_retryPendingQuarantines_SkipsPartialQuarantine(t *testing.T) {
 	}}, nil)
 
 	require.NoError(t, app.retryPendingQuarantines(map[string]bool{}))
-	repo.AssertNotCalled(t, "ResolveParseQuarantine", mock.Anything)
+	repo.AssertNumberOfCalls(t, "ResolveParseQuarantine", 0)
 }
 
 func Test_validate(t *testing.T) {

--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -54,6 +54,7 @@ func New(repo dex.PairRepo, _ logging.Logger, c configs.ParserDexConfig, chainId
 
 func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
 	txDtos := []dex.ParsedTx{}
+	partialQuarantine := dex.NewPartialQuarantineRecorder(tx, height)
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "dezswap.ParseTxs create_pair tx_hash=%s", tx.Hash)
@@ -91,7 +92,10 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrapf(err, "dezswap.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			wrapped := errors.Wrapf(err, "dezswap.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			if !partialQuarantine.Record("wasm_transfer", wrapped) {
+				return nil, wrapped
+			}
 		}
 		wasmTransferTxs = append(wasmTransferTxs, wtxs...)
 
@@ -115,6 +119,10 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTransferTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
+
+	if err := partialQuarantine.Err(txDtos); err != nil {
+		return txDtos, err
+	}
 
 	return txDtos, nil
 }

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -29,6 +30,18 @@ const (
 )
 
 var testPair = dex.Pair{ContractAddr: pairAddr, LpAddr: lpAddr, Assets: []string{asset1, asset2}}
+
+type parseFunc struct {
+	parse func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error)
+}
+
+func (f parseFunc) Parse(raws eventlog.LogResults, defaultVal parser.Overrider[dex.ParsedTx], optionals ...interface{}) ([]*dex.ParsedTx, error) {
+	return f.parse(raws, defaultVal, optionals...)
+}
+
+func (f parseFunc) MatchedToParsedTx(eventlog.MatchedResult, ...interface{}) ([]*dex.ParsedTx, error) {
+	return nil, nil
+}
 
 func Test_ParseTxs(t *testing.T) {
 	type testcase struct {
@@ -222,6 +235,145 @@ func Test_ParseTxs_AppendsInitialProvideWhenPairActionHasProvide(t *testing.T) {
 			LpAmount:     "30",
 		},
 	}, txs)
+}
+
+func Test_ParseTxs_PartialQuarantineKeepsParsedTxsFromSameRawLog(t *testing.T) {
+	pairActionParser := parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+		return []*dex.ParsedTx{{
+			Hash:         txHash,
+			Type:         dex.Swap,
+			ContractAddr: pairAddr,
+			Assets:       [2]dex.Asset{{Addr: asset1, Amount: "10"}, {Addr: asset2, Amount: "-20"}},
+		}}, nil
+	}}
+	wasmTransferParser := parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+		return []*dex.ParsedTx{{
+				Hash:         txHash,
+				Type:         dex.Transfer,
+				Sender:       "partial-sender",
+				ContractAddr: "partial-token",
+				Assets:       [2]dex.Asset{{Addr: asset1, Amount: "3"}},
+			}}, &eventlog.AmbiguousEventError{
+				Contract: "ambiguous-token",
+				Action:   "transfer",
+				Key:      "amount",
+				Values:   []string{"1", "2"},
+			}
+	}}
+	transferParser := parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+		return []*dex.ParsedTx{{
+			Hash:         txHash,
+			Type:         dex.Transfer,
+			Sender:       "bank-sender",
+			ContractAddr: "bank-token",
+			Assets:       [2]dex.Asset{{Addr: "bank-token", Amount: "7"}},
+		}}, nil
+	}}
+	emptyParser := parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+		return nil, nil
+	}}
+	app := dezswapApp{
+		PairRepo: &dex.RepoMock{},
+		Parsers: &dex.PairParsers{
+			CreatePairParser: emptyParser,
+			PairActionParser: pairActionParser,
+			InitialProvide:   emptyParser,
+			WasmTransfer:     wasmTransferParser,
+			Transfer:         transferParser,
+			BurnParser:       emptyParser,
+		},
+		DexMixin:    dex.DexMixin{},
+		chainId:     chainId,
+		pairs:       map[string]dex.Pair{pairAddr: testPair},
+		lpPairAddrs: map[string]string{lpAddr: pairAddr},
+	}
+	tx := parser.RawTx{
+		Sender: txSender,
+		Hash:   txHash,
+		LogResults: eventlog.LogResults{{
+			Type: eventlog.WasmType,
+			Attributes: eventlog.Attributes{
+				{Key: "_contract_address", Value: pairAddr},
+				{Key: "action", Value: "swap"},
+				{Key: "action", Value: "transfer"},
+			},
+		}},
+	}
+
+	txs, err := app.ParseTxs(tx, 100)
+
+	var partial *dex.PartialParseQuarantineError
+	require.ErrorAs(t, err, &partial)
+	assert.Equal(t, partial.ParsedTxs, txs)
+	assert.Equal(t, dex.PartialQuarantineStagePrefix+"wasm_transfer", partial.Quarantine.Stage)
+	assert.Equal(t, "ambiguous-token", partial.Quarantine.Contract)
+	assert.Equal(t, tx, partial.Quarantine.RawTx)
+	assert.Equal(t, []dex.ParsedTx{{
+		Hash:         txHash,
+		Type:         dex.Swap,
+		Sender:       txSender,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: asset1, Amount: "10"}, {Addr: asset2, Amount: "-20"}},
+	}, {
+		Hash:         txHash,
+		Type:         dex.Transfer,
+		Sender:       "partial-sender",
+		ContractAddr: "partial-token",
+		Assets:       [2]dex.Asset{{Addr: asset1, Amount: "3"}},
+	}, {
+		Hash:         txHash,
+		Type:         dex.Transfer,
+		Sender:       "bank-sender",
+		ContractAddr: "bank-token",
+		Assets:       [2]dex.Asset{{Addr: "bank-token", Amount: "7"}},
+	}}, txs)
+}
+
+func Test_ParseTxs_DoesNotPartialQuarantineCreatePairTransaction(t *testing.T) {
+	ambiguous := &eventlog.AmbiguousEventError{
+		Contract: "token",
+		Action:   "transfer",
+		Key:      "amount",
+		Values:   []string{"1", "2"},
+	}
+	emptyParser := parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+		return nil, nil
+	}}
+	app := dezswapApp{
+		PairRepo: &dex.RepoMock{},
+		Parsers: &dex.PairParsers{
+			CreatePairParser: emptyParser,
+			PairActionParser: parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+				return nil, nil
+			}},
+			InitialProvide: emptyParser,
+			WasmTransfer: parseFunc{parse: func(eventlog.LogResults, parser.Overrider[dex.ParsedTx], ...interface{}) ([]*dex.ParsedTx, error) {
+				return nil, ambiguous
+			}},
+			Transfer:   emptyParser,
+			BurnParser: emptyParser,
+		},
+		DexMixin:    dex.DexMixin{},
+		chainId:     chainId,
+		pairs:       map[string]dex.Pair{pairAddr: testPair},
+		lpPairAddrs: map[string]string{lpAddr: pairAddr},
+	}
+	tx := parser.RawTx{
+		Sender: txSender,
+		Hash:   txHash,
+		LogResults: eventlog.LogResults{{
+			Type: eventlog.WasmType,
+			Attributes: eventlog.Attributes{
+				{Key: "action", Value: string(dex.CreatePair)},
+			},
+		}},
+	}
+
+	_, err := app.ParseTxs(tx, 100)
+
+	var partial *dex.PartialParseQuarantineError
+	assert.NotErrorAs(t, err, &partial)
+	assert.ErrorIs(t, err, ambiguous)
 }
 
 func Test_ParseTxs_ReturnsStageAndTxHashOnError(t *testing.T) {

--- a/parser/dex/interface.go
+++ b/parser/dex/interface.go
@@ -4,6 +4,13 @@ import (
 	"github.com/dezswap/cosmwasm-etl/parser"
 )
 
+const (
+	InsertArgPoolsIndex = iota
+	InsertArgPairsIndex
+	InsertArgParseQuarantinesIndex
+	InsertArgCount
+)
+
 type DexParserApp interface {
 	Run() error
 	TargetApp
@@ -26,7 +33,6 @@ type Repo interface {
 	GetValidationHeight() (uint64, error)
 	SetValidationHeight(height uint64) error
 	ClearValidationHeight() error
-	UpsertParseQuarantine(quarantine ParseQuarantine) error
 	PendingParseQuarantines() ([]ParseQuarantine, error)
 	ResolveParseQuarantine(id uint64, height uint64, txs []ParsedTx) error
 }

--- a/parser/dex/mock.go
+++ b/parser/dex/mock.go
@@ -69,22 +69,27 @@ func (m *RepoMock) GetSyncedHeight() (uint64, error) {
 
 // Insert implements Repo
 func (m *RepoMock) Insert(srcHeight uint64, targetHeight uint64, txs []ParsedTx, arg ...interface{}) error {
-	if len(arg) != 2 {
+	if len(arg) != InsertArgCount {
 		errMsg := fmt.Sprintf("invalid others(%v)", arg)
 		return errors.New(errMsg)
 	}
 
-	pools, ok := arg[0].([]PoolInfo)
+	pools, ok := arg[InsertArgPoolsIndex].([]PoolInfo)
 	if !ok {
-		errMsg := fmt.Sprintf("invalid pools(%v)", arg[0])
+		errMsg := fmt.Sprintf("invalid pools(%v)", arg[InsertArgPoolsIndex])
 		return errors.New(errMsg)
 	}
-	pairs, ok := arg[1].([]Pair)
+	pairs, ok := arg[InsertArgPairsIndex].([]Pair)
 	if !ok {
-		errMsg := fmt.Sprintf("invalid pairs(%v)", arg[1])
+		errMsg := fmt.Sprintf("invalid pairs(%v)", arg[InsertArgPairsIndex])
 		return errors.New(errMsg)
 	}
-	args := m.MethodCalled("Insert", srcHeight, targetHeight, txs, pools, pairs)
+	quarantines, ok := arg[InsertArgParseQuarantinesIndex].([]ParseQuarantine)
+	if !ok {
+		errMsg := fmt.Sprintf("invalid quarantines(%v)", arg[InsertArgParseQuarantinesIndex])
+		return errors.New(errMsg)
+	}
+	args := m.MethodCalled("Insert", srcHeight, targetHeight, txs, pools, pairs, quarantines)
 	return args.Error(0)
 }
 
@@ -118,11 +123,6 @@ func (m *RepoMock) SetValidationHeight(_ uint64) error {
 // ClearValidationHeight implements Repo.
 func (m *RepoMock) ClearValidationHeight() error {
 	return nil
-}
-
-func (m *RepoMock) UpsertParseQuarantine(quarantine ParseQuarantine) error {
-	args := m.MethodCalled("UpsertParseQuarantine", quarantine)
-	return args.Error(0)
 }
 
 func (m *RepoMock) PendingParseQuarantines() ([]ParseQuarantine, error) {

--- a/parser/dex/parser_test.go
+++ b/parser/dex/parser_test.go
@@ -68,6 +68,36 @@ func Test_parser(t *testing.T) {
 	}
 }
 
+func Test_parser_ReturnsParsedTxsAndAmbiguityForPartialMatches(t *testing.T) {
+	logFinder := logfinderMock{}
+	mapper := mapperMock{}
+	firstMatch := eventlog.MatchedResult{{Key: "Key", Value: "First"}}
+	ambiguousMatch := eventlog.MatchedResult{{Key: "Key", Value: "Ambiguous"}}
+	thirdMatch := eventlog.MatchedResult{{Key: "Key", Value: "Third"}}
+	firstTx := &ParsedTx{Type: Provide, ContractAddr: "pair1"}
+	thirdTx := &ParsedTx{Type: Swap, ContractAddr: "pair2"}
+	ambiguousErr := &eventlog.AmbiguousEventError{
+		Contract: "token",
+		Action:   "transfer",
+		Key:      "amount",
+		Values:   []string{"1", "2"},
+	}
+
+	logFinder.On("FindFromLogs", mock.Anything).Return(eventlog.MatchedResults{firstMatch, ambiguousMatch, thirdMatch})
+	mapper.On("matchedToParsedTx", firstMatch, mock.Anything).Return([]*ParsedTx{firstTx}, nil)
+	mapper.On("matchedToParsedTx", ambiguousMatch, mock.Anything).Return([]*ParsedTx(nil), ambiguousErr)
+	mapper.On("matchedToParsedTx", thirdMatch, mock.Anything).Return([]*ParsedTx{thirdTx}, nil)
+
+	p := parser.NewParser[ParsedTx](&logFinder, &mapper)
+	txs, err := p.Parse(eventlog.LogResults{}, ParsedTx{Hash: "hash", Timestamp: time.Time{}})
+
+	assert.ErrorAs(t, err, &ambiguousErr)
+	assert.Equal(t, []*ParsedTx{
+		{Hash: "hash", Type: Provide, ContractAddr: "pair1"},
+		{Hash: "hash", Type: Swap, ContractAddr: "pair2"},
+	}, txs)
+}
+
 var _ eventlog.LogFinder = &logfinderMock{}
 var _ parser.Mapper[ParsedTx] = &mapperMock{}
 

--- a/parser/dex/quarantine.go
+++ b/parser/dex/quarantine.go
@@ -1,12 +1,18 @@
 package dex
 
 import (
+	"errors"
+	"strings"
+
 	"github.com/dezswap/cosmwasm-etl/parser"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 )
 
 const (
 	QuarantineStatusPending  = "pending"
 	QuarantineStatusResolved = "resolved"
+
+	PartialQuarantineStagePrefix = "partial_"
 )
 
 type ParseQuarantine struct {
@@ -18,4 +24,83 @@ type ParseQuarantine struct {
 	Action   string
 	Error    string
 	RawTx    parser.RawTx
+}
+
+type PartialParseQuarantineError struct {
+	ParsedTxs  []ParsedTx
+	Quarantine ParseQuarantine
+	Err        error
+}
+
+func (e *PartialParseQuarantineError) Error() string {
+	if e.Err == nil {
+		return "partial parse quarantine"
+	}
+	return e.Err.Error()
+}
+
+func (e *PartialParseQuarantineError) Unwrap() error {
+	return e.Err
+}
+
+func IsPartialQuarantineStage(stage string) bool {
+	return strings.HasPrefix(stage, PartialQuarantineStagePrefix)
+}
+
+type PartialQuarantineRecorder struct {
+	tx                 parser.RawTx
+	height             uint64
+	containsCreatePair bool
+	quarantine         *ParseQuarantine
+	err                error
+}
+
+func NewPartialQuarantineRecorder(tx parser.RawTx, height uint64) PartialQuarantineRecorder {
+	return PartialQuarantineRecorder{
+		tx:                 tx,
+		height:             height,
+		containsCreatePair: RawTxContainsCreatePair(tx),
+	}
+}
+
+func (r *PartialQuarantineRecorder) Record(stage string, err error) bool {
+	var ambiguity *eventlog.AmbiguousEventError
+	if !errors.As(err, &ambiguity) || r.containsCreatePair {
+		return false
+	}
+	if r.quarantine == nil {
+		r.quarantine = &ParseQuarantine{
+			Height:   r.height,
+			Hash:     r.tx.Hash,
+			Stage:    PartialQuarantineStagePrefix + stage,
+			Contract: ambiguity.Contract,
+			Action:   ambiguity.Action,
+			Error:    err.Error(),
+			RawTx:    r.tx,
+		}
+		r.err = err
+	}
+	return true
+}
+
+func (r *PartialQuarantineRecorder) Err(parsedTxs []ParsedTx) error {
+	if r.quarantine == nil {
+		return nil
+	}
+	return &PartialParseQuarantineError{
+		ParsedTxs:  parsedTxs,
+		Quarantine: *r.quarantine,
+		Err:        r.err,
+	}
+}
+
+func RawTxContainsCreatePair(tx parser.RawTx) bool {
+	for _, log := range tx.LogResults {
+		for _, attr := range log.Attributes {
+			if attr.Key == "action" && attr.Value == string(CreatePair) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/parser/dex/repo/repository.go
+++ b/parser/dex/repo/repository.go
@@ -61,19 +61,24 @@ func (r *repoImpl) GetPairs() (map[string]dex.Pair, error) {
 
 // Insert implements p_dex.Repo
 func (r *repoImpl) Insert(srcHeight uint64, targetHeight uint64, txs []dex.ParsedTx, arg ...interface{}) error {
-	if len(arg) != 2 {
+	if len(arg) != dex.InsertArgCount {
 		errMsg := fmt.Sprintf("invalid others(%v)", arg)
 		return errors.New(errMsg)
 	}
 
-	pools, ok := arg[0].([]dex.PoolInfo)
+	pools, ok := arg[dex.InsertArgPoolsIndex].([]dex.PoolInfo)
 	if !ok {
-		errMsg := fmt.Sprintf("invalid pools(%v)", arg[0])
+		errMsg := fmt.Sprintf("invalid pools(%v)", arg[dex.InsertArgPoolsIndex])
 		return errors.New(errMsg)
 	}
-	pairs, ok := arg[1].([]dex.Pair)
+	pairs, ok := arg[dex.InsertArgPairsIndex].([]dex.Pair)
 	if !ok {
-		errMsg := fmt.Sprintf("invalid pair(%v)", arg[1])
+		errMsg := fmt.Sprintf("invalid pair(%v)", arg[dex.InsertArgPairsIndex])
+		return errors.New(errMsg)
+	}
+	quarantines, ok := arg[dex.InsertArgParseQuarantinesIndex].([]dex.ParseQuarantine)
+	if !ok {
+		errMsg := fmt.Sprintf("invalid quarantines(%v)", arg[dex.InsertArgParseQuarantinesIndex])
 		return errors.New(errMsg)
 	}
 
@@ -91,14 +96,23 @@ func (r *repoImpl) Insert(srcHeight uint64, targetHeight uint64, txs []dex.Parse
 	}
 
 	return r.db.Transaction(func(tx *gorm.DB) error {
-		if err := tx.Model(schemas.Pair{}).CreateInBatches(pairTxs, len(pairTxs)).Error; err != nil {
-			return errors.Wrap(err, "repo.Insert.Pair")
+		if len(pairTxs) > 0 {
+			if err := tx.Model(schemas.Pair{}).CreateInBatches(pairTxs, len(pairTxs)).Error; err != nil {
+				return errors.Wrap(err, "repo.Insert.Pair")
+			}
 		}
-		if err := tx.Model(schemas.ParsedTx{}).Omit("Id").CreateInBatches(parsedTxs, len(parsedTxs)).Error; err != nil {
-			return errors.Wrap(err, "repo.Insert.ParsedTx")
+		if len(parsedTxs) > 0 {
+			if err := tx.Model(schemas.ParsedTx{}).Omit("Id").CreateInBatches(parsedTxs, len(parsedTxs)).Error; err != nil {
+				return errors.Wrap(err, "repo.Insert.ParsedTx")
+			}
 		}
-		if err := tx.Model(schemas.PoolInfo{}).CreateInBatches(poolInfoTxs, len(poolInfoTxs)).Error; err != nil {
-			return errors.Wrap(err, "repo.Insert.PoolInfo")
+		if len(poolInfoTxs) > 0 {
+			if err := tx.Model(schemas.PoolInfo{}).CreateInBatches(poolInfoTxs, len(poolInfoTxs)).Error; err != nil {
+				return errors.Wrap(err, "repo.Insert.PoolInfo")
+			}
+		}
+		if err := r.upsertParseQuarantines(tx, quarantines); err != nil {
+			return err
 		}
 		if err := tx.Model(&schemas.SyncedHeight{}).Where("chain_id = ? AND height = ?", r.chainId, srcHeight).Update("height", targetHeight).Error; err != nil {
 			return errors.Wrap(err, "repo.Insert.SyncedHeight")
@@ -217,39 +231,41 @@ func (r *repoImpl) ClearValidationHeight() error {
 	return nil
 }
 
-func (r *repoImpl) UpsertParseQuarantine(quarantine dex.ParseQuarantine) error {
-	rawTx, err := json.Marshal(quarantine.RawTx)
-	if err != nil {
-		return errors.Wrap(err, "repo.UpsertParseQuarantine")
-	}
+func (r *repoImpl) upsertParseQuarantines(tx *gorm.DB, quarantines []dex.ParseQuarantine) error {
+	for _, quarantine := range quarantines {
+		rawTx, err := json.Marshal(quarantine.RawTx)
+		if err != nil {
+			return errors.Wrap(err, "repo.Insert.ParseQuarantine")
+		}
 
-	row := schemas.ParseQuarantine{
-		ChainId:  r.chainId,
-		Height:   quarantine.Height,
-		Hash:     quarantine.Hash,
-		Stage:    quarantine.Stage,
-		Contract: quarantine.Contract,
-		Action:   quarantine.Action,
-		Error:    quarantine.Error,
-		RawTx:    schemas.JSON(rawTx),
-		Status:   dex.QuarantineStatusPending,
-	}
-	tx := r.db.Clauses(clause.OnConflict{
-		Columns: []clause.Column{{Name: "chain_id"}, {Name: "hash"}},
-		DoUpdates: clause.Assignments(map[string]interface{}{
-			"height":      row.Height,
-			"stage":       row.Stage,
-			"contract":    row.Contract,
-			"action":      row.Action,
-			"error":       row.Error,
-			"raw_tx":      row.RawTx,
-			"status":      row.Status,
-			"resolved_at": nil,
-			"updated_at":  gorm.Expr("EXTRACT(EPOCH FROM NOW())"),
-		}),
-	}).Create(&row)
-	if tx.Error != nil {
-		return errors.Wrap(tx.Error, "repo.UpsertParseQuarantine")
+		row := schemas.ParseQuarantine{
+			ChainId:  r.chainId,
+			Height:   quarantine.Height,
+			Hash:     quarantine.Hash,
+			Stage:    quarantine.Stage,
+			Contract: quarantine.Contract,
+			Action:   quarantine.Action,
+			Error:    quarantine.Error,
+			RawTx:    schemas.JSON(rawTx),
+			Status:   dex.QuarantineStatusPending,
+		}
+		result := tx.Clauses(clause.OnConflict{
+			Columns: []clause.Column{{Name: "chain_id"}, {Name: "hash"}},
+			DoUpdates: clause.Assignments(map[string]interface{}{
+				"height":      row.Height,
+				"stage":       row.Stage,
+				"contract":    row.Contract,
+				"action":      row.Action,
+				"error":       row.Error,
+				"raw_tx":      row.RawTx,
+				"status":      row.Status,
+				"resolved_at": nil,
+				"updated_at":  gorm.Expr("EXTRACT(EPOCH FROM NOW())"),
+			}),
+		}).Create(&row)
+		if result.Error != nil {
+			return errors.Wrap(result.Error, "repo.Insert.ParseQuarantine")
+		}
 	}
 	return nil
 }

--- a/parser/dex/repo/repository_test.go
+++ b/parser/dex/repo/repository_test.go
@@ -170,7 +170,7 @@ func (s *insertSuite) SetupSuite() {
 	}
 }
 
-func (s *insertSuite) SetSuccessMock() {
+func (s *insertSuite) SetSuccessMock(quarantines []dex.ParseQuarantine) {
 
 	pairLen, poolInfosLen := int64(len(s.pairs)), int64(len(s.poolInfos))
 	parsedTxIds := sqlmock.NewRows([]string{"id"})
@@ -182,6 +182,10 @@ func (s *insertSuite) SetSuccessMock() {
 	s.Mock.ExpectExec(`INSERT INTO "pair" (.*)`).WillReturnResult(sqlmock.NewResult(pairLen, pairLen))
 	s.Mock.ExpectQuery(`INSERT INTO "parsed_tx" (.*)`).WillReturnRows(parsedTxIds)
 	s.Mock.ExpectExec(`INSERT INTO "pool_info" (.*)`).WillReturnResult(sqlmock.NewResult(poolInfosLen, poolInfosLen))
+	for range quarantines {
+		s.Mock.ExpectQuery(`INSERT INTO "parse_quarantine" (.+) ON CONFLICT (.+) DO UPDATE SET (.+)"updated_at"=EXTRACT\(EPOCH FROM NOW\(\)\)(.+)RETURNING "id"`).
+			WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	}
 	s.Mock.ExpectExec(`UPDATE "synced_height" SET "height"=\$1 WHERE chain\_id = \$2 AND height = \$3`).WithArgs(s.height, s.Repo.chainId, s.height-1).WillReturnResult(sqlmock.NewResult(1, 1))
 	s.Mock.ExpectCommit()
 
@@ -194,15 +198,57 @@ func (s *insertSuite) SetFailMock() {
 
 }
 
+func (s *insertSuite) SetQuarantineFailMock() {
+	pairLen, poolInfosLen := int64(len(s.pairs)), int64(len(s.poolInfos))
+	parsedTxIds := sqlmock.NewRows([]string{"id"})
+	for i := 0; i < len(s.parsedTxs); i++ {
+		parsedTxIds = parsedTxIds.AddRow(0)
+	}
+
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectExec(`INSERT INTO "pair" (.*)`).WillReturnResult(sqlmock.NewResult(pairLen, pairLen))
+	s.Mock.ExpectQuery(`INSERT INTO "parsed_tx" (.*)`).WillReturnRows(parsedTxIds)
+	s.Mock.ExpectExec(`INSERT INTO "pool_info" (.*)`).WillReturnResult(sqlmock.NewResult(poolInfosLen, poolInfosLen))
+	s.Mock.ExpectQuery(`INSERT INTO "parse_quarantine" (.+) ON CONFLICT (.+) DO UPDATE SET (.+)"updated_at"=EXTRACT\(EPOCH FROM NOW\(\)\)(.+)RETURNING "id"`).
+		WillReturnError(errors.New("quarantine insert failed"))
+	s.Mock.ExpectRollback()
+}
+
+func (s *insertSuite) SetQuarantineOnlyMock() {
+	s.Mock.ExpectBegin()
+	s.Mock.ExpectQuery(`INSERT INTO "parse_quarantine" (.+) ON CONFLICT (.+) DO UPDATE SET (.+)"updated_at"=EXTRACT\(EPOCH FROM NOW\(\)\)(.+)RETURNING "id"`).
+		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
+	s.Mock.ExpectExec(`UPDATE "synced_height" SET "height"=\$1 WHERE chain\_id = \$2 AND height = \$3`).WithArgs(s.height, s.Repo.chainId, s.height-1).WillReturnResult(sqlmock.NewResult(1, 1))
+	s.Mock.ExpectCommit()
+}
+
 func (s *insertSuite) Test_Insert() {
 	assert := assert.New(s.T())
-	s.SetSuccessMock()
-	err := s.Repo.Insert(s.height-1, s.height, s.parsedTxs, s.poolInfos, s.pairs)
+	s.SetSuccessMock(nil)
+	err := s.Repo.Insert(s.height-1, s.height, s.parsedTxs, s.poolInfos, s.pairs, []dex.ParseQuarantine{})
+	assert.NoError(err)
+
+	quarantines := []dex.ParseQuarantine{{
+		Height: s.height,
+		Hash:   "tx-hash",
+		Stage:  "wasm_transfer",
+		RawTx:  parser.RawTx{Hash: "tx-hash"},
+	}}
+	s.SetSuccessMock(quarantines)
+	err = s.Repo.Insert(s.height-1, s.height, s.parsedTxs, s.poolInfos, s.pairs, quarantines)
+	assert.NoError(err)
+
+	s.SetQuarantineFailMock()
+	err = s.Repo.Insert(s.height-1, s.height, s.parsedTxs, s.poolInfos, s.pairs, quarantines)
+	assert.Error(err)
+
+	s.SetQuarantineOnlyMock()
+	err = s.Repo.Insert(s.height-1, s.height, []dex.ParsedTx{}, []dex.PoolInfo{}, []dex.Pair{}, quarantines)
 	assert.NoError(err)
 
 	s.SetFailMock()
 	s.pairs[0].ContractAddr = ""
-	err = s.Repo.Insert(s.height-1, s.height, s.parsedTxs, s.poolInfos, s.pairs)
+	err = s.Repo.Insert(s.height-1, s.height, s.parsedTxs, s.poolInfos, s.pairs, []dex.ParseQuarantine{})
 	assert.Error(err)
 }
 
@@ -325,27 +371,6 @@ func (s *validationHeightSuite) Test_ClearValidationHeight() {
 
 type parseQuarantineSuite struct {
 	baseSuite
-}
-
-func (s *parseQuarantineSuite) Test_UpsertParseQuarantine() {
-	quarantine := dex.ParseQuarantine{
-		Height:   10,
-		Hash:     "tx-hash",
-		Stage:    "wasm_transfer",
-		Contract: "token",
-		Action:   "transfer",
-		Error:    "ambiguous amount",
-		RawTx: parser.RawTx{
-			Hash: "tx-hash",
-		},
-	}
-
-	s.Mock.ExpectBegin()
-	s.Mock.ExpectQuery(`INSERT INTO "parse_quarantine" (.+) ON CONFLICT (.+) DO UPDATE SET (.+)"updated_at"=EXTRACT\(EPOCH FROM NOW\(\)\)(.+)RETURNING "id"`).
-		WillReturnRows(sqlmock.NewRows([]string{"id"}).AddRow(1))
-	s.Mock.ExpectCommit()
-
-	s.NoError(s.Repo.UpsertParseQuarantine(quarantine))
 }
 
 func (s *parseQuarantineSuite) Test_PendingParseQuarantines() {

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -53,6 +53,7 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig, ch
 
 func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
 	txDtos := []dex.ParsedTx{}
+	partialQuarantine := dex.NewPartialQuarantineRecorder(tx, height)
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "starfleit.ParseTxs create_pair tx_hash=%s", tx.Hash)
@@ -91,7 +92,10 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		// find transfer from user
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrapf(err, "starfleit.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			wrapped := errors.Wrapf(err, "starfleit.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			if !partialQuarantine.Record("wasm_transfer", wrapped) {
+				return nil, wrapped
+			}
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
@@ -113,6 +117,10 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	}
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
+
+	if err := partialQuarantine.Err(txDtos); err != nil {
+		return txDtos, err
+	}
 
 	return txDtos, nil
 }

--- a/parser/dex/terraswap/columbusv1/app.go
+++ b/parser/dex/terraswap/columbusv1/app.go
@@ -49,6 +49,7 @@ func New(repo p_dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) 
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedTx, error) {
 	txDtos := []p_dex.ParsedTx{}
+	partialQuarantine := p_dex.NewPartialQuarantineRecorder(tx, height)
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "columbusv1.ParseTxs create_pair tx_hash=%s", tx.Hash)
@@ -78,7 +79,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrapf(err, "columbusv1.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			wrapped := errors.Wrapf(err, "columbusv1.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			if !partialQuarantine.Record("wasm_transfer", wrapped) {
+				return nil, wrapped
+			}
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
@@ -94,6 +98,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 	}
 
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
+
+	if err := partialQuarantine.Err(txDtos); err != nil {
+		return txDtos, err
+	}
 
 	return txDtos, nil
 }

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -62,6 +62,7 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
 	txDtos := []dex.ParsedTx{}
+	partialQuarantine := dex.NewPartialQuarantineRecorder(tx, height)
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "columbusv2.ParseTxs create_pair tx_hash=%s", tx.Hash)
@@ -103,7 +104,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrapf(err, "columbusv2.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			wrapped := errors.Wrapf(err, "columbusv2.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			if !partialQuarantine.Record("wasm_transfer", wrapped) {
+				return nil, wrapped
+			}
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
@@ -157,6 +161,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 	}
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
+
+	if err := partialQuarantine.Err(txDtos); err != nil {
+		return txDtos, err
+	}
 
 	return txDtos, nil
 }

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -54,6 +54,7 @@ func New(repo dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (d
 
 func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, error) {
 	txDtos := []dex.ParsedTx{}
+	partialQuarantine := dex.NewPartialQuarantineRecorder(tx, height)
 	createPairTxs, err := p.Parsers.CreatePairParser.Parse(tx.LogResults, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, nil)
 	if err != nil {
 		return nil, errors.Wrapf(err, "phoenix.ParseTxs create_pair tx_hash=%s", tx.Hash)
@@ -93,7 +94,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 
 		wtxs, err := p.Parsers.WasmTransfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
-			return nil, errors.Wrapf(err, "phoenix.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			wrapped := errors.Wrapf(err, "phoenix.ParseTxs wasm_transfer tx_hash=%s", tx.Hash)
+			if !partialQuarantine.Record("wasm_transfer", wrapped) {
+				return nil, wrapped
+			}
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
@@ -128,6 +132,10 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 
 	txDtos = append(txDtos, p.RemoveDuplicatedTxs(pairTxs, append(wasmTxs, transferTxs...))...)
 	txDtos = append(txDtos, dex.CollectLpBurnTxs(burnTxs, p.lpPairAddrs)...)
+
+	if err := partialQuarantine.Err(txDtos); err != nil {
+		return txDtos, err
+	}
 
 	return txDtos, nil
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,8 +1,10 @@
 package parser
 
 import (
+	stderrors "errors"
+
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 )
 
 type Overrider[T any] interface {
@@ -31,11 +33,19 @@ func NewParser[T any](finder eventlog.LogFinder, mapper Mapper[T]) Parser[T] {
 func (p *parserImpl[T]) Parse(raws eventlog.LogResults, defaultVal Overrider[T], optionals ...interface{}) ([]*T, error) {
 	matched := p.FindFromLogs(raws)
 	txs := []*T{}
+	var ambiguousErr error
 
 	for _, match := range matched {
 		dtos, err := p.MatchedToParsedTx(match, optionals...)
 		if err != nil {
-			return nil, errors.Wrap(err, "parserImpl.Parse")
+			var ambiguity *eventlog.AmbiguousEventError
+			if stderrors.As(err, &ambiguity) {
+				if ambiguousErr == nil {
+					ambiguousErr = pkgerrors.Wrap(err, "parserImpl.Parse")
+				}
+				continue
+			}
+			return nil, pkgerrors.Wrap(err, "parserImpl.Parse")
 		}
 		// skip if no dto
 		if len(dtos) == 0 {
@@ -45,13 +55,13 @@ func (p *parserImpl[T]) Parse(raws eventlog.LogResults, defaultVal Overrider[T],
 		for _, d := range dtos {
 			overridden, err := defaultVal.Override(*d)
 			if err != nil {
-				return nil, errors.Wrap(err, "parserImpl.Parse")
+				return nil, pkgerrors.Wrap(err, "parserImpl.Parse")
 			}
 			txs = append(txs, &overridden)
 		}
 	}
 
-	return txs, nil
+	return txs, ambiguousErr
 }
 
 // matchedToParsedTxDto implements parser


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Ambiguous wasm transfer events can currently block DEX parsing for an entire transaction, even when other parsed txs from the same raw transaction are valid. This change preserves parser progress while retaining enough quarantine data for ambiguous portions.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Allow parser implementations to return successfully parsed txs alongside an `AmbiguousEventError`.
- Add partial parse quarantine handling for ambiguous wasm transfers across Dezswap, Starfleit, and Terraswap apps.
- Persist successfully parsed txs while recording ambiguous wasm transfer details as `partial_` quarantine entries.
- Skip partial quarantine entries during normal full-transaction quarantine replay.
- Add tests for partial parsing, partial quarantine insertion, create-pair safeguards, and parser partial-match behavior.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [ ] Test enough in your local environment?
- [ ] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parsing now continues past partial ambiguities, preserving successfully parsed transactions while recording quarantine details.
  * Quarantine handling now supports partial-record entries and skips reprocessing those records during retry.

* **Bug Fixes**
  * Improved handling of ambiguous log matches so non-ambiguous transactions are still returned.
  * Create-pair transactions are no longer incorrectly treated as partial quarantine cases.

* **Chores**
  * Updated internal persistence and parsing flows to carry quarantine details through the full insert path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->