### PR TITLE
fix(aggregator): bound parent task wait with timeout

### DIFF
--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -83,6 +83,13 @@ func initTaskSchedulers(config configs.AggregatorConfig, srcRepo parser.ReadRepo
 	}, nil
 }
 
+func reportError(err error) {
+	select {
+	case errChan <- err:
+	default:
+	}
+}
+
 func (a aggregatorImpl) Run() error {
 	a.logger.Info("Aggregator has been started.")
 
@@ -121,7 +128,7 @@ func (a aggregatorImpl) runTasks(ctx context.Context) {
 
 	if a.cleanDups {
 		if err := a.destDbConn.DeleteDuplicates(a.startTs); err != nil {
-			errChan <- err
+			reportError(err)
 			return
 		}
 		a.logger.Infof("Stats data since %s has been deleted for new update.", a.startTs.String())
@@ -132,7 +139,7 @@ func (a aggregatorImpl) runTasks(ctx context.Context) {
 		go func(tk scheduler) {
 			defer wg.Done()
 			if err := tk.Schedule(ctx); err != nil {
-				errChan <- err
+				reportError(err)
 			}
 		}(t)
 	}

--- a/aggregator/aggregator.go
+++ b/aggregator/aggregator.go
@@ -108,7 +108,7 @@ func (a aggregatorImpl) Run() error {
 		cancel()
 	}()
 
-	errChan = make(chan error)
+	errChan = make(chan error, 1)
 
 	go func() {
 		err := <-errChan

--- a/aggregator/scheduler.go
+++ b/aggregator/scheduler.go
@@ -35,7 +35,7 @@ loop:
 			break loop
 		case <-time.After(time.Until(endTs)):
 			if err := s.Execute(ctx, time.Time{}, endTs); err != nil {
-				reportError(err)
+				return err
 			}
 			s.logger.Infof("%s(%s) has been finished", reflect.TypeOf(s.task), endTs.UTC().Format(time.RFC1123Z))
 
@@ -60,7 +60,7 @@ func (s *predeterminedTimeScheduler) Schedule(ctx context.Context) error {
 	start, end := timeframe(optimizedStartTs, s.interval)
 	for end.Before(time.Now()) {
 		if err := (s.predeterminedTimeTask).Execute(ctx, start, end); err != nil {
-			reportError(err)
+			return err
 		}
 		start = end
 		end = end.Add(s.interval)
@@ -73,7 +73,7 @@ loop:
 			break loop
 		case <-time.After(time.Until(end)):
 			if err := (s.predeterminedTimeTask).Execute(ctx, start, end); err != nil {
-				reportError(err)
+				return err
 			}
 			s.logger.Infof("%s(%s-%s) has been finished", reflect.TypeOf(s.predeterminedTimeTask), start.UTC().Format(time.RFC1123Z), end.UTC().Format(time.RFC1123Z))
 

--- a/aggregator/scheduler.go
+++ b/aggregator/scheduler.go
@@ -35,7 +35,7 @@ loop:
 			break loop
 		case <-time.After(time.Until(endTs)):
 			if err := s.Execute(ctx, time.Time{}, endTs); err != nil {
-				errChan <- err
+				reportError(err)
 			}
 			s.logger.Infof("%s(%s) has been finished", reflect.TypeOf(s.task), endTs.UTC().Format(time.RFC1123Z))
 
@@ -60,7 +60,7 @@ func (s *predeterminedTimeScheduler) Schedule(ctx context.Context) error {
 	start, end := timeframe(optimizedStartTs, s.interval)
 	for end.Before(time.Now()) {
 		if err := (s.predeterminedTimeTask).Execute(ctx, start, end); err != nil {
-			errChan <- err
+			reportError(err)
 		}
 		start = end
 		end = end.Add(s.interval)
@@ -73,7 +73,7 @@ loop:
 			break loop
 		case <-time.After(time.Until(end)):
 			if err := (s.predeterminedTimeTask).Execute(ctx, start, end); err != nil {
-				errChan <- err
+				reportError(err)
 			}
 			s.logger.Infof("%s(%s-%s) has been finished", reflect.TypeOf(s.predeterminedTimeTask), start.UTC().Format(time.RFC1123Z), end.UTC().Format(time.RFC1123Z))
 

--- a/aggregator/scheduler.go
+++ b/aggregator/scheduler.go
@@ -34,7 +34,7 @@ loop:
 		case <-ctx.Done():
 			break loop
 		case <-time.After(time.Until(endTs)):
-			if err := s.Execute(time.Time{}, endTs); err != nil {
+			if err := s.Execute(ctx, time.Time{}, endTs); err != nil {
 				errChan <- err
 			}
 			s.logger.Infof("%s(%s) has been finished", reflect.TypeOf(s.task), endTs.UTC().Format(time.RFC1123Z))
@@ -59,7 +59,7 @@ func (s *predeterminedTimeScheduler) Schedule(ctx context.Context) error {
 
 	start, end := timeframe(optimizedStartTs, s.interval)
 	for end.Before(time.Now()) {
-		if err := (s.predeterminedTimeTask).Execute(start, end); err != nil {
+		if err := (s.predeterminedTimeTask).Execute(ctx, start, end); err != nil {
 			errChan <- err
 		}
 		start = end
@@ -72,7 +72,7 @@ loop:
 		case <-ctx.Done():
 			break loop
 		case <-time.After(time.Until(end)):
-			if err := (s.predeterminedTimeTask).Execute(start, end); err != nil {
+			if err := (s.predeterminedTimeTask).Execute(ctx, start, end); err != nil {
 				errChan <- err
 			}
 			s.logger.Infof("%s(%s-%s) has been finished", reflect.TypeOf(s.predeterminedTimeTask), start.UTC().Format(time.RFC1123Z), end.UTC().Format(time.RFC1123Z))

--- a/aggregator/scheduler_test.go
+++ b/aggregator/scheduler_test.go
@@ -86,6 +86,22 @@ func TestIntervalSchedulePropagatesTaskError(t *testing.T) {
 	}
 }
 
+func TestReportErrorDoesNotBlockWithoutReceiver(t *testing.T) {
+	errChan = make(chan error)
+
+	done := make(chan struct{})
+	go func() {
+		reportError(errors.New("task failed"))
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		assert.Fail(t, "reportError blocked without a receiver")
+	}
+}
+
 func TestPredeterminedTimeSchedule(t *testing.T) {
 	assert := assert.New(t)
 

--- a/aggregator/scheduler_test.go
+++ b/aggregator/scheduler_test.go
@@ -2,6 +2,7 @@ package aggregator
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -11,12 +12,13 @@ import (
 
 type counterTask struct {
 	counter int
+	err     error
 }
 
-func (t *counterTask) Execute(_ time.Time, _ time.Time) error {
+func (t *counterTask) Execute(_ context.Context, _ time.Time, _ time.Time) error {
 	t.counter++
 
-	return nil
+	return t.err
 }
 func (t *counterTask) LastProcessedHeight() uint64 {
 	return 0
@@ -46,6 +48,42 @@ func TestIntervalSchedule(t *testing.T) {
 	cancel()
 
 	assert.Equal(task.counter, 6)
+}
+
+func TestIntervalSchedulePropagatesTaskError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedErr := errors.New("task failed")
+	task := counterTask{err: expectedErr}
+	scheduler := intervalScheduler{
+		task:     &task,
+		interval: time.Hour,
+		logger:   logging.Discard,
+	}
+
+	errChan = make(chan error, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- scheduler.Schedule(ctx)
+	}()
+
+	select {
+	case err := <-errChan:
+		assert.ErrorIs(err, expectedErr)
+	case <-time.After(time.Second):
+		assert.Fail("scheduler did not propagate task error")
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		assert.NoError(err)
+	case <-time.After(time.Second):
+		assert.Fail("scheduler did not stop after context cancellation")
+	}
 }
 
 func TestPredeterminedTimeSchedule(t *testing.T) {

--- a/aggregator/scheduler_test.go
+++ b/aggregator/scheduler_test.go
@@ -50,7 +50,7 @@ func TestIntervalSchedule(t *testing.T) {
 	assert.Equal(task.counter, 6)
 }
 
-func TestIntervalSchedulePropagatesTaskError(t *testing.T) {
+func TestIntervalScheduleReturnsTaskError(t *testing.T) {
 	assert := assert.New(t)
 
 	expectedErr := errors.New("task failed")
@@ -61,7 +61,6 @@ func TestIntervalSchedulePropagatesTaskError(t *testing.T) {
 		logger:   logging.Discard,
 	}
 
-	errChan = make(chan error, 1)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -71,27 +70,22 @@ func TestIntervalSchedulePropagatesTaskError(t *testing.T) {
 	}()
 
 	select {
-	case err := <-errChan:
+	case err := <-done:
 		assert.ErrorIs(err, expectedErr)
 	case <-time.After(time.Second):
-		assert.Fail("scheduler did not propagate task error")
-	}
-
-	cancel()
-	select {
-	case err := <-done:
-		assert.NoError(err)
-	case <-time.After(time.Second):
-		assert.Fail("scheduler did not stop after context cancellation")
+		assert.Fail("scheduler did not return task error")
 	}
 }
 
-func TestReportErrorDoesNotBlockWithoutReceiver(t *testing.T) {
-	errChan = make(chan error)
+func TestReportErrorPreservesFirstErrorAndDoesNotBlockWhenFull(t *testing.T) {
+	expectedErr := errors.New("task failed")
+	errChan = make(chan error, 1)
+
+	reportError(expectedErr)
 
 	done := make(chan struct{})
 	go func() {
-		reportError(errors.New("task failed"))
+		reportError(errors.New("second task failed"))
 		close(done)
 	}()
 
@@ -100,6 +94,8 @@ func TestReportErrorDoesNotBlockWithoutReceiver(t *testing.T) {
 	case <-time.After(time.Second):
 		assert.Fail(t, "reportError blocked without a receiver")
 	}
+
+	assert.ErrorIs(t, <-errChan, expectedErr)
 }
 
 func TestPredeterminedTimeSchedule(t *testing.T) {
@@ -124,6 +120,24 @@ func TestPredeterminedTimeSchedule(t *testing.T) {
 	cancel()
 
 	assert.Equal(task.counter, 6)
+}
+
+func TestPredeterminedTimeScheduleReturnsCatchUpTaskError(t *testing.T) {
+	assert := assert.New(t)
+
+	expectedErr := errors.New("task failed")
+	task := counterTask{err: expectedErr}
+	scheduler := predeterminedTimeScheduler{
+		predeterminedTimeTask: &task,
+		interval:              time.Hour,
+		startTs:               time.Now().Add(-2 * time.Hour),
+		logger:                logging.Discard,
+	}
+
+	err := scheduler.Schedule(context.Background())
+
+	assert.ErrorIs(err, expectedErr)
+	assert.Equal(1, task.counter)
 }
 
 func TestTimeframe_0_30(t *testing.T) {

--- a/aggregator/task.go
+++ b/aggregator/task.go
@@ -1,6 +1,7 @@
 package aggregator
 
 import (
+	"context"
 	"math"
 	"strconv"
 	"time"
@@ -22,7 +23,7 @@ const LpHistoryUpdateLimit = 100
 const WaitPeriod = 10 * time.Second
 
 type task interface {
-	Execute(start time.Time, end time.Time) error
+	Execute(ctx context.Context, start time.Time, end time.Time) error
 	LastProcessedHeight() uint64
 }
 
@@ -32,10 +33,11 @@ type predeterminedTimeTask interface {
 }
 
 type taskImpl struct {
-	chainId     string
-	destDb      repo.Repo
-	parentTasks []task
-	logger      logging.Logger
+	chainId         string
+	destDb          repo.Repo
+	parentTasks     []task
+	taskWaitTimeout time.Duration
+	logger          logging.Logger
 
 	// State
 	lastProcessedHeight uint64
@@ -99,7 +101,7 @@ func newLpHistoryTask(config configs.AggregatorConfig, srcRepo parser.ReadReposi
 	}
 }
 
-func (t *lpHistoryTask) Execute(_ time.Time, _ time.Time) error {
+func (t *lpHistoryTask) Execute(_ context.Context, _ time.Time, _ time.Time) error {
 	lastHistories, err := t.destDb.LastLpHistory(uint64(math.MaxInt64))
 	if err != nil {
 		return err
@@ -229,7 +231,7 @@ func newRouterTask(config configs.AggregatorConfig, logger logging.Logger) task 
 	}
 }
 
-func (t *routerTask) Execute(_ time.Time, _ time.Time) error {
+func (t *routerTask) Execute(_ context.Context, _ time.Time, _ time.Time) error {
 	pairs, err := t.db.Pairs()
 	if err != nil {
 		return err
@@ -251,16 +253,17 @@ func newPriceTask(config configs.AggregatorConfig, destRepo repo.Repo, logger lo
 
 	return &priceTask{
 		taskImpl: taskImpl{
-			chainId:     config.ChainId,
-			destDb:      destRepo,
-			parentTasks: parentTasks,
-			logger:      logger,
+			chainId:         config.ChainId,
+			destDb:          destRepo,
+			parentTasks:     parentTasks,
+			taskWaitTimeout: taskWaitTimeout(config),
+			logger:          logger,
 		},
 		priceTracker: pt,
 	}, nil
 }
 
-func (t *priceTask) Execute(_ time.Time, _ time.Time) error {
+func (t *priceTask) Execute(ctx context.Context, _ time.Time, _ time.Time) error {
 	height := uint64(0)
 
 	for {
@@ -279,7 +282,9 @@ func (t *priceTask) Execute(_ time.Time, _ time.Time) error {
 		}
 
 		height = uint64(nextHeight)
-		waitUntilReachingHeight(&t.parentTasks, height)
+		if err := waitUntilReachingHeight(ctx, t.parentTasks, height, t.taskWaitTimeout); err != nil {
+			return err
+		}
 
 		err = t.priceTracker.Run(height)
 		if err != nil {
@@ -292,10 +297,11 @@ func (t *priceTask) Execute(_ time.Time, _ time.Time) error {
 func newPairStatsRecentUpdateTask(config configs.AggregatorConfig, srcRepo parser.ReadRepository, destRepo repo.Repo, logger logging.Logger, parentTasks []task) task {
 	return &pairStatsRecentUpdateTask{
 		taskImpl: taskImpl{
-			chainId:     config.ChainId,
-			destDb:      destRepo,
-			parentTasks: parentTasks,
-			logger:      logger,
+			chainId:         config.ChainId,
+			destDb:          destRepo,
+			parentTasks:     parentTasks,
+			taskWaitTimeout: taskWaitTimeout(config),
+			logger:          logger,
 		},
 		priceToken: config.PriceToken,
 		srcDb:      srcRepo,
@@ -303,7 +309,7 @@ func newPairStatsRecentUpdateTask(config configs.AggregatorConfig, srcRepo parse
 	}
 }
 
-func (t *pairStatsRecentUpdateTask) Execute(_ time.Time, end time.Time) error {
+func (t *pairStatsRecentUpdateTask) Execute(ctx context.Context, _ time.Time, end time.Time) error {
 	if t.lastProcessedHeight == 0 {
 		var err error
 		t.lastProcessedHeight, err = t.destDb.LastHeightOfPairStatsRecent()
@@ -324,7 +330,9 @@ func (t *pairStatsRecentUpdateTask) Execute(_ time.Time, end time.Time) error {
 
 	var stats []schemas.PairStatsRecent
 	if endHeight > t.lastProcessedHeight {
-		waitUntilReachingHeight(&t.parentTasks, endHeight)
+		if err := waitUntilReachingHeight(ctx, t.parentTasks, endHeight, t.taskWaitTimeout); err != nil {
+			return err
+		}
 
 		if startHeight <= t.lastProcessedHeight {
 			startHeight = t.lastProcessedHeight + 1
@@ -572,10 +580,11 @@ func (t pairStatsRecentUpdateTask) searchPrice(tokenIdStr string, targetHeight u
 func newPairStatsUpdateTask(config configs.AggregatorConfig, srcRepo parser.ReadRepository, destRepo repo.Repo, logger logging.Logger, parentTasks []task) predeterminedTimeTask {
 	return &pairStatsUpdateTask{
 		taskImpl: taskImpl{
-			chainId:     config.ChainId,
-			destDb:      destRepo,
-			parentTasks: parentTasks,
-			logger:      logger,
+			chainId:         config.ChainId,
+			destDb:          destRepo,
+			parentTasks:     parentTasks,
+			taskWaitTimeout: taskWaitTimeout(config),
+			logger:          logger,
 		},
 		priceToken:  config.PriceToken,
 		srcDb:       srcRepo,
@@ -606,12 +615,14 @@ func (t pairStatsUpdateTask) StartTimestamp(startTs time.Time) (time.Time, error
 	return destTs, nil
 }
 
-func (t *pairStatsUpdateTask) Execute(start time.Time, end time.Time) error {
+func (t *pairStatsUpdateTask) Execute(ctx context.Context, start time.Time, end time.Time) error {
 	lastHeight, err := t.srcDb.HeightOnTimestamp(util.ToEpoch(end))
 	if err != nil {
 		return err
 	}
-	waitUntilReachingHeight(&t.parentTasks, lastHeight)
+	if err := waitUntilReachingHeight(ctx, t.parentTasks, lastHeight, t.taskWaitTimeout); err != nil {
+		return err
+	}
 
 	startTs := util.ToEpoch(start)
 	endTs := util.ToEpoch(end)
@@ -656,10 +667,11 @@ func (t *pairStatsUpdateTask) Execute(start time.Time, end time.Time) error {
 func newAccountStatsUpdateTask(config configs.AggregatorConfig, srcRepo parser.ReadRepository, destRepo repo.Repo, logger logging.Logger, parentTasks []task) predeterminedTimeTask {
 	return &accountStatsUpdateTask{
 		taskImpl: taskImpl{
-			chainId:     config.ChainId,
-			destDb:      destRepo,
-			parentTasks: parentTasks,
-			logger:      logger,
+			chainId:         config.ChainId,
+			destDb:          destRepo,
+			parentTasks:     parentTasks,
+			taskWaitTimeout: taskWaitTimeout(config),
+			logger:          logger,
 		},
 		priceToken: config.PriceToken,
 		srcDb:      srcRepo,
@@ -689,14 +701,16 @@ func (t *accountStatsUpdateTask) StartTimestamp(startTs time.Time) (time.Time, e
 	return destTs, nil
 }
 
-func (t *accountStatsUpdateTask) Execute(start time.Time, end time.Time) error {
+func (t *accountStatsUpdateTask) Execute(ctx context.Context, start time.Time, end time.Time) error {
 	startEpoch, endEpoch := util.ToEpoch(start), util.ToEpoch(end)
 
 	endHeight, err := t.srcDb.HeightOnTimestamp(endEpoch)
 	if err != nil {
 		return err
 	}
-	waitUntilReachingHeight(&t.parentTasks, endHeight)
+	if err := waitUntilReachingHeight(ctx, t.parentTasks, endHeight, t.taskWaitTimeout); err != nil {
+		return err
+	}
 
 	stats, err := t.srcDb.AccountStats(startEpoch, endEpoch, t.priceToken)
 	if err != nil {
@@ -758,14 +772,40 @@ func uniqueAccountAddresses(stats []schemas.AccountStats30m) []string {
 	return addresses
 }
 
-func waitUntilReachingHeight(parentTasks *[]task, targetHeight uint64) {
-	for _, t := range *parentTasks {
+// taskWaitTimeout resolves the configured wait timeout, falling back to the
+// default when the config omits it or sets a non-positive value.
+func taskWaitTimeout(config configs.AggregatorConfig) time.Duration {
+	if config.TaskWaitTimeout <= 0 {
+		return configs.DefaultTaskWaitTimeout
+	}
+
+	return config.TaskWaitTimeout
+}
+
+// waitUntilReachingHeight blocks until every parent task reaches targetHeight
+// or the context/timeout ends the wait.
+func waitUntilReachingHeight(ctx context.Context, parentTasks []task, targetHeight uint64, timeout time.Duration) error {
+	if timeout <= 0 {
+		timeout = configs.DefaultTaskWaitTimeout
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	for _, parent := range parentTasks {
 		for {
-			if t.LastProcessedHeight() < targetHeight {
-				time.Sleep(WaitPeriod)
-			} else {
+			currentHeight := parent.LastProcessedHeight()
+			if currentHeight >= targetHeight {
 				break
+			}
+
+			select {
+			case <-waitCtx.Done():
+				return errors.Wrapf(waitCtx.Err(), "waitUntilReachingHeight: parent task did not reach target height %d; current height=%d timeout=%s", targetHeight, currentHeight, timeout)
+			case <-time.After(WaitPeriod):
 			}
 		}
 	}
+
+	return nil
 }

--- a/aggregator/task_test.go
+++ b/aggregator/task_test.go
@@ -34,7 +34,7 @@ type completedTask struct {
 	height atomic.Uint64
 }
 
-func (t *completedTask) Execute(_ time.Time, _ time.Time) error {
+func (t *completedTask) Execute(_ context.Context, _ time.Time, _ time.Time) error {
 	return nil
 }
 
@@ -44,6 +44,42 @@ func (t *completedTask) LastProcessedHeight() uint64 {
 
 func (t *completedTask) setLastProcessedHeight(height uint64) {
 	t.height.Store(height)
+}
+
+func TestWaitUntilReachingHeightAlreadyReached(t *testing.T) {
+	assert := assert.New(t)
+
+	parent := &completedTask{}
+	parent.setLastProcessedHeight(10)
+
+	err := waitUntilReachingHeight(context.Background(), []task{parent}, 10, time.Minute)
+
+	assert.NoError(err)
+}
+
+func TestWaitUntilReachingHeightContextCanceled(t *testing.T) {
+	assert := assert.New(t)
+
+	parent := &completedTask{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := waitUntilReachingHeight(ctx, []task{parent}, 10, time.Minute)
+
+	assert.ErrorIs(err, context.Canceled)
+	assert.ErrorContains(err, "target height 10")
+	assert.ErrorContains(err, "current height=0")
+}
+
+func TestWaitUntilReachingHeightTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	parent := &completedTask{}
+
+	err := waitUntilReachingHeight(context.Background(), []task{parent}, 10, time.Millisecond)
+
+	assert.ErrorIs(err, context.DeadlineExceeded)
+	assert.ErrorContains(err, "timeout=1ms")
 }
 
 func TestLpHistoryTaskExecute(t *testing.T) {
@@ -102,7 +138,7 @@ func TestLpHistoryTaskExecute(t *testing.T) {
 		srcDb: &rp,
 	}
 
-	err := task.Execute(time.Time{}, time.Time{})
+	err := task.Execute(context.Background(), time.Time{}, time.Time{})
 	assert.NoError(err)
 	assert.Equal(expected[0], rp.updatedLpHistory[0])
 }
@@ -211,7 +247,7 @@ func TestPairStatsRecentUpdateTaskExecute(t *testing.T) {
 		srcDb:      &rp,
 	}
 
-	err := task.Execute(time.Time{}, time.Time{})
+	err := task.Execute(context.Background(), time.Time{}, time.Time{})
 	assert.NoError(err)
 	assert.Equal(expected[0], rp.updatedPairStatsRecent[len(rp.updatedPairStatsRecent)-1])
 }
@@ -297,7 +333,7 @@ func TestPairStatsUpdateTaskExecute(t *testing.T) {
 		srcDb:       &rp,
 		prevStatMap: make(map[uint64]schemas.PairStats30m),
 	}
-	err := task.Execute(time.Time{}, end)
+	err := task.Execute(context.Background(), time.Time{}, end)
 
 	assert.NoError(err)
 	assert.Equal(expected, rp.updatedPairStats[0])
@@ -360,7 +396,7 @@ func TestExecuteAccountStatsUpdateTask(t *testing.T) {
 		priceToken: priceToken,
 		srcDb:      &rp,
 	}
-	err := task.Execute(time.Time{}, end)
+	err := task.Execute(context.Background(), time.Time{}, end)
 
 	assert.NoError(err)
 	assert.Equal(expected, rp.updatedAccountStats)
@@ -390,7 +426,7 @@ func TestExecuteAccountStatsUpdateTaskDeduplicatesAccountCreation(t *testing.T) 
 		priceToken: priceToken,
 		srcDb:      &rp,
 	}
-	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+	err := task.Execute(context.Background(), time.Time{}, time.Unix(1666765800, 0).UTC())
 
 	assert.NoError(err)
 	assert.Equal([]string{accountAddress}, rp.updatedAccounts)
@@ -420,7 +456,7 @@ func TestExecuteAccountStatsUpdateTaskReturnsErrorWhenAccountIdMissing(t *testin
 		priceToken: priceToken,
 		srcDb:      &rp,
 	}
-	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+	err := task.Execute(context.Background(), time.Time{}, time.Unix(1666765800, 0).UTC())
 
 	assert.ErrorContains(err, "account id not found")
 	assert.Empty(rp.updatedAccountStats)
@@ -446,7 +482,7 @@ func TestExecuteAccountStatsUpdateTaskPropagatesCreateAccountsError(t *testing.T
 		priceToken: priceToken,
 		srcDb:      &rp,
 	}
-	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+	err := task.Execute(context.Background(), time.Time{}, time.Unix(1666765800, 0).UTC())
 
 	assert.ErrorIs(err, createErr)
 	assert.Empty(rp.updatedAccountStats)
@@ -472,7 +508,7 @@ func TestExecuteAccountStatsUpdateTaskPassesPriceToken(t *testing.T) {
 		priceToken: priceToken,
 		srcDb:      &rp,
 	}
-	err := task.Execute(time.Time{}, end)
+	err := task.Execute(context.Background(), time.Time{}, end)
 
 	assert.NoError(err)
 	rp.AssertCalled(t, "AccountStats", util.ToEpoch(time.Time{}), util.ToEpoch(end), priceToken)
@@ -493,7 +529,7 @@ func TestExecuteAccountStatsUpdateTaskNoStats(t *testing.T) {
 		},
 		srcDb: &rp,
 	}
-	err := task.Execute(time.Time{}, time.Unix(1666765800, 0).UTC())
+	err := task.Execute(context.Background(), time.Time{}, time.Unix(1666765800, 0).UTC())
 
 	assert.NoError(err)
 	assert.Empty(rp.updatedAccounts)
@@ -518,16 +554,17 @@ func TestExecuteAccountStatsUpdateTaskWaitsForParentPriceTask(t *testing.T) {
 	parent.setLastProcessedHeight(endHeight - 1)
 	task := accountStatsUpdateTask{
 		taskImpl: taskImpl{
-			chainId:     "cube_47-5",
-			destDb:      &rp,
-			parentTasks: []task{parent},
-			logger:      logging.Discard,
+			chainId:         "cube_47-5",
+			destDb:          &rp,
+			parentTasks:     []task{parent},
+			taskWaitTimeout: time.Minute,
+			logger:          logging.Discard,
 		},
 		srcDb: &rp,
 	}
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- task.Execute(time.Time{}, end)
+		errCh <- task.Execute(context.Background(), time.Time{}, end)
 	}()
 
 	select {
@@ -549,4 +586,34 @@ func TestExecuteAccountStatsUpdateTaskWaitsForParentPriceTask(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(endHeight, task.LastProcessedHeight())
 	rp.AssertCalled(t, "AccountStats", util.ToEpoch(time.Time{}), util.ToEpoch(end), "")
+}
+
+func TestExecuteAccountStatsUpdateTaskParentWaitTimeout(t *testing.T) {
+	assert := assert.New(t)
+
+	end := time.Unix(1666765800, 0).UTC()
+	endHeight := uint64(10)
+
+	rp := repoMock{}
+	rp.On("HeightOnTimestamp").Return(endHeight, nil)
+
+	parent := &completedTask{}
+	parent.setLastProcessedHeight(endHeight - 1)
+	task := accountStatsUpdateTask{
+		taskImpl: taskImpl{
+			chainId:         "cube_47-5",
+			destDb:          &rp,
+			parentTasks:     []task{parent},
+			taskWaitTimeout: time.Millisecond,
+			logger:          logging.Discard,
+		},
+		srcDb: &rp,
+	}
+
+	err := task.Execute(context.Background(), time.Time{}, end)
+
+	assert.ErrorIs(err, context.DeadlineExceeded)
+	assert.Empty(rp.updatedAccountStats)
+	assert.Equal(uint64(0), task.LastProcessedHeight())
+	rp.AssertNotCalled(t, "AccountStats", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/configs/aggregator.config.go
+++ b/configs/aggregator.config.go
@@ -4,12 +4,23 @@ import (
 	"time"
 )
 
+const DefaultTaskWaitTimeout = 30 * time.Minute
+
 type AggregatorConfig struct {
-	ChainId    string       `mapstructure:"chainid"`
-	PriceToken string       `mapstructure:"pricetoken"`
-	StartTs    time.Time    `mapstructure:"startts"`
-	CleanDups  bool         `mapstructure:"cleandups"`
-	SrcDb      RdbConfig    `mapstructure:"srcdb"`
-	DestDb     RdbConfig    `mapstructure:"destdb"`
-	Router     RouterConfig `mapstructure:"router"`
+	ChainId         string        `mapstructure:"chainid"`
+	PriceToken      string        `mapstructure:"pricetoken"`
+	StartTs         time.Time     `mapstructure:"startts"`
+	CleanDups       bool          `mapstructure:"cleandups"`
+	TaskWaitTimeout time.Duration `mapstructure:"taskwaittimeout"`
+	SrcDb           RdbConfig     `mapstructure:"srcdb"`
+	DestDb          RdbConfig     `mapstructure:"destdb"`
+	Router          RouterConfig  `mapstructure:"router"`
+}
+
+// defaultAggregatorConfig returns aggregator defaults that are not covered by
+// zero values.
+func defaultAggregatorConfig() AggregatorConfig {
+	return AggregatorConfig{
+		TaskWaitTimeout: DefaultTaskWaitTimeout,
+	}
 }

--- a/configs/config.go
+++ b/configs/config.go
@@ -18,7 +18,8 @@ const (
 )
 
 var defaultConfig = Config{
-	Collector: defaultCollectorConfig(),
+	Aggregator: defaultAggregatorConfig(),
+	Collector:  defaultCollectorConfig(),
 	Parser: ParserConfig{
 		DexConfig: ParserDexConfig{
 			QuarantineRetryMode: QuarantineRetryDisabled,
@@ -57,11 +58,7 @@ func New() Config {
 	}
 
 	var cfg = defaultConfig
-	if err = v.Unmarshal(&cfg, viper.DecodeHook(
-		mapstructure.ComposeDecodeHookFunc(
-			mapstructure.TextUnmarshallerHookFunc(),
-		),
-	)); err != nil {
+	if err = v.Unmarshal(&cfg, viper.DecodeHook(configDecodeHook())); err != nil {
 		panic(fmt.Errorf("unmarshal config: %w", err))
 	}
 
@@ -81,11 +78,7 @@ func NewWithFileName(fileName string) Config {
 	}
 
 	var cfg = defaultConfig
-	if err = v.Unmarshal(&cfg, viper.DecodeHook(
-		mapstructure.ComposeDecodeHookFunc(
-			mapstructure.TextUnmarshallerHookFunc(),
-		),
-	)); err != nil {
+	if err = v.Unmarshal(&cfg, viper.DecodeHook(configDecodeHook())); err != nil {
 		panic(fmt.Errorf("unmarshal config: %w", err))
 	}
 
@@ -114,6 +107,16 @@ func initViper(configName string) (*viper.Viper, error) {
 	}
 
 	return v, nil
+}
+
+// configDecodeHook returns the shared mapstructure hooks for config values.
+// It supports plain time.Duration fields as strings like "30m" while
+// preserving existing custom Duration wrappers that implement TextUnmarshaler.
+func configDecodeHook() mapstructure.DecodeHookFunc {
+	return mapstructure.ComposeDecodeHookFunc(
+		mapstructure.StringToTimeDurationHookFunc(),
+		mapstructure.TextUnmarshallerHookFunc(),
+	)
 }
 
 func (c Config) Redacted() Config {

--- a/configs/config_test.go
+++ b/configs/config_test.go
@@ -144,6 +144,7 @@ func Test_AggregatorConfig_EnvVars(t *testing.T) {
 	t.Setenv("APP_AGGREGATOR_CHAINID", "columbus-5")
 	t.Setenv("APP_AGGREGATOR_PRICETOKEN", "uusd")
 	t.Setenv("APP_AGGREGATOR_CLEANDUPS", "true")
+	t.Setenv("APP_AGGREGATOR_TASKWAITTIMEOUT", "2h")
 	t.Setenv("APP_AGGREGATOR_SRCDB_HOST", "src-host")
 	t.Setenv("APP_AGGREGATOR_SRCDB_PORT", "5432")
 	t.Setenv("APP_AGGREGATOR_SRCDB_DATABASE", "srcdb")
@@ -169,6 +170,7 @@ func Test_AggregatorConfig_EnvVars(t *testing.T) {
 	require.Equal(t, "columbus-5", agg.ChainId)
 	require.Equal(t, "uusd", agg.PriceToken)
 	require.True(t, agg.CleanDups)
+	require.Equal(t, 2*time.Hour, agg.TaskWaitTimeout)
 	// SrcDb
 	require.Equal(t, "src-host", agg.SrcDb.Host)
 	require.Equal(t, 5432, agg.SrcDb.Port)
@@ -188,6 +190,12 @@ func Test_AggregatorConfig_EnvVars(t *testing.T) {
 	require.Equal(t, "terra1router", agg.Router.RouterAddr)
 	require.Equal(t, uint(3), agg.Router.MaxHopCount)
 	require.True(t, agg.Router.WriteDb)
+}
+
+func Test_AggregatorConfig_DefaultTaskWaitTimeout(t *testing.T) {
+	cfg := defaultAggregatorConfig()
+
+	require.Equal(t, DefaultTaskWaitTimeout, cfg.TaskWaitTimeout)
 }
 
 func Test_CollectorConfig_EnvVars(t *testing.T) {


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`waitUntilReachingHeight` could block forever while waiting for parent aggregator tasks to reach a target height. This could leave dependent task scheduler goroutines stuck without surfacing an actionable error through the existing scheduler error path.

Fixes #134.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Pass `context.Context` through aggregator task execution so scheduled tasks can observe cancellation.
- Bound parent task height waits with configurable `aggregator.taskwaittimeout` / `APP_AGGREGATOR_TASKWAITTIMEOUT`, defaulting to `30m`.
- Return dependency wait errors on context cancellation or timeout, preserving existing fatal scheduler error handling instead of skipping windows or advancing task height.
- Add config decode support for string duration values and cover timeout/default parsing.
- Add tests for wait success/cancel/timeout behavior, scheduler error propagation, and account stats avoiding work when parent wait times out.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable task wait timeout for aggregator processing (with default and environment variable support).
* **Bug Fixes**
  * Scheduler and task execution now consistently respect cancellation, preventing hangs during parent-task waiting.
  * Task failures are propagated more reliably, and error reporting no longer risks blocking when no receiver is available.
* **Tests**
  * Added/updated tests to cover task error propagation, timeout behavior, and non-blocking error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->