### PR TITLE
fix: use /block instead of /block_results for remote height

### DIFF
--- a/parser/dex/srcstore/terraswap/base_datastore.go
+++ b/parser/dex/srcstore/terraswap/base_datastore.go
@@ -2,6 +2,7 @@ package terraswap
 
 import (
 	"encoding/json"
+	"strconv"
 	"time"
 
 	"github.com/dezswap/cosmwasm-etl/parser"
@@ -39,12 +40,17 @@ func NewBaseStore(rpc rpc.Rpc, client terraswap.QueryClient, cda chainDataAdapte
 
 // GetSourceSyncedHeight implements p_dex.RawDataStore
 func (r *baseRawDataStoreImpl) GetSourceSyncedHeight() (uint64, error) {
-	height, err := r.rpc.RemoteBlockHeight()
+	block, err := r.rpc.Block()
 	if err != nil {
 		return 0, errors.Wrap(err, "baseRawDataStoreImpl.GetSourceSyncedHeight")
 	}
 
-	return height, nil
+	height, err := strconv.ParseInt(block.Result.Block.Header.Height, 10, 64)
+	if err != nil {
+		return 0, errors.Wrap(err, "baseRawDataStoreImpl.GetSourceSyncedHeight")
+	}
+
+	return uint64(height), nil
 }
 
 // GetPoolInfos implements p_dex.RawDataStore

--- a/pkg/terra/rpc/rpc.go
+++ b/pkg/terra/rpc/rpc.go
@@ -3,7 +3,6 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/dezswap/cosmwasm-etl/pkg/util"
 	"io"
 	"net/http"
 	"strconv"
@@ -77,26 +76,14 @@ func (r *rpcImpl) BlockResults(height ...uint64) (*RpcRes[RpcBlockResultRes], er
 
 // RemoteBlockHeight implements Rpc.
 func (r *rpcImpl) RemoteBlockHeight() (uint64, error) {
-	response, err := r.client.Get(fmt.Sprintf("%s/%s", r.baseUrl, rpcBlockResultsPath))
+	res, err := r.Block()
 	if err != nil {
 		return 0, errors.Wrap(err, "rpcImpl.RemoteBlockHeight")
 	}
-	defer response.Body.Close()
 
-	data, _ := io.ReadAll(response.Body)
-
-	var res RpcRes[RpcBlockResultRes]
-	if err := json.Unmarshal(data, &res); err != nil {
-		return 0, errors.Wrapf(
-			err, "rpcImpl.RemoteBlockHeight: failed to unmarshal data, first %d bytes: %s",
-			util.DefaultErrorDataLength, util.TruncateBytes(data, util.DefaultErrorDataLength))
-	}
-
-	height, err := strconv.ParseInt(res.Result.Height, 10, 64)
+	height, err := strconv.ParseInt(res.Result.Block.Header.Height, 10, 64)
 	if err != nil {
-		return 0, errors.Wrapf(
-			err, "rpcImpl.RemoteBlockHeight: failed to parse int, first %d bytes: %s",
-			util.DefaultErrorDataLength, util.TruncateBytes(data, util.DefaultErrorDataLength))
+		return 0, errors.Wrap(err, "rpcImpl.RemoteBlockHeight")
 	}
 	return uint64(height), nil
 }


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The Terra Classic (columbus-5) `/block_results` RPC endpoint on the archive node returns the following error:
```
{"jsonrpc":"2.0","id":-1,"error":{"code":-32603,"message":"Internal error","data":"could not find results for height #29706141"}}
```

`RemoteBlockHeight()` and `GetSourceSyncedHeight()` relied on `/block_results` solely to read the latest block height — a value that is equally available from `/block`, which does not exhibit this problem.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- **`pkg/terra/rpc/rpc.go`**: `RemoteBlockHeight()` now delegates to the existing `Block()` method and parses the height from the block header, removing the dependency on `/block_results`.
- **`parser/dex/srcstore/terraswap/base_datastore.go`**: `GetSourceSyncedHeight()` now calls `Block()` directly instead of going through `RemoteBlockHeight()`.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [ ] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization height reporting by using the current block height consistently.
  * Enhanced reliability when retrieving and parsing blockchain height information.
  * Preserved clear error reporting when block data cannot be retrieved or parsed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->