### PR TITLE
chore(parser): improve pool validation logging

### DIFF
--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -21,6 +21,7 @@ import (
 	pts "github.com/dezswap/cosmwasm-etl/parser/dex/terraswap"
 	"github.com/dezswap/cosmwasm-etl/pkg/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
+	"github.com/sirupsen/logrus"
 
 	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
@@ -112,10 +113,21 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 	for errCount := uint(0); errCount <= c.ErrTolerance; {
 		if err := runner.Run(); err != nil {
 			if errors.Is(err, p_dex.ErrNoNewHeight) {
-				logger.Infof("no new block yet: %s", err)
+				logger.WithFields(logrus.Fields{
+					"event":     "parser.waiting_for_new_height",
+					"operation": "parser.run",
+					"chain_id":  c.ChainId,
+					"err":       logging.NewErrorField(err),
+				}).Info("parser waiting for new height")
 			} else {
 				errCount++
-				logger.Errorf("errCount: %d, err: %s", errCount, err)
+				logger.WithFields(logrus.Fields{
+					"event":       "parser.run_failed",
+					"operation":   "parser.run",
+					"chain_id":    c.ChainId,
+					"retry_count": errCount,
+					"err":         logging.NewErrorField(err),
+				}).Error("parser run failed")
 			}
 		} else {
 			errCount = 0

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -5,17 +5,26 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+	"github.com/sirupsen/logrus"
 )
 
 // ErrNoNewHeight is returned when the remote node height has not advanced for
 // sameHeightTolerance consecutive checks. Callers should treat this as a
 // transient "wait for next block" condition, not a hard error.
 var ErrNoNewHeight = errors.New("no new height")
+
+const (
+	validationMismatchUnexpectedPool      = "unexpected_pool"
+	validationMismatchExpectedPoolMissing = "expected_pool_not_found"
+	validationMismatchAssetAmount         = "asset_amount_mismatch"
+	validationMismatchTotalShare          = "total_share_mismatch"
+)
 
 type PairParsers struct {
 	CreatePairParser parser.Parser[ParsedTx]
@@ -76,6 +85,7 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 }
 
 func (app *dexApp) Run() error {
+	runStartedAt := time.Now()
 	tokenExceptions, err := app.GetTokenExceptions()
 	if err != nil {
 		return fmt.Errorf("app.Run: %w", err)
@@ -114,12 +124,31 @@ func (app *dexApp) Run() error {
 		app.triggerValidation(localSynced)
 	}
 
-	app.logger.Infof("current synced height: %d, remote node height: %d", localSynced, srcHeight)
+	app.logger.WithFields(logrus.Fields{
+		"event":         "parser.sync_status",
+		"operation":     "parser.run",
+		"chain_id":      app.chainId,
+		"local_height":  localSynced,
+		"source_height": srcHeight,
+		"lag":           srcHeight - localSynced,
+	}).Info("parser sync status")
+
+	processedHeightCount := 0
+	parsedTxCount := 0
+	quarantineCount := 0
+	poolSnapshotCount := 0
+
 	for cur := localSynced + 1; cur <= srcHeight; cur++ {
 		txs, err := app.GetSourceTxs(cur)
 		if err != nil {
 			if strings.Contains(err.Error(), fmt.Sprintf("greater than the current height %d", srcHeight-1)) {
-				app.logger.Infof("remote node is indexing tx_results, skip")
+				app.logger.WithFields(logrus.Fields{
+					"event":         "parser.source_indexing",
+					"operation":     "get_source_txs",
+					"chain_id":      app.chainId,
+					"height":        cur,
+					"source_height": srcHeight,
+				}).Info("remote node is indexing tx_results")
 				return nil
 			}
 			return fmt.Errorf("app.Run: %w", err)
@@ -137,7 +166,18 @@ func (app *dexApp) Run() error {
 				var partial *PartialParseQuarantineError
 				if errors.As(err, &partial) {
 					parseQuarantines = append(parseQuarantines, partial.Quarantine)
-					app.logger.Errorf("partially quarantined ambiguous transaction height=%d tx_hash=%s err=%s", cur, tx.Hash, err)
+					app.logger.WithFields(logrus.Fields{
+						"event":             "parse_quarantine.partial_created",
+						"operation":         "parse_txs",
+						"chain_id":          app.chainId,
+						"height":            cur,
+						"tx_hash":           tx.Hash,
+						"stage":             partial.Quarantine.Stage,
+						"contract":          partial.Quarantine.Contract,
+						"action":            partial.Quarantine.Action,
+						"quarantine_status": QuarantineStatusPending,
+						"err":               logging.NewErrorField(err),
+					}).Warn("partial parse quarantine created")
 					parsedTxs = append(parsedTxs, partial.ParsedTxs...)
 					continue
 				}
@@ -153,7 +193,18 @@ func (app *dexApp) Run() error {
 						Error:    err.Error(),
 						RawTx:    tx,
 					})
-					app.logger.Errorf("quarantined ambiguous transaction height=%d tx_hash=%s err=%s", cur, tx.Hash, err)
+					app.logger.WithFields(logrus.Fields{
+						"event":             "parse_quarantine.created",
+						"operation":         "parse_txs",
+						"chain_id":          app.chainId,
+						"height":            cur,
+						"tx_hash":           tx.Hash,
+						"stage":             parseStage(err),
+						"contract":          ambiguity.Contract,
+						"action":            ambiguity.Action,
+						"quarantine_status": QuarantineStatusPending,
+						"err":               logging.NewErrorField(err),
+					}).Warn("parse quarantine created")
 					continue
 				}
 				return fmt.Errorf("app.Run: %w", err)
@@ -162,22 +213,55 @@ func (app *dexApp) Run() error {
 		}
 
 		poolInfos := []PoolInfo{}
+		poolSnapshotSaved := false
 		if (cur % uint64(app.poolSnapshotInterval)) == 0 {
 			poolInfos, err = app.GetPoolInfos(cur)
 			if err != nil {
 				return fmt.Errorf("app.Run: %w", err)
 			}
+			poolSnapshotSaved = true
 		}
 
 		if err := app.insert(cur-1, cur, parsedTxs, poolInfos, parseQuarantines); err != nil {
 			return fmt.Errorf("app.Run: %w", err)
 		}
+		processedHeightCount++
+		parsedTxCount += len(parsedTxs)
+		quarantineCount += len(parseQuarantines)
+		if poolSnapshotSaved {
+			poolSnapshotCount++
+		}
+		app.logger.WithFields(logrus.Fields{
+			"event":               "parser.height_processed",
+			"operation":           "parser.run",
+			"chain_id":            app.chainId,
+			"height":              cur,
+			"parsed_tx_count":     len(parsedTxs),
+			"quarantine_count":    len(parseQuarantines),
+			"pool_snapshot_saved": poolSnapshotSaved,
+		}).Debug("parser height processed")
 
 		if app.isValidationHeight(cur) {
 			app.triggerValidation(cur)
 		}
 	}
 	app.lastSrcHeight = srcHeight
+	if processedHeightCount > 0 {
+		app.logger.WithFields(logrus.Fields{
+			"event":                  "parser.run_summary",
+			"operation":              "parser.run",
+			"chain_id":               app.chainId,
+			"from_height":            localSynced + 1,
+			"to_height":              srcHeight,
+			"synced_height":          srcHeight,
+			"source_height":          srcHeight,
+			"processed_height_count": processedHeightCount,
+			"parsed_tx_count":        parsedTxCount,
+			"quarantine_count":       quarantineCount,
+			"pool_snapshot_count":    poolSnapshotCount,
+			"duration_ms":            time.Since(runStartedAt).Milliseconds(),
+		}).Info("parser run summary")
+	}
 
 	return nil
 }
@@ -219,7 +303,18 @@ func (app *dexApp) retryPendingQuarantines(tokenExceptions map[string]bool) erro
 		if err := app.ResolveParseQuarantine(quarantine.ID, quarantine.Height, txs); err != nil {
 			return err
 		}
-		app.logger.Infof("resolved quarantined transaction height=%d tx_hash=%s", quarantine.Height, quarantine.Hash)
+		app.logger.WithFields(logrus.Fields{
+			"event":             "parse_quarantine.resolved",
+			"operation":         "retry_parse_quarantine",
+			"chain_id":          app.chainId,
+			"height":            quarantine.Height,
+			"tx_hash":           quarantine.Hash,
+			"stage":             quarantine.Stage,
+			"contract":          quarantine.Contract,
+			"action":            quarantine.Action,
+			"quarantine_status": QuarantineStatusResolved,
+			"parsed_tx_count":   len(txs),
+		}).Info("parse quarantine resolved")
 	}
 	return nil
 }
@@ -403,16 +498,51 @@ func (app *dexApp) validateAtHeight(height uint64) bool {
 		return false
 	}
 	if err := app.validate(0, height, poolInfos); err != nil {
-		app.logger.Errorf("validator: pool mismatch at height %d: %s", height, err)
+		var validationErr *poolValidationError
+		if errors.As(err, &validationErr) {
+			for _, mismatch := range validationErr.Mismatches {
+				app.logPoolValidationMismatch(height, mismatch)
+			}
+		} else {
+			app.logger.WithFields(logrus.Fields{
+				"event":     "parser.pool_validation_failed",
+				"operation": "pool_validation",
+				"chain_id":  app.chainId,
+				"height":    height,
+				"err":       logging.NewErrorField(err),
+			}).Error("pool validation failed")
+		}
 		return false
 	}
 	return true
 }
 
+// logPoolValidationMismatch emits the agent-facing root log for one pool validation mismatch.
+func (app *dexApp) logPoolValidationMismatch(height uint64, mismatch poolValidationMismatch) {
+	app.logger.WithFields(logrus.Fields{
+		"event":         "parser.pool_validation_failed",
+		"operation":     "pool_validation",
+		"chain_id":      app.chainId,
+		"height":        height,
+		"contract":      mismatch.Contract,
+		"mismatch_type": mismatch.Type,
+		"asset":         mismatch.Asset,
+		"actual":        mismatch.Actual,
+		"expected":      mismatch.Expected,
+		"lookup_tables": []string{"parsed_tx", "pool_info", "parse_quarantine"},
+	}).Error("pool validation failed")
+}
+
 // validate with `expected` from the node, compare database updates, as `actual`
 func (app *dexApp) validate(from, to uint64, expected []PoolInfo) error {
 	if len(expected) == 0 {
-		app.logger.Infof("No pool info found at height %d", to)
+		app.logger.WithFields(logrus.Fields{
+			"event":     "parser.pool_validation_skipped",
+			"operation": "pool_validation",
+			"chain_id":  app.chainId,
+			"height":    to,
+			"reason":    "empty_expected_pool_info",
+		}).Info("no pool info found")
 		return nil
 	}
 
@@ -438,54 +568,107 @@ func (app *dexApp) validate(from, to uint64, expected []PoolInfo) error {
 		exceptionMap[addr] = true
 	}
 
+	validationErr := &poolValidationError{}
 	for _, pool := range actual {
 		if _, ok := exceptionMap[pool.ContractAddr]; ok {
 			continue
 		}
 		exp, ok := expectedPool[pool.ContractAddr]
 		if !ok {
-			return fmt.Errorf("unexpected pool(%s) found", pool.ContractAddr)
+			validationErr.Add(poolValidationMismatch{
+				Type:     validationMismatchUnexpectedPool,
+				Contract: pool.ContractAddr,
+				Actual:   pool.TotalShare,
+			})
+			continue
 		}
-		if err := app.comparePair(pool, exp); err != nil {
+		if err := app.collectPairValidationMismatches(pool, exp, validationErr); err != nil {
 			return err
 		}
 
 		delete(expectedPool, pool.ContractAddr)
 	}
-	if len(expectedPool) > 0 {
-		addrs := []string{}
-		for _, pool := range expectedPool {
-			addrs = append(addrs, pool.ContractAddr)
-		}
-		return fmt.Errorf("expected pools(%s) not found", addrs)
+	for _, pool := range expectedPool {
+		validationErr.Add(poolValidationMismatch{
+			Type:     validationMismatchExpectedPoolMissing,
+			Contract: pool.ContractAddr,
+			Expected: pool.TotalShare,
+		})
+	}
+	if validationErr.HasMismatches() {
+		return validationErr
 	}
 	return nil
 }
 
-func (app *dexApp) comparePair(actual PoolInfo, expected PoolInfo) error {
-	var diffs []string
+// poolValidationMismatch describes one concrete difference between source pool state and parsed DB state.
+type poolValidationMismatch struct {
+	Type     string
+	Contract string
+	Asset    string
+	Actual   string
+	Expected string
+}
+
+// poolValidationError aggregates every mismatch found during one validation run.
+type poolValidationError struct {
+	Mismatches []poolValidationMismatch
+}
+
+// Error summarizes the aggregated validation failure without hiding per-pool mismatch details.
+func (e *poolValidationError) Error() string {
+	if len(e.Mismatches) == 0 {
+		return "pool validation failed"
+	}
+	return fmt.Sprintf("pool validation failed with %d mismatch(es)", len(e.Mismatches))
+}
+
+// Add records one mismatch while allowing validation to continue collecting the rest.
+func (e *poolValidationError) Add(mismatch poolValidationMismatch) {
+	e.Mismatches = append(e.Mismatches, mismatch)
+}
+
+// HasMismatches reports whether validation found any differences worth failing on.
+func (e *poolValidationError) HasMismatches() bool {
+	return len(e.Mismatches) > 0
+}
+
+// collectPairValidationMismatches compares one pair and appends every asset/share mismatch.
+func (app *dexApp) collectPairValidationMismatches(actual PoolInfo, expected PoolInfo, validationErr *poolValidationError) error {
+	var mismatches []poolValidationMismatch
 
 	for idx, expAsset := range expected.Assets {
-		if expAsset.Amount != actual.Assets[idx].Amount {
-			diffs = append(diffs, fmt.Sprintf(
-				"pool(%s) asset(%s) amount mismatch: actual(%s), expected(%s)", actual.ContractAddr, expAsset.Addr, actual.Assets[idx].Amount, expAsset.Amount,
-			))
+		actualAmount := ""
+		if idx < len(actual.Assets) {
+			actualAmount = actual.Assets[idx].Amount
+		}
+		if expAsset.Amount != actualAmount {
+			mismatches = append(mismatches, poolValidationMismatch{
+				Type:     validationMismatchAssetAmount,
+				Contract: actual.ContractAddr,
+				Asset:    expAsset.Addr,
+				Actual:   actualAmount,
+				Expected: expAsset.Amount,
+			})
 		}
 	}
 
 	if expected.TotalShare != actual.TotalShare {
-		diffs = append(diffs, fmt.Sprintf(
-			"pool(%s) total share mismatch: actual(%s), expected(%s)", actual.ContractAddr, actual.TotalShare, expected.TotalShare,
-		))
+		mismatches = append(mismatches, poolValidationMismatch{
+			Type:     validationMismatchTotalShare,
+			Contract: actual.ContractAddr,
+			Actual:   actual.TotalShare,
+			Expected: expected.TotalShare,
+		})
 	}
 
-	if len(diffs) == 0 {
+	if len(mismatches) == 0 {
 		return nil
 	}
 
 	isValidationException := false
 	for _, a := range actual.Assets {
-		if app.IsValidationExceptionCandidate(a.Addr) {
+		if app.isValidationExceptionCandidate(a.Addr) {
 			isValidationException = true
 		}
 	}
@@ -499,7 +682,18 @@ func (app *dexApp) comparePair(actual PoolInfo, expected PoolInfo) error {
 		return nil
 	}
 
-	return errors.New(strings.Join(diffs, "; "))
+	for _, mismatch := range mismatches {
+		validationErr.Add(mismatch)
+	}
+	return nil
+}
+
+// isValidationExceptionCandidate safely delegates exception detection to the target app.
+func (app *dexApp) isValidationExceptionCandidate(contractAddress string) bool {
+	if app.TargetApp == nil {
+		return false
+	}
+	return app.IsValidationExceptionCandidate(contractAddress)
 }
 
 // CollectLpBurnTxs collects LP burn events and associates them with their pair contract.

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -1,6 +1,8 @@
 package dex
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"testing"
@@ -11,6 +13,7 @@ import (
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -256,6 +259,63 @@ func Test_Run_UpsertsPartialQuarantineAndInsertsParsedTxs(t *testing.T) {
 	srcStore.AssertExpectations(t)
 }
 
+func Test_Run_LogsSummaryAtInfoAndHeightProcessedAtDebug(t *testing.T) {
+	logBuf := &bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetOutput(logBuf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetLevel(logrus.InfoLevel)
+
+	target := &quarantineTargetApp{parse: func(tx parser.RawTx, _ uint64) ([]ParsedTx, error) {
+		return []ParsedTx{{
+			Hash:         tx.Hash,
+			Type:         Transfer,
+			Sender:       "sender",
+			ContractAddr: "pair",
+			Assets:       [2]Asset{{Addr: "asset0", Amount: "1"}, {Addr: "asset1", Amount: "0"}},
+		}}, nil
+	}}
+	repo := &RepoMock{}
+	srcStore := &RawStoreMock{}
+	app := &dexApp{
+		TargetApp:            target,
+		Repo:                 repo,
+		SourceDataStore:      srcStore,
+		logger:               logger.WithField("chainId", "chain-1"),
+		chainId:              "chain-1",
+		poolSnapshotInterval: 100,
+		sameHeightTolerance:  3,
+		quarantineRetryMode:  configs.QuarantineRetryDisabled,
+	}
+
+	repo.On("GetTokenExceptions").Return(map[string]bool{}, nil)
+	repo.On("GetSyncedHeight").Return(uint64(0), nil)
+	srcStore.On("GetSourceSyncedHeight").Return(uint64(2), nil)
+	srcStore.On("GetSourceTxs", uint64(1)).Return(parser.RawTxs{{Hash: "tx1"}}, nil)
+	srcStore.On("GetSourceTxs", uint64(2)).Return(parser.RawTxs{{Hash: "tx2"}}, nil)
+	repo.On("Insert", uint64(0), uint64(1), mock.Anything, []PoolInfo{}, []Pair{}, []ParseQuarantine{}).Return(nil)
+	repo.On("Insert", uint64(1), uint64(2), mock.Anything, []PoolInfo{}, []Pair{}, []ParseQuarantine{}).Return(nil)
+
+	require.NoError(t, app.Run())
+
+	var summary map[string]interface{}
+	for _, line := range bytes.Split(bytes.TrimSpace(logBuf.Bytes()), []byte("\n")) {
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal(line, &entry))
+		require.NotEqual(t, "parser.height_processed", entry["event"])
+		if entry["event"] == "parser.run_summary" {
+			summary = entry
+		}
+	}
+
+	require.NotNil(t, summary)
+	assert.Equal(t, float64(1), summary["from_height"])
+	assert.Equal(t, float64(2), summary["to_height"])
+	assert.Equal(t, float64(2), summary["processed_height_count"])
+	assert.Equal(t, float64(2), summary["parsed_tx_count"])
+	assert.Equal(t, float64(0), summary["quarantine_count"])
+}
+
 func Test_retryPendingQuarantines_ResolvesSuccessfulReplay(t *testing.T) {
 	rawTx := parser.RawTx{Hash: "replay"}
 	parsedTx := ParsedTx{
@@ -402,6 +462,91 @@ func Test_validate(t *testing.T) {
 			assert.NoError(t, err, errMsg)
 		}
 	}
+}
+
+func Test_validate_CollectsAllPoolValidationMismatches(t *testing.T) {
+	expectedPools := []PoolInfo{
+		{ContractAddr: "pair1", TotalShare: "1000", Assets: []Asset{{"asset0", "500"}, {"asset1", "500"}}},
+		{ContractAddr: "pair2", TotalShare: "2000", Assets: []Asset{{"asset2", "1000"}, {"asset3", "1000"}}},
+	}
+	actualPools := []PoolInfo{
+		{ContractAddr: "pair1", TotalShare: "900", Assets: []Asset{{"asset0", "400"}, {"asset1", "450"}}},
+		{ContractAddr: "unexpected", TotalShare: "3000", Assets: []Asset{{"asset4", "1500"}, {"asset5", "1500"}}},
+	}
+	repoMock := RepoMock{}
+	repoMock.On("ParsedPoolsInfo", uint64(0), uint64(100)).Return(actualPools, nil)
+	repoMock.On("ValidationExceptionList").Return([]string{}, nil)
+	app := dexApp{Repo: &repoMock}
+
+	err := app.validate(0, 100, expectedPools)
+	require.Error(t, err)
+
+	var validationErr *poolValidationError
+	require.ErrorAs(t, err, &validationErr)
+	assert.ElementsMatch(t, []poolValidationMismatch{
+		{Type: validationMismatchAssetAmount, Contract: "pair1", Asset: "asset0", Actual: "400", Expected: "500"},
+		{Type: validationMismatchAssetAmount, Contract: "pair1", Asset: "asset1", Actual: "450", Expected: "500"},
+		{Type: validationMismatchTotalShare, Contract: "pair1", Actual: "900", Expected: "1000"},
+		{Type: validationMismatchUnexpectedPool, Contract: "unexpected", Actual: "3000"},
+		{Type: validationMismatchExpectedPoolMissing, Contract: "pair2", Expected: "2000"},
+	}, validationErr.Mismatches)
+}
+
+func Test_validateAtHeight_LogsEveryPoolValidationMismatch(t *testing.T) {
+	expectedPools := []PoolInfo{
+		{ContractAddr: "pair1", TotalShare: "1000", Assets: []Asset{{"asset0", "500"}, {"asset1", "500"}}},
+		{ContractAddr: "pair2", TotalShare: "2000", Assets: []Asset{{"asset2", "1000"}, {"asset3", "1000"}}},
+	}
+	actualPools := []PoolInfo{
+		{ContractAddr: "pair1", TotalShare: "900", Assets: []Asset{{"asset0", "400"}, {"asset1", "500"}}},
+		{ContractAddr: "unexpected", TotalShare: "3000", Assets: []Asset{{"asset4", "1500"}, {"asset5", "1500"}}},
+	}
+	logBuf := &bytes.Buffer{}
+	logger := logrus.New()
+	logger.SetOutput(logBuf)
+	logger.SetFormatter(&logrus.JSONFormatter{})
+	logger.SetLevel(logrus.InfoLevel)
+
+	srcStore := &RawStoreMock{}
+	repo := &RepoMock{}
+	app := &dexApp{
+		Repo:            repo,
+		SourceDataStore: srcStore,
+		logger:          logger.WithField("chainId", "chain-1"),
+		chainId:         "chain-1",
+	}
+
+	srcStore.On("GetPoolInfos", uint64(100)).Return(expectedPools, nil)
+	repo.On("ParsedPoolsInfo", uint64(0), uint64(100)).Return(actualPools, nil)
+	repo.On("ValidationExceptionList").Return([]string{}, nil)
+
+	assert.False(t, app.validateAtHeight(100))
+
+	var logs []map[string]interface{}
+	for _, line := range bytes.Split(bytes.TrimSpace(logBuf.Bytes()), []byte("\n")) {
+		var entry map[string]interface{}
+		require.NoError(t, json.Unmarshal(line, &entry))
+		if entry["event"] == "parser.pool_validation_failed" {
+			logs = append(logs, entry)
+		}
+	}
+
+	require.Len(t, logs, 4)
+	assertLogFields := func(contract, mismatchType string) bool {
+		for _, entry := range logs {
+			if entry["contract"] == contract && entry["mismatch_type"] == mismatchType {
+				assert.Equal(t, "chain-1", entry["chain_id"])
+				assert.Equal(t, float64(100), entry["height"])
+				assert.Equal(t, "pool_validation", entry["operation"])
+				return true
+			}
+		}
+		return false
+	}
+	assert.True(t, assertLogFields("pair1", validationMismatchAssetAmount))
+	assert.True(t, assertLogFields("pair1", validationMismatchTotalShare))
+	assert.True(t, assertLogFields("unexpected", validationMismatchUnexpectedPool))
+	assert.True(t, assertLogFields("pair2", validationMismatchExpectedPoolMissing))
 }
 
 var (


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Parser validation failures were hard to diagnose from logs because pool mismatches were reported as unstructured error strings and validation stopped at the first detected issue. This change makes parser and pool validation logs easier for engineers and AI agents to inspect during incident/debug workflows.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Add structured parser logs for sync status, retry failures, source indexing waits, parse quarantine creation/resolution, and per-run parser summaries.
- Aggregate all pool validation mismatches in a validation run instead of returning only the first mismatch.
- Emit one structured validation failure log per mismatch with contract, mismatch type, asset, actual/expected values, and related lookup tables.
- Move per-height processed logs to debug level and keep info-level run summaries to reduce catch-up log noise.
- Add tests for parser run summary logging, validation mismatch aggregation, and validation mismatch log emission.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parser logging to use structured, more readable messages for retries, sync status, height processing, and quarantine handling.
  * Validation now reports all pool mismatches instead of stopping at the first issue, making failures easier to diagnose.
  * Added safer handling for validation checks when app context is unavailable.

* **Tests**
  * Expanded coverage for run summaries, height-processing logs, and detailed pool validation mismatch reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->