### PR TITLE
fix: sort arbitrary transfer attribute

### DIFF
--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -99,6 +99,18 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 		}
 		wasmTransferTxs = append(wasmTransferTxs, wtxs...)
 
+		if raw.Type == eventlog.TransferType {
+			// event log messages are not sorted well
+			// bug tx: 8C4CF31E736AAC477F61704ECCBBB5A5ABBAA2A8A12576EFAA9F8546F1F60FE2 (cube_47-5)
+			filter := []string{
+				pdex.TransferRecipientKey, pdex.TransferSenderKey, pdex.TransferAmountKey,
+			}
+			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
+			if err != nil {
+				return nil, errors.Wrapf(err, "dezswap.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
+			}
+			raw.Attributes = *attrs
+		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
 			return nil, errors.Wrapf(err, "dezswap.ParseTxs transfer tx_hash=%s", tx.Hash)

--- a/parser/dex/dezswap/app_test.go
+++ b/parser/dex/dezswap/app_test.go
@@ -493,6 +493,53 @@ func Test_IsValidationExceptionCandidate(t *testing.T) {
 	assert.False(t, app.IsValidationExceptionCandidate(""))
 }
 
+func Test_ParseTxs_SortsTransferAttributesWhenRandomOrder(t *testing.T) {
+	const nativeAsset = "axpla"
+	nativePair := dex.Pair{
+		ContractAddr: pairAddr,
+		LpAddr:       lpAddr,
+		Assets:       []string{nativeAsset, asset2},
+	}
+
+	createPairParser := dex.ParserMock{}
+	repo := dex.RepoMock{}
+	rawStore := dex.RawStoreMock{}
+	createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{}, nil)
+
+	inner := dezswapApp{
+		PairRepo:    &repo,
+		Parsers:     &dex.PairParsers{CreatePairParser: &createPairParser},
+		DexMixin:    dex.DexMixin{},
+		chainId:     chainId,
+		pairs:       map[string]dex.Pair{pairAddr: nativePair},
+		lpPairAddrs: map[string]string{lpAddr: pairAddr},
+	}
+	dexApp := dex.NewDexApp(&inner, &rawStore, &repo, logging.New("test", configs.LogConfig{}), configs.ParserDexConfig{})
+	app := dexApp.(dex.DexParserApp)
+
+	require.NoError(t, app.UpdateParsers(make(map[string]bool), 100))
+
+	var logs eventlog.LogResults
+	require.NoError(t, json.Unmarshal([]byte(randomOrderTransferLogStr), &logs))
+
+	tx := parser.RawTx{Sender: txSender, Hash: txHash, LogResults: logs}
+	txs, err := app.ParseTxs(tx, 100)
+
+	assert.NoError(t, err)
+	assert.Equal(t, []dex.ParsedTx{{
+		Hash:         txHash,
+		Type:         dex.Transfer,
+		Sender:       txSender,
+		ContractAddr: pairAddr,
+		Assets: [2]dex.Asset{
+			{Addr: nativeAsset, Amount: "1000"},
+			{Addr: asset2, Amount: ""},
+		},
+		Meta: map[string]interface{}{"recipient": pairAddr},
+	}}, txs)
+}
+
 var (
 	swapTx = dex.ParsedTx{
 		Hash: txHash, Timestamp: time.Time{},
@@ -522,6 +569,16 @@ var (
 		LpAddr: lpAddr, LpAmount: "1098669138945462355",
 	}
 )
+
+// randomOrderTransferLogStr has transfer event attributes in a random order (sender, amount, recipient)
+// to verify that SortAttributes normalises them before parsing.
+const randomOrderTransferLogStr = `[
+	{"type":"transfer","attributes":[
+		{"key":"sender","value":"` + txSender + `"},
+		{"key":"amount","value":"1000axpla"},
+		{"key":"recipient","value":"` + pairAddr + `"}
+	]}
+]`
 
 // log strings are taken from pkg/dex/dezswap/logfinders_test.go
 const swapLogStr = `[

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -121,7 +121,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			// event log messages are not sorted well
 			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
 			filter := []string{
-				columbusv2.SortedTransferAmountKey, columbusv2.SortedTransferRecipientKey, columbusv2.SortedTransferSenderKey,
+				pdex.TransferAmountKey, pdex.TransferRecipientKey, pdex.TransferSenderKey,
 			}
 			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
 			if err != nil {

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -105,7 +105,7 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 			// event log messages are not sorted well
 			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
 			filter := []string{
-				phoenix.SortedTransferAmountKey, phoenix.SortedTransferRecipientKey, phoenix.SortedTransferSenderKey,
+				pdex.TransferAmountKey, pdex.TransferRecipientKey, pdex.TransferSenderKey,
 			}
 			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
 			if err != nil {

--- a/pkg/dex/dezswap/logfinders.go
+++ b/pkg/dex/dezswap/logfinders.go
@@ -1,6 +1,7 @@
 package dezswap
 
 import (
+	"github.com/dezswap/cosmwasm-etl/pkg/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 )
 
@@ -127,12 +128,12 @@ var withdrawRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleIt
 var wasmTransferRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_contract_address", Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "_contract_address", Filter: nil},
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {
-		return v == string(WasmTransferAction) || v == string(WasmTransferFromAction)
+		return v == dex.WasmTransferAction || v == dex.WasmTransferFromAction
 	}},
 }}
 
 var transferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
-	eventlog.RuleItem{Key: "recipient", Filter: nil},
-	eventlog.RuleItem{Key: "sender", Filter: nil},
-	eventlog.RuleItem{Key: "amount", Filter: nil},
+	eventlog.RuleItem{Key: dex.TransferRecipientKey, Filter: nil},
+	eventlog.RuleItem{Key: dex.TransferSenderKey, Filter: nil},
+	eventlog.RuleItem{Key: dex.TransferAmountKey, Filter: nil},
 }}

--- a/pkg/dex/terraswap/columbusv2/consts.go
+++ b/pkg/dex/terraswap/columbusv2/consts.go
@@ -25,12 +25,6 @@ const (
 )
 
 const (
-	SortedTransferAmountKey    = "amount"
-	SortedTransferRecipientKey = "recipient"
-	SortedTransferSenderKey    = "sender"
-)
-
-const (
 	PairProvideAssetsKey      = "assets"
 	PairProvideSenderKey      = "sender"
 	PairProvideReceiverKey    = "receiver"

--- a/pkg/dex/terraswap/phoenix/consts.go
+++ b/pkg/dex/terraswap/phoenix/consts.go
@@ -25,12 +25,6 @@ const (
 )
 
 const (
-	SortedTransferAmountKey    = "amount"
-	SortedTransferRecipientKey = "recipient"
-	SortedTransferSenderKey    = "sender"
-)
-
-const (
 	PairProvideAssetsKey      = "assets"
 	PairProvideSenderKey      = "sender"
 	PairProvideReceiverKey    = "receiver"


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The CONX chain (testnet) started emitting transfer event attributes in arbitrary order (e.g. sender, amount, recipient instead of recipient, sender, amount). This was already handled in `columbus-5` via eventlog.SortAttributes, and the same fix was applied to dezswap.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Sort tranfer event attribute to have filtered fixed order in dezswap parser
- Remove duplicate transfer keys across dezswap, columbusv2, and phoenix parsers
- Add `Test_ParseTxs_SortsTransferAttributesWhenRandomOrder` to verify dezswap correctly parses a transfer event whose attributes arrive in arbitrary order

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transfer parsing when transaction event attributes appear in an unexpected order.
  * Standardized transfer event handling across supported DEX integrations.
  * Parsing now reports sorting failures instead of producing potentially incorrect results.

* **Tests**
  * Added coverage for unordered transfer attributes, including recipient metadata validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->