### PR TITLE
fix(parser): handle optional transfer sender in columbusv2

### DIFF
--- a/parser/dex/mapper.go
+++ b/parser/dex/mapper.go
@@ -165,6 +165,9 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 	}
 
 	sender, receiver := matchMap[pdex.TransferSenderKey].Value, matchMap[pdex.TransferRecipientKey].Value
+	if sender == "" {
+		sender = transferFallbackSender(optionals...)
+	}
 	fp, fromPair := m.pairSet[sender]
 	tp, toPair := m.pairSet[receiver]
 
@@ -193,6 +196,17 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 	}
 
 	return txs, nil
+}
+
+// transferFallbackSender returns the first non-empty string optional as the transfer sender fallback.
+func transferFallbackSender(optionals ...interface{}) string {
+	for _, optional := range optionals {
+		sender, ok := optional.(string)
+		if ok && sender != "" {
+			return sender
+		}
+	}
+	return ""
 }
 
 func (m transferMapper) transferToParsedTx(pair Pair, from, assetsStr string, fromPair bool, msgIndex int) (*ParsedTx, error) {

--- a/parser/dex/mappers_test.go
+++ b/parser/dex/mappers_test.go
@@ -113,6 +113,55 @@ func Test_TransferMapper(t *testing.T) {
 	}
 }
 
+func Test_TransferMapper_OptionalFallbackSenderAndPairFiltering(t *testing.T) {
+	const userAddr = "user"
+	pair := Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
+	pairSet := map[string]Pair{pair.ContractAddr: pair}
+
+	tcs := []struct {
+		name           string
+		matchedResults el.MatchedResult
+		optionals      []interface{}
+		expectedTx     []*ParsedTx
+	}{
+		{
+			name: "sender missing uses fallback when recipient is pair",
+			matchedResults: el.MatchedResult{
+				{Key: "amount", Value: "1000Asset1"},
+				{Key: "recipient", Value: pair.ContractAddr},
+			},
+			optionals:  []interface{}{userAddr},
+			expectedTx: []*ParsedTx{{"", time.Time{}, Transfer, userAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], "1000"}, {pair.Assets[1], ""}}, "", "", "", 0, make(map[string]interface{})}},
+		},
+		{
+			name: "sender missing fallback still skips non-pair transfer",
+			matchedResults: el.MatchedResult{
+				{Key: "amount", Value: "1000Asset1"},
+				{Key: "recipient", Value: "other"},
+			},
+			optionals:  []interface{}{userAddr},
+			expectedTx: nil,
+		},
+		{
+			name: "sender pair is collected even when recipient is not pair",
+			matchedResults: el.MatchedResult{
+				{Key: "amount", Value: "1000Asset2"},
+				{Key: "recipient", Value: userAddr},
+				{Key: "sender", Value: pair.ContractAddr},
+			},
+			expectedTx: []*ParsedTx{{"", time.Time{}, Transfer, pair.ContractAddr, pair.ContractAddr, [2]Asset{{pair.Assets[0], ""}, {pair.Assets[1], "-1000"}}, "", "", "", 0, make(map[string]interface{})}},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			tx, err := NewTransferMapper(pairSet).MatchedToParsedTx(tc.matchedResults, tc.optionals...)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedTx, tx)
+		})
+	}
+}
+
 func Test_InitialProvideMapper(t *testing.T) {
 
 	const userAddr = "userAddr"

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -129,7 +129,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			}
 			raw.Attributes = *attrs
 		}
-		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "columbusv2.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -94,6 +94,9 @@ func Test_parseTxs(t *testing.T) {
 		{[]string{swapLogStr, provideLogStr, withdrawLogStr, wasmTransferLogStr, transferLogStr}, 1, 0, []dex.ParsedTx{swapTx, provideTx, withdrawTx}, ""},
 		{[]string{withdrawLogStr, transferLogStr, wasmTransferLogStr}, 1, 0, []dex.ParsedTx{withdrawTx, transferTx, wasmTransferTx}, ""},
 		{[]string{swapLogStr, wasmTransferLogStr, transferLogStr}, 1, 0, []dex.ParsedTx{swapTx, transferTx}, ""},
+		{[]string{transferWithoutSenderLogStr}, 1, 0, []dex.ParsedTx{transferTx}, ""},
+		{[]string{transferFromPairLogStr}, 1, 0, []dex.ParsedTx{transferFromPairTx}, ""},
+		{[]string{unrelatedTransferWithoutSenderLogStr}, 1, 0, []dex.ParsedTx{}, ""},
 		{nil, 0, 0, []dex.ParsedTx{}, ""},
 		{nil, 3, 1, []dex.ParsedTx{}, ""},
 	}
@@ -323,12 +326,16 @@ func rawLogs(logStr string) eventlog.LogResults {
 }
 
 var (
-	pair           = dex.Pair{ContractAddr: "PAIR_ADDR", Assets: []string{"Asset0", "Asset1"}, LpAddr: "Lp"}
-	createTx       = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
-	swapTx         = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", 0, nil}
-	provideTx      = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
-	withdrawTx     = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", 0, map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-1000"}, {pair.Assets[1], "-1000"}}}}
-	transferTx     = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", 0, make(map[string]interface{})}
+	pair               = dex.Pair{ContractAddr: "PAIR_ADDR", Assets: []string{"Asset0", "Asset1"}, LpAddr: "Lp"}
+	createTx           = dex.ParsedTx{hash, time.Time{}, dex.CreatePair, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	swapTx             = dex.ParsedTx{hash, time.Time{}, dex.Swap, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "-1000"}}, "", "", "1", 0, nil}
+	provideTx          = dex.ParsedTx{hash, time.Time{}, dex.Provide, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", "1000"}}, "Lp", "1000", "", 0, nil}
+	withdrawTx         = dex.ParsedTx{hash, time.Time{}, dex.Withdraw, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "0"}, {"Asset1", "0"}}, "Lp", "1000", "", 0, map[string]interface{}{"withdraw_assets": []dex.Asset{{pair.Assets[0], "-1000"}, {pair.Assets[1], "-1000"}}}}
+	transferTx         = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", ""}, {"Asset1", "1000"}}, "", "", "", 0, make(map[string]interface{})}
+	transferFromPairTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, "PAIR_ADDR", "PAIR_ADDR", [2]dex.Asset{
+		{"Asset0", "-1000"},
+		{"Asset1", ""},
+	}, "", "", "", 0, make(map[string]interface{})}
 	wasmTransferTx = dex.ParsedTx{hash, time.Time{}, dex.Transfer, sender, "PAIR_ADDR", [2]dex.Asset{{"Asset0", "1000"}, {"Asset1", ""}}, "", "", "", 0, make(map[string]interface{})}
 )
 
@@ -342,5 +349,8 @@ const (
 	{"key":"to","value":"A"},{"key":"amount","value":"12418119"},{"key":"_contract_address","value":"PAIR_ADDR"},{"key":"action","value":"withdraw_liquidity"},{"key":"sender","value":"sender"},{"key":"withdrawn_share","value":"1000"},{"key":"refund_assets","value":"1000Asset0, 1000Asset1"},{"key":"_contract_address","value":"asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"A"},{"key":"to","value":"terra1cupj7d70jrtjxqhpr6s3qq68t8ky4smcjvccm4"},{"key":"amount","value":"24999998"},{"key":"_contract_address","value":"terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7"},{"key":"action","value":"burn"},{"key":"from","value":"A"},{"key":"amount","value":"12418119"}]}]`
 	wasmTransferLogStr = `[{"type":"wasm","attributes":[{"key":"_contract_address","value":"Asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"sender"},
 	{"key":"to","value":"PAIR_ADDR"},{"key":"amount","value":"1000"}]}]`
-	transferLogStr = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"sender","value":"sender"},{"key":"amount","value":"1000Asset0"}]}]`
+	transferLogStr                       = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"sender","value":"sender"},{"key":"amount","value":"1000Asset0"}]}]`
+	transferWithoutSenderLogStr          = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"amount","value":"1000Asset1"}]}]`
+	transferFromPairLogStr               = `[{"type":"transfer","attributes":[{"key":"recipient","value":"sender"},{"key":"sender","value":"PAIR_ADDR"},{"key":"amount","value":"1000Asset0"}]}]`
+	unrelatedTransferWithoutSenderLogStr = `[{"type":"transfer","attributes":[{"key":"recipient","value":"OTHER_ADDR"},{"key":"amount","value":"1000Asset1"}]}]`
 )

--- a/pkg/dex/terraswap/columbusv2/consts.go
+++ b/pkg/dex/terraswap/columbusv2/consts.go
@@ -9,10 +9,6 @@ const (
 )
 
 const (
-	SortedTransferMatchedLen = SortedTransferSenderIdx + 1
-)
-
-const (
 	PairAddrIdx = iota
 	PairActionIdx
 )

--- a/pkg/dex/terraswap/columbusv2/logfinders.go
+++ b/pkg/dex/terraswap/columbusv2/logfinders.go
@@ -78,10 +78,9 @@ var wasmTransferCommonRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_con
 	}},
 }}
 
-var sortedTransferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
+var sortedTransferRule = eventlog.Rule{Type: eventlog.TransferType, Until: "amount", Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "amount", Filter: nil},
 	eventlog.RuleItem{Key: "recipient", Filter: nil},
-	eventlog.RuleItem{Key: "sender", Filter: nil},
 }}
 
 var taxPaymentRule = eventlog.Rule{Type: eventlog.TaxPaymentType, Items: eventlog.RuleItems{

--- a/pkg/dex/terraswap/columbusv2/logfinders_test.go
+++ b/pkg/dex/terraswap/columbusv2/logfinders_test.go
@@ -102,6 +102,73 @@ func Test_LogFinders(t *testing.T) {
 
 }
 
+func Test_SortedTransferRuleFinder_OptionalSender(t *testing.T) {
+	tcs := []struct {
+		name          string
+		rawLogStr     string
+		expectedKeys  []string
+		expectedValue map[string]string
+	}{
+		{
+			name:         "with sender",
+			rawLogStr:    TransferRawLogStr,
+			expectedKeys: []string{"amount", "recipient", "sender"},
+			expectedValue: map[string]string{
+				"amount":    "1000000uluna",
+				"recipient": "terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y",
+				"sender":    "terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv",
+			},
+		},
+		{
+			name:         "without sender",
+			rawLogStr:    TransferRawLogWithoutSenderStr,
+			expectedKeys: []string{"amount", "recipient"},
+			expectedValue: map[string]string{
+				"amount":    "1000000uluna",
+				"recipient": "terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y",
+			},
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			logFinder, err := CreateSortedTransferRuleFinder(nil)
+			assert.NoError(t, err)
+
+			eventLogs := eventlog.LogResults{}
+			assert.NoError(t, json.Unmarshal([]byte(tc.rawLogStr), &eventLogs))
+
+			matchedResults := logFinder.FindFromLogs(eventLogs)
+			assert.Len(t, matchedResults, 1)
+			assert.Len(t, matchedResults[0], len(tc.expectedKeys))
+			for idx, key := range tc.expectedKeys {
+				assert.Equal(t, key, matchedResults[0][idx].Key)
+				assert.Equal(t, tc.expectedValue[key], matchedResults[0][idx].Value)
+			}
+		})
+	}
+}
+
+func Test_SortedTransferRuleFinder_FiltersPairRecipient(t *testing.T) {
+	const pairAddr = "terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"
+
+	logFinder, err := CreateSortedTransferRuleFinder(map[string]bool{pairAddr: true})
+	assert.NoError(t, err)
+
+	eventLogs := eventlog.LogResults{}
+	assert.NoError(t, json.Unmarshal([]byte(TransferRawLogStr), &eventLogs))
+
+	matchedResults := logFinder.FindFromLogs(eventLogs)
+	assert.Len(t, matchedResults, 1)
+	assert.Equal(t, pairAddr, matchedResults[0][SortedTransferRecipientIdx].Value)
+
+	logFinder, err = CreateSortedTransferRuleFinder(map[string]bool{"other_pair": true})
+	assert.NoError(t, err)
+
+	matchedResults = logFinder.FindFromLogs(eventLogs)
+	assert.Empty(t, matchedResults)
+}
+
 const (
 	differentTypeLogsStr = `[{ "type":"wrongType", "attributes":[{ "key":"_contract_address", "value":"terra1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjqxl5qul"},
 			{ "key":"action", "value":"create_pair"},
@@ -193,4 +260,11 @@ const TransferRawLogStr = `[
 	{"type":"coin_spent","attributes":[{"key":"spender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"amount","value":"1000000uluna"}]},
 	{"type":"message","attributes":[{"key":"action","value":"/cosmos.bank.v1beta1.MsgSend"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"module","value":"bank"}]},
 	{"type":"transfer","attributes":[{"key":"amount","value":"1000000uluna"},{"key":"recipient","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"}]}
+]`
+
+const TransferRawLogWithoutSenderStr = `[
+	{"type":"coin_received","attributes":[{"key":"receiver","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"amount","value":"1000000uluna"}]},
+	{"type":"coin_spent","attributes":[{"key":"spender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"amount","value":"1000000uluna"}]},
+	{"type":"message","attributes":[{"key":"action","value":"/cosmos.bank.v1beta1.MsgSend"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"module","value":"bank"}]},
+	{"type":"transfer","attributes":[{"key":"amount","value":"1000000uluna"},{"key":"recipient","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"}]}
 ]`

--- a/pkg/dex/terraswap/phoenix/consts.go
+++ b/pkg/dex/terraswap/phoenix/consts.go
@@ -9,10 +9,6 @@ const (
 )
 
 const (
-	SortedTransferMatchedLen = SortedTransferSenderIdx + 1
-)
-
-const (
 	PairAddrIdx = iota
 	PairActionIdx
 )

--- a/pkg/eventlog/util.go
+++ b/pkg/eventlog/util.go
@@ -25,17 +25,34 @@ func SortAttributes(attrs Attributes, filter []string) (*Attributes, error) {
 		}
 	}
 
-	idx := 0
-	end := len(filter)
-	for end <= len(filtered) {
-		sort.Slice(filtered[idx:end], func(i, j int) bool {
-			return order[filtered[idx:end][i].Key] < order[filtered[idx:end][j].Key]
+	sorted := make(Attributes, 0, len(filtered))
+	group := make(Attributes, 0, len(filter))
+	seen := make(map[string]bool, len(filter))
+	flush := func() {
+		// A repeated key starts a new group, which lets callers sort optional trailing keys.
+		sort.Slice(group, func(i, j int) bool {
+			return order[group[i].Key] < order[group[j].Key]
 		})
-		idx = end
-		end = idx + len(filter)
+		sorted = append(sorted, group...)
+		group = make(Attributes, 0, len(filter))
+		seen = make(map[string]bool, len(filter))
 	}
 
-	return &filtered, nil
+	for _, attr := range filtered {
+		if seen[attr.Key] {
+			flush()
+		}
+		group = append(group, attr)
+		seen[attr.Key] = true
+		if len(group) == len(filter) {
+			flush()
+		}
+	}
+	if len(group) > 0 {
+		flush()
+	}
+
+	return &sorted, nil
 }
 
 type AmbiguousEventError struct {

--- a/pkg/eventlog/util_test.go
+++ b/pkg/eventlog/util_test.go
@@ -114,6 +114,38 @@ func TestSortAttributes(t *testing.T) {
 				{Key: "sender", Value: "terra1abcdr"},
 			},
 		},
+		{
+			name: "tc with optional sender mixed in key sets",
+			attrs: Attributes{
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "amount", Value: "100uluna"},
+				{Key: "amount", Value: "101uluna"},
+				{Key: "recipient", Value: "terra1abcdr2"},
+				{Key: "sender", Value: "terra1abcds2"},
+				{Key: "amount", Value: "102uluna"},
+				{Key: "recipient", Value: "terra1abcdr3"},
+				{Key: "sender", Value: "terra1abcds3"},
+				{Key: "recipient", Value: "terra1abcdr4"},
+				{Key: "amount", Value: "103uluna"},
+			},
+			filter: []string{
+				"amount",
+				"recipient",
+				"sender",
+			},
+			expected: &Attributes{
+				{Key: "amount", Value: "100uluna"},
+				{Key: "recipient", Value: "terra1abcdr"},
+				{Key: "amount", Value: "101uluna"},
+				{Key: "recipient", Value: "terra1abcdr2"},
+				{Key: "sender", Value: "terra1abcds2"},
+				{Key: "amount", Value: "102uluna"},
+				{Key: "recipient", Value: "terra1abcdr3"},
+				{Key: "sender", Value: "terra1abcds3"},
+				{Key: "amount", Value: "103uluna"},
+				{Key: "recipient", Value: "terra1abcdr4"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
ColumbusV2 transfer logs can omit the `sender` attribute in `MsgMultiSend` cases while still containing enough information to identify a user-to-pair transfer. The parser previously required `sender` in the sorted transfer rule, so those transfers were not parsed.
e.g. https://finder.terra.money/classic/tx/A659E9C5450F007F9B90880017F6A568AAB75E5B4D65F16766FF8CBC9CBA0D1B

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Allow ColumbusV2 sorted transfer matching with required `amount` and `recipient`, while preserving optional `sender` when present.
- Pass the raw tx sender into transfer parsing as a fallback when the transfer event omits `sender`.
- Keep pair recipient filtering for ColumbusV2 transfer candidates.
- Improve `eventlog.SortAttributes` to sort repeated attribute groups with optional trailing keys.
- Add coverage for optional sender matching, pair filtering, sender fallback, and mixed transfer attribute groups.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transfer parsing now handles logs even when the sender is missing, using a fallback value when available.
  * Transfer event matching was expanded to better recognize valid pair-recipient transfers.

* **Bug Fixes**
  * Improved handling of mixed attribute groups so transfer fields are sorted and matched more reliably.
  * Transfer parsing now skips events that do not target the expected pair, reducing incorrect matches.

* **Tests**
  * Added coverage for optional sender handling, pair filtering, and updated attribute ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->