### PR TITLE
feat(parser): add dry-run diagnose command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ down:
 deps:
 	go mod download
 
-.PHONY: build-all aggregator collector parser-dex
+.PHONY: build-all aggregator collector parser-dex parser-diagnose
 build-all: aggregator collector parser-dex
 
 aggregator:
@@ -32,6 +32,9 @@ collector:
 # Build the main executable
 parser-dex:
 	go  build -mod=readonly -o ./build/parser-dex ./cmd/parser/dex
+
+parser-diagnose:
+	go  build -mod=readonly -o ./build/parser-diagnose ./cmd/parser/diagnose
 
 .PHONY: install-all install-aggregator install-collector install-parser-dex
 install-all: install-aggregator install-collector install-parser-dex
@@ -120,10 +123,13 @@ image:
 # Migrate database.
 .PHONY: parser-migrate-test parser-migrate-up parser-migrate-down parser-generate-migration \
 		aggregator-migrate-up aggregator-migrate-down aggregator-generate-migration \
-		collector-migrate-up collector-migrate-down collector-generate-migration
+		collector-migrate-test collector-migrate-up collector-migrate-down collector-generate-migration
 
 parser-migrate-test:
 	go test -count=1 -tags=mig,faker ./db/migrations/parser
+
+collector-migrate-test:
+	go test -count=1 -tags=mig ./db/migrations/collector
 
 parser-migrate-up:
 	go run db/migrations/parser/main.go

--- a/cmd/parser/dex/main.go
+++ b/cmd/parser/dex/main.go
@@ -10,22 +10,14 @@ import (
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/dezswap/cosmwasm-etl/collector/datastore"
-	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
 	"github.com/dezswap/cosmwasm-etl/configs"
 	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
-	pds "github.com/dezswap/cosmwasm-etl/parser/dex/dezswap"
+	"github.com/dezswap/cosmwasm-etl/parser/dex/dexwiring"
 	"github.com/dezswap/cosmwasm-etl/parser/dex/repo"
-	"github.com/dezswap/cosmwasm-etl/parser/dex/srcstore"
-	ts_srcstore "github.com/dezswap/cosmwasm-etl/parser/dex/srcstore/terraswap"
-	psf "github.com/dezswap/cosmwasm-etl/parser/dex/starfleit"
-	pts "github.com/dezswap/cosmwasm-etl/parser/dex/terraswap"
-	"github.com/dezswap/cosmwasm-etl/pkg/dex"
-	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
 	"github.com/sirupsen/logrus"
 
 	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
-	"github.com/dezswap/cosmwasm-etl/pkg/s3client"
 )
 
 const (
@@ -33,38 +25,6 @@ const (
 )
 
 var version = "dev" // overridden via -ldflags "-X main.version=v1.2.3"
-
-func getDexCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) datastore.ReadStore {
-	nodeConf := dc.NodeConfig
-	if nodeConf.GrpcConfig.Host != "" {
-		nodeConf := dc.NodeConfig
-		serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)
-
-		store, err := datastore.New(c, serviceDesc, nil)
-		if err != nil {
-			panic(err)
-		}
-		if nodeConf.FailoverLcdHost != "" {
-			failoverStore, err := datastore.New(
-				c,
-				serviceDesc,
-				datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)),
-			)
-			if err != nil {
-				panic(err)
-			}
-			store = failoverStore
-		}
-
-		return datastore.NewReadStoreWithGrpc(dc.ChainId, store)
-	}
-
-	s3Client, err := s3client.NewClient(c.S3)
-	if err != nil {
-		panic(err)
-	}
-	return datastore.NewReadStore(dc.ChainId, s3Client)
-}
 
 func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs.SentryConfig, rdbc configs.RdbConfig, readStore datastore.ReadStore) {
 	logger := logging.New("main", logc)
@@ -79,32 +39,14 @@ func dex_main(c configs.ParserDexConfig, logc configs.LogConfig, sentryc configs
 	defer catch(logger)
 
 	repo := repo.New(c.ChainId, rdbc)
-	var app p_dex.TargetApp
-	var err error
-	switch c.TargetApp {
-	case dex.Terraswap:
-		app, err = pts.New(repo, logger, c)
-	case dex.Dezswap:
-		app, err = pds.New(repo, logger, c, c.ChainId)
-	case dex.Starfleit:
-		app, err = psf.New(repo, logger, c, c.ChainId)
-	default:
-		panic("unknown target app: " + c.TargetApp)
-	}
-
+	app, err := dexwiring.NewTargetApp(repo, logger, c)
 	if err != nil {
 		panic(err)
 	}
 
-	var rawDataStore p_dex.SourceDataStore
-	if c.TargetApp == dex.Terraswap {
-		fallback, err := ts_srcstore.NewFromConfig(c.NodeConfig, c.FactoryAddress)
-		if err != nil {
-			panic(err)
-		}
-		rawDataStore = srcstore.NewCollectorFallback(c.ChainId, collectorrepo.New(rdbc), fallback, logger)
-	} else {
-		rawDataStore = srcstore.New(readStore)
+	rawDataStore, err := dexwiring.NewSourceDataStore(c, rdbc, readStore, logger)
+	if err != nil {
+		panic(err)
 	}
 
 	runner := p_dex.NewDexApp(app, rawDataStore, repo, logger, c)
@@ -150,11 +92,9 @@ func main() {
 	}
 
 	dc := c.Parser.DexConfig
-	var readstore datastore.ReadStore
-	switch dc.TargetApp {
-	case dex.Terraswap:
-	case dex.Dezswap, dex.Starfleit:
-		readstore = getDexCollectorReadStore(c, dc)
+	readstore, err := dexwiring.NewTargetReadStore(c, dc)
+	if err != nil {
+		panic(err)
 	}
 	dex_main(dc, c.Log, c.Sentry, c.Rdb, readstore)
 }

--- a/cmd/parser/diagnose/README.md
+++ b/cmd/parser/diagnose/README.md
@@ -1,0 +1,66 @@
+# Parser Diagnose
+
+`parser-diagnose` replays parser logic for a height range and pair contract without advancing parser synced height or writing parsed rows.
+
+```bash
+make parser-diagnose
+./build/parser-diagnose --from 26407001 --to 26408000 --contract terra1...
+```
+
+Use this command after a `parser.pool_validation_failed` log. The log includes:
+
+- `chain_id`
+- `contract`
+- `validation_height`
+- `investigation_from_height`
+- `investigation_to_height`
+- `validation_interval`
+- `mismatch_type`
+- `actual`
+- `expected`
+- `lookup_tables`
+
+## Investigation Query Templates
+
+Check quarantined transactions in the investigation window. `contract` can be a token contract, so scan `raw_tx` for the pair contract or expected action.
+
+```sql
+SELECT *
+FROM parse_quarantine
+WHERE chain_id = $1
+  AND height BETWEEN $2 AND $3
+ORDER BY height ASC, id ASC;
+```
+
+Check parsed transactions for the pair in the same window.
+
+```sql
+SELECT height, hash, type, sender, asset0_amount, asset1_amount,
+       lp_amount, commission0_amount, commission1_amount
+FROM parsed_tx
+WHERE chain_id = $1
+  AND contract = $2
+  AND height BETWEEN $3 AND $4
+ORDER BY height DESC;
+```
+
+Find raw collector transactions when collector source tables are available.
+
+```sql
+SELECT *
+FROM collector_blocks
+WHERE chain_id = $1
+  AND height BETWEEN $2 AND $3
+  AND txs::text ILIKE '%' || $4 || '%'
+ORDER BY height ASC;
+```
+
+Find raw FCD logs when `fcd_tx_log` is available.
+
+```sql
+SELECT *
+FROM fcd_tx_log
+WHERE address = $1
+  AND height BETWEEN $2 AND $3
+ORDER BY height DESC, fcd_offset DESC;
+```

--- a/cmd/parser/diagnose/main.go
+++ b/cmd/parser/diagnose/main.go
@@ -9,22 +9,12 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dezswap/cosmwasm-etl/collector/datastore"
-	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
 	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
-	pds "github.com/dezswap/cosmwasm-etl/parser/dex/dezswap"
+	"github.com/dezswap/cosmwasm-etl/parser/dex/dexwiring"
 	"github.com/dezswap/cosmwasm-etl/parser/dex/repo"
-	"github.com/dezswap/cosmwasm-etl/parser/dex/srcstore"
-	ts_srcstore "github.com/dezswap/cosmwasm-etl/parser/dex/srcstore/terraswap"
-	psf "github.com/dezswap/cosmwasm-etl/parser/dex/starfleit"
-	pts "github.com/dezswap/cosmwasm-etl/parser/dex/terraswap"
-	"github.com/dezswap/cosmwasm-etl/pkg/dex"
-	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
-	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
-	"github.com/dezswap/cosmwasm-etl/pkg/s3client"
 )
 
 type diagnosisReport struct {
@@ -69,10 +59,10 @@ func main() {
 	}
 
 	report, err := diagnoseRange(target, source, tokenExceptions, dc.ChainId, *from, *to, *contract)
-	if err != nil {
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
 		fail(err.Error())
 	}
-	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+	if err != nil {
 		fail(err.Error())
 	}
 }
@@ -85,30 +75,18 @@ func buildDiagnosticTargets(c configs.Config, dc configs.ParserDexConfig) (p_dex
 		return nil, nil, nil, fmt.Errorf("load token exceptions: %w", err)
 	}
 
-	var app p_dex.TargetApp
-	switch dc.TargetApp {
-	case dex.Terraswap:
-		app, err = pts.New(parserRepo, logging.Discard, dc)
-	case dex.Dezswap:
-		app, err = pds.New(parserRepo, logging.Discard, dc, dc.ChainId)
-	case dex.Starfleit:
-		app, err = psf.New(parserRepo, logging.Discard, dc, dc.ChainId)
-	default:
-		return nil, nil, nil, fmt.Errorf("unknown target app: %s", dc.TargetApp)
-	}
+	app, err := dexwiring.NewTargetApp(parserRepo, logging.Discard, dc)
 	if err != nil {
 		return nil, nil, nil, err
 	}
 
-	var source p_dex.SourceDataStore
-	if dc.TargetApp == dex.Terraswap {
-		fallback, err := ts_srcstore.NewFromConfig(dc.NodeConfig, dc.FactoryAddress)
-		if err != nil {
-			return nil, nil, nil, err
-		}
-		source = srcstore.NewCollectorFallback(dc.ChainId, collectorrepo.New(c.Rdb), fallback, logging.Discard)
-	} else {
-		source = srcstore.New(getDexCollectorReadStore(c, dc))
+	readStore, err := dexwiring.NewTargetReadStore(c, dc)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	source, err := dexwiring.NewSourceDataStore(dc, c.Rdb, readStore, logging.Discard)
+	if err != nil {
+		return nil, nil, nil, err
 	}
 
 	return app, source, tokenExceptions, nil
@@ -177,38 +155,6 @@ func rawTxContainsContract(tx parser.RawTx, contract string) bool {
 		}
 	}
 	return false
-}
-
-// getDexCollectorReadStore mirrors the production parser source selection for collector-backed DEXes.
-func getDexCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) datastore.ReadStore {
-	nodeConf := dc.NodeConfig
-	if nodeConf.GrpcConfig.Host != "" {
-		serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)
-
-		store, err := datastore.New(c, serviceDesc, nil)
-		if err != nil {
-			panic(err)
-		}
-		if nodeConf.FailoverLcdHost != "" {
-			failoverStore, err := datastore.New(
-				c,
-				serviceDesc,
-				datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)),
-			)
-			if err != nil {
-				panic(err)
-			}
-			store = failoverStore
-		}
-
-		return datastore.NewReadStoreWithGrpc(dc.ChainId, store)
-	}
-
-	s3Client, err := s3client.NewClient(c.S3)
-	if err != nil {
-		panic(err)
-	}
-	return datastore.NewReadStore(dc.ChainId, s3Client)
 }
 
 func fail(msg string) {

--- a/cmd/parser/diagnose/main.go
+++ b/cmd/parser/diagnose/main.go
@@ -1,0 +1,217 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"strings"
+
+	"github.com/dezswap/cosmwasm-etl/collector/datastore"
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
+	"github.com/dezswap/cosmwasm-etl/configs"
+	"github.com/dezswap/cosmwasm-etl/parser"
+	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
+	pds "github.com/dezswap/cosmwasm-etl/parser/dex/dezswap"
+	"github.com/dezswap/cosmwasm-etl/parser/dex/repo"
+	"github.com/dezswap/cosmwasm-etl/parser/dex/srcstore"
+	ts_srcstore "github.com/dezswap/cosmwasm-etl/parser/dex/srcstore/terraswap"
+	psf "github.com/dezswap/cosmwasm-etl/parser/dex/starfleit"
+	pts "github.com/dezswap/cosmwasm-etl/parser/dex/terraswap"
+	"github.com/dezswap/cosmwasm-etl/pkg/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
+	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+	"github.com/dezswap/cosmwasm-etl/pkg/s3client"
+)
+
+type diagnosisReport struct {
+	ChainID  string              `json:"chain_id"`
+	From     uint64              `json:"from_height"`
+	To       uint64              `json:"to_height"`
+	Contract string              `json:"contract"`
+	Results  []diagnosisTxResult `json:"results"`
+}
+
+type diagnosisTxResult struct {
+	Height        uint64           `json:"height"`
+	Hash          string           `json:"hash"`
+	Sender        string           `json:"sender"`
+	ParsedTxCount int              `json:"parsed_tx_count"`
+	ParsedTxs     []p_dex.ParsedTx `json:"parsed_txs,omitempty"`
+	Error         string           `json:"error,omitempty"`
+}
+
+func main() {
+	from := flag.Uint64("from", 0, "first height to diagnose")
+	to := flag.Uint64("to", 0, "last height to diagnose")
+	contract := flag.String("contract", "", "pair contract address to diagnose")
+	flag.Parse()
+
+	if *from == 0 || *to == 0 || *contract == "" {
+		fail("required flags: --from, --to, --contract")
+	}
+	if *from > *to {
+		fail("--from must be less than or equal to --to")
+	}
+
+	c := configs.New()
+	dc := c.Parser.DexConfig
+	if err := dc.Validate(); err != nil {
+		fail(fmt.Sprintf("invalid parser dex config: %s", err))
+	}
+
+	target, source, tokenExceptions, err := buildDiagnosticTargets(c, dc)
+	if err != nil {
+		fail(err.Error())
+	}
+
+	report, err := diagnoseRange(target, source, tokenExceptions, dc.ChainId, *from, *to, *contract)
+	if err != nil {
+		fail(err.Error())
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+		fail(err.Error())
+	}
+}
+
+// buildDiagnosticTargets creates the parser target and raw source reader used by dry-run diagnosis.
+func buildDiagnosticTargets(c configs.Config, dc configs.ParserDexConfig) (p_dex.TargetApp, p_dex.SourceDataStore, map[string]bool, error) {
+	parserRepo := repo.New(dc.ChainId, c.Rdb)
+	tokenExceptions, err := parserRepo.GetTokenExceptions()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("load token exceptions: %w", err)
+	}
+
+	var app p_dex.TargetApp
+	switch dc.TargetApp {
+	case dex.Terraswap:
+		app, err = pts.New(parserRepo, logging.Discard, dc)
+	case dex.Dezswap:
+		app, err = pds.New(parserRepo, logging.Discard, dc, dc.ChainId)
+	case dex.Starfleit:
+		app, err = psf.New(parserRepo, logging.Discard, dc, dc.ChainId)
+	default:
+		return nil, nil, nil, fmt.Errorf("unknown target app: %s", dc.TargetApp)
+	}
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	var source p_dex.SourceDataStore
+	if dc.TargetApp == dex.Terraswap {
+		fallback, err := ts_srcstore.NewFromConfig(dc.NodeConfig, dc.FactoryAddress)
+		if err != nil {
+			return nil, nil, nil, err
+		}
+		source = srcstore.NewCollectorFallback(dc.ChainId, collectorrepo.New(c.Rdb), fallback, logging.Discard)
+	} else {
+		source = srcstore.New(getDexCollectorReadStore(c, dc))
+	}
+
+	return app, source, tokenExceptions, nil
+}
+
+// diagnoseRange replays parsing for matching raw transactions without writing parser state.
+func diagnoseRange(app p_dex.TargetApp, source p_dex.SourceDataStore, tokenExceptions map[string]bool, chainID string, from, to uint64, contract string) (diagnosisReport, error) {
+	report := diagnosisReport{
+		ChainID:  chainID,
+		From:     from,
+		To:       to,
+		Contract: contract,
+		Results:  []diagnosisTxResult{},
+	}
+	for height := from; height <= to; height++ {
+		if err := app.UpdateParsers(tokenExceptions, height); err != nil {
+			return report, fmt.Errorf("update parsers at height %d: %w", height, err)
+		}
+		txs, err := source.GetSourceTxs(height)
+		if err != nil {
+			return report, fmt.Errorf("get source txs at height %d: %w", height, err)
+		}
+		for _, tx := range txs {
+			if !rawTxContainsContract(tx, contract) {
+				continue
+			}
+			result := diagnosisTxResult{
+				Height: height,
+				Hash:   tx.Hash,
+				Sender: tx.Sender,
+			}
+			parsedTxs, err := app.ParseTxs(tx, height)
+			if err != nil {
+				var partial *p_dex.PartialParseQuarantineError
+				if errors.As(err, &partial) {
+					result.ParsedTxs = partial.ParsedTxs
+					result.ParsedTxCount = len(partial.ParsedTxs)
+				}
+				result.Error = err.Error()
+			} else {
+				result.ParsedTxs = parsedTxs
+				result.ParsedTxCount = len(parsedTxs)
+			}
+			report.Results = append(report.Results, result)
+		}
+		if height == math.MaxUint64 {
+			break
+		}
+	}
+	return report, nil
+}
+
+// rawTxContainsContract reports whether a raw transaction directly mentions the target contract.
+func rawTxContainsContract(tx parser.RawTx, contract string) bool {
+	if contract == "" {
+		return false
+	}
+	if strings.Contains(tx.Hash, contract) || strings.Contains(tx.Sender, contract) {
+		return true
+	}
+	for _, log := range tx.LogResults {
+		for _, attr := range log.Attributes {
+			if strings.Contains(attr.Value, contract) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getDexCollectorReadStore mirrors the production parser source selection for collector-backed DEXes.
+func getDexCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) datastore.ReadStore {
+	nodeConf := dc.NodeConfig
+	if nodeConf.GrpcConfig.Host != "" {
+		serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)
+
+		store, err := datastore.New(c, serviceDesc, nil)
+		if err != nil {
+			panic(err)
+		}
+		if nodeConf.FailoverLcdHost != "" {
+			failoverStore, err := datastore.New(
+				c,
+				serviceDesc,
+				datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)),
+			)
+			if err != nil {
+				panic(err)
+			}
+			store = failoverStore
+		}
+
+		return datastore.NewReadStoreWithGrpc(dc.ChainId, store)
+	}
+
+	s3Client, err := s3client.NewClient(c.S3)
+	if err != nil {
+		panic(err)
+	}
+	return datastore.NewReadStore(dc.ChainId, s3Client)
+}
+
+func fail(msg string) {
+	_, _ = fmt.Fprintln(os.Stderr, msg)
+	os.Exit(1)
+}

--- a/cmd/parser/diagnose/main_test.go
+++ b/cmd/parser/diagnose/main_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"testing"
+	"time"
+
+	"github.com/dezswap/cosmwasm-etl/parser"
+	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_rawTxContainsContract(t *testing.T) {
+	tx := parser.RawTx{
+		Hash:   "hash",
+		Sender: "sender",
+		LogResults: eventlog.LogResults{{
+			Type: eventlog.WasmType,
+			Attributes: eventlog.Attributes{
+				{Key: "_contract_address", Value: "pair1"},
+				{Key: "action", Value: "swap"},
+			},
+		}},
+	}
+
+	assert.True(t, rawTxContainsContract(tx, "pair1"))
+	assert.False(t, rawTxContainsContract(tx, "pair2"))
+}
+
+func Test_diagnoseRange_ReplaysOnlyMatchingTransactions(t *testing.T) {
+	target := &diagnoseTargetApp{}
+	source := &diagnoseSourceDataStore{
+		txs: map[uint64]parser.RawTxs{
+			10: {
+				rawTxWithContract("matching-hash", "pair1"),
+				rawTxWithContract("other-hash", "pair2"),
+			},
+		},
+	}
+	tokenExceptions := map[string]bool{"token": true}
+
+	report, err := diagnoseRange(target, source, tokenExceptions, "chain-1", 10, 10, "pair1")
+
+	require.NoError(t, err)
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, "chain-1", report.ChainID)
+	assert.Equal(t, uint64(10), report.From)
+	assert.Equal(t, uint64(10), report.To)
+	assert.Equal(t, "pair1", report.Contract)
+	assert.Equal(t, "matching-hash", report.Results[0].Hash)
+	assert.Equal(t, 1, report.Results[0].ParsedTxCount)
+	assert.Equal(t, []uint64{10}, target.updatedHeights)
+	assert.Equal(t, tokenExceptions, target.tokenExceptions)
+}
+
+type diagnoseTargetApp struct {
+	updatedHeights  []uint64
+	tokenExceptions map[string]bool
+}
+
+func (a *diagnoseTargetApp) ParseTxs(tx parser.RawTx, _ uint64) ([]p_dex.ParsedTx, error) {
+	return []p_dex.ParsedTx{{Hash: tx.Hash, ContractAddr: "pair1", Type: p_dex.Swap}}, nil
+}
+
+func (*diagnoseTargetApp) IsValidationExceptionCandidate(string) bool {
+	return false
+}
+
+func (a *diagnoseTargetApp) UpdateParsers(tokenExceptions map[string]bool, height uint64) error {
+	a.tokenExceptions = tokenExceptions
+	a.updatedHeights = append(a.updatedHeights, height)
+	return nil
+}
+
+type diagnoseSourceDataStore struct {
+	txs map[uint64]parser.RawTxs
+}
+
+func (*diagnoseSourceDataStore) GetPoolInfos(uint64) ([]p_dex.PoolInfo, error) {
+	return nil, nil
+}
+
+func (*diagnoseSourceDataStore) GetSourceSyncedHeight() (uint64, error) {
+	return 0, nil
+}
+
+func (s *diagnoseSourceDataStore) GetSourceTxs(height uint64) (parser.RawTxs, error) {
+	return s.txs[height], nil
+}
+
+func rawTxWithContract(hash, contract string) parser.RawTx {
+	return parser.RawTx{
+		Hash:      hash,
+		Sender:    "sender",
+		Timestamp: time.Unix(1, 0),
+		LogResults: eventlog.LogResults{{
+			Type: eventlog.WasmType,
+			Attributes: eventlog.Attributes{
+				{Key: "_contract_address", Value: contract},
+				{Key: "action", Value: "swap"},
+			},
+		}},
+	}
+}

--- a/cmd/parser/diagnose/main_test.go
+++ b/cmd/parser/diagnose/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -54,6 +55,26 @@ func Test_diagnoseRange_ReplaysOnlyMatchingTransactions(t *testing.T) {
 	assert.Equal(t, tokenExceptions, target.tokenExceptions)
 }
 
+func Test_diagnoseRange_ReturnsPartialReportOnHeightError(t *testing.T) {
+	target := &diagnoseTargetApp{}
+	source := &diagnoseSourceDataStore{
+		txs: map[uint64]parser.RawTxs{
+			10: {rawTxWithContract("height-10", "pair1")},
+		},
+		sourceErrors: map[uint64]error{
+			11: errors.New("collector unavailable"),
+		},
+	}
+
+	report, err := diagnoseRange(target, source, map[string]bool{}, "chain-1", 10, 11, "pair1")
+
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get source txs at height 11")
+	require.Len(t, report.Results, 1)
+	assert.Equal(t, "height-10", report.Results[0].Hash)
+	assert.Equal(t, []uint64{10, 11}, target.updatedHeights)
+}
+
 type diagnoseTargetApp struct {
 	updatedHeights  []uint64
 	tokenExceptions map[string]bool
@@ -74,7 +95,8 @@ func (a *diagnoseTargetApp) UpdateParsers(tokenExceptions map[string]bool, heigh
 }
 
 type diagnoseSourceDataStore struct {
-	txs map[uint64]parser.RawTxs
+	txs          map[uint64]parser.RawTxs
+	sourceErrors map[uint64]error
 }
 
 func (*diagnoseSourceDataStore) GetPoolInfos(uint64) ([]p_dex.PoolInfo, error) {
@@ -86,6 +108,9 @@ func (*diagnoseSourceDataStore) GetSourceSyncedHeight() (uint64, error) {
 }
 
 func (s *diagnoseSourceDataStore) GetSourceTxs(height uint64) (parser.RawTxs, error) {
+	if err := s.sourceErrors[height]; err != nil {
+		return nil, err
+	}
 	return s.txs[height], nil
 }
 

--- a/db/migrations/parser/migration_test.go
+++ b/db/migrations/parser/migration_test.go
@@ -19,13 +19,20 @@ import (
 const batch_size = 100
 
 func Test_ParserMigration(t *testing.T) {
-	c := configs.New()
+	c := configs.NewWithFileName("config.test")
+	assertLocalTestDB(t, c.Rdb)
+
 	faker.MigFakerInit()
 	p_dex.FakerCustomGenerator()
 	dbCon, err := db.OpenGormPostgres(c.Rdb)
 	if err != nil {
 		panic(err)
 	}
+	tx := dbCon.Begin()
+	if tx.Error != nil {
+		panic(tx.Error)
+	}
+	defer tx.Rollback()
 
 	parsedTxs := []schemas.ParsedTx{}
 	poolInfos := []schemas.PoolInfo{}
@@ -65,10 +72,10 @@ func Test_ParserMigration(t *testing.T) {
 	actualPairs := []schemas.Pair{}
 	actualSyncedHeights := []schemas.SyncedHeight{}
 
-	batchInsertAndRead(dbCon, schemas.Pair{}, pairs, &actualPairs, len(pairs))
-	batchInsertAndRead(dbCon, schemas.ParsedTx{}, parsedTxs, &actualParsedTxs, len(parsedTxs))
-	batchInsertAndRead(dbCon, schemas.PoolInfo{}, poolInfos, &actualPoolInfos, len(poolInfos))
-	batchInsertAndRead(dbCon, schemas.SyncedHeight{}, syncedHeights, &actualSyncedHeights, len(syncedHeights))
+	batchInsertAndRead(tx, schemas.Pair{}, pairs, &actualPairs, len(pairs))
+	batchInsertAndRead(tx, schemas.ParsedTx{}, parsedTxs, &actualParsedTxs, len(parsedTxs))
+	batchInsertAndRead(tx, schemas.PoolInfo{}, poolInfos, &actualPoolInfos, len(poolInfos))
+	batchInsertAndRead(tx, schemas.SyncedHeight{}, syncedHeights, &actualSyncedHeights, len(syncedHeights))
 
 	assert := assert.New(t)
 	assert.Len(actualPairs, len(pairs))
@@ -80,6 +87,16 @@ func Test_ParserMigration(t *testing.T) {
 
 type Batchable interface {
 	schemas.Pair | schemas.ParsedTx | schemas.PoolInfo | schemas.SyncedHeight
+}
+
+func assertLocalTestDB(t *testing.T, c configs.RdbConfig) {
+	t.Helper()
+
+	switch c.Host {
+	case "localhost", "127.0.0.1", "::1":
+	default:
+		t.Fatalf("migration tests must use a local test DB, got host=%s database=%s", c.Host, c.Database)
+	}
 }
 
 func batchInsertAndRead[T Batchable](con *gorm.DB, v T, models []T, targets *[]T, limit int) {

--- a/parser/dex/dexwiring/wiring.go
+++ b/parser/dex/dexwiring/wiring.go
@@ -1,0 +1,97 @@
+package dexwiring
+
+import (
+	"fmt"
+
+	"github.com/dezswap/cosmwasm-etl/collector/datastore"
+	collectorrepo "github.com/dezswap/cosmwasm-etl/collector/repo"
+	"github.com/dezswap/cosmwasm-etl/configs"
+	p_dex "github.com/dezswap/cosmwasm-etl/parser/dex"
+	pds "github.com/dezswap/cosmwasm-etl/parser/dex/dezswap"
+	"github.com/dezswap/cosmwasm-etl/parser/dex/srcstore"
+	ts_srcstore "github.com/dezswap/cosmwasm-etl/parser/dex/srcstore/terraswap"
+	psf "github.com/dezswap/cosmwasm-etl/parser/dex/starfleit"
+	pts "github.com/dezswap/cosmwasm-etl/parser/dex/terraswap"
+	"github.com/dezswap/cosmwasm-etl/pkg/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/grpc"
+	"github.com/dezswap/cosmwasm-etl/pkg/httpclient"
+	"github.com/dezswap/cosmwasm-etl/pkg/logging"
+	"github.com/dezswap/cosmwasm-etl/pkg/s3client"
+)
+
+// NewTargetApp builds the configured DEX target parser used by parser commands.
+func NewTargetApp(repo p_dex.PairRepo, logger logging.Logger, c configs.ParserDexConfig) (p_dex.TargetApp, error) {
+	switch c.TargetApp {
+	case dex.Terraswap:
+		return pts.New(repo, logger, c)
+	case dex.Dezswap:
+		return pds.New(repo, logger, c, c.ChainId)
+	case dex.Starfleit:
+		return psf.New(repo, logger, c, c.ChainId)
+	default:
+		return nil, fmt.Errorf("unknown target app: %s", c.TargetApp)
+	}
+}
+
+// NewTargetReadStore builds the collector-backed raw read store required by the configured DEX.
+func NewTargetReadStore(c configs.Config, dc configs.ParserDexConfig) (datastore.ReadStore, error) {
+	switch dc.TargetApp {
+	case dex.Terraswap:
+		return nil, nil
+	case dex.Dezswap, dex.Starfleit:
+		return NewCollectorReadStore(c, dc)
+	default:
+		return nil, fmt.Errorf("unknown target app: %s", dc.TargetApp)
+	}
+}
+
+// NewCollectorReadStore mirrors the production parser source selection for collector-backed DEXes.
+func NewCollectorReadStore(c configs.Config, dc configs.ParserDexConfig) (datastore.ReadStore, error) {
+	nodeConf := dc.NodeConfig
+	if nodeConf.GrpcConfig.Host != "" {
+		serviceDesc := grpc.GetServiceDesc("collector", nodeConf.GrpcConfig)
+
+		store, err := datastore.New(c, serviceDesc, nil)
+		if err != nil {
+			return nil, err
+		}
+		if nodeConf.FailoverLcdHost != "" {
+			failoverStore, err := datastore.New(
+				c,
+				serviceDesc,
+				datastore.NewLcdClient(nodeConf.FailoverLcdHost, httpclient.New(dc.NodeConfig.HttpClientConfig)),
+			)
+			if err != nil {
+				return nil, err
+			}
+			store = failoverStore
+		}
+
+		return datastore.NewReadStoreWithGrpc(dc.ChainId, store), nil
+	}
+
+	s3Client, err := s3client.NewClient(c.S3)
+	if err != nil {
+		return nil, err
+	}
+	return datastore.NewReadStore(dc.ChainId, s3Client), nil
+}
+
+// NewSourceDataStore builds the raw transaction source used by parser commands.
+func NewSourceDataStore(dc configs.ParserDexConfig, rdbc configs.RdbConfig, readStore datastore.ReadStore, logger logging.Logger) (p_dex.SourceDataStore, error) {
+	switch dc.TargetApp {
+	case dex.Terraswap:
+		fallback, err := ts_srcstore.NewFromConfig(dc.NodeConfig, dc.FactoryAddress)
+		if err != nil {
+			return nil, err
+		}
+		return srcstore.NewCollectorFallback(dc.ChainId, collectorrepo.New(rdbc), fallback, logger), nil
+	case dex.Dezswap, dex.Starfleit:
+		if readStore == nil {
+			return nil, fmt.Errorf("collector read store is required for target app: %s", dc.TargetApp)
+		}
+		return srcstore.New(readStore), nil
+	default:
+		return nil, fmt.Errorf("unknown target app: %s", dc.TargetApp)
+	}
+}


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pool validation failures are the first entry point for parser incident diagnosis, but the manual workflow still requires checking raw source data and rerunning parser logic for a narrow height range. This PR adds a dry-run diagnostic command so agents and engineers can replay parser behavior for a target pair without mutating parser state.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Add `parser-diagnose`, a dry-run parser diagnostic command that accepts `from`, `to`, and `contract` inputs.
- Replay matching raw transactions through parser logic without advancing synced height or writing parsed rows.
- Document agent query templates for `parse_quarantine`, `parsed_tx`, `collector_blocks`, and `fcd_tx_log`.
- Add Makefile targets for building the diagnostic command and running collector migration tests.
- Add unit tests for contract filtering and diagnostic replay behavior.

<!--- Add More if you need. -->

## Checklist

- [ ] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic tool to replay DEX parsing over a height range for a specific contract, producing JSON output.
  * Added new build and migration test targets to support the diagnostic and migration workflows.
* **Documentation**
  * Added a README with usage examples, output/log guidance, and SQL snippets for investigating results.
* **Tests**
  * Expanded diagnostic test coverage for contract filtering, partial reporting on height errors, and replay behavior.
  * Improved migration test execution for safer local-only runs and transactional inserts/reads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->