### PR TITLE
fix: use /status endpoint for source synced height

### DIFF
--- a/collector/datastore/lcdclient.go
+++ b/collector/datastore/lcdclient.go
@@ -41,7 +41,7 @@ func NewLcdClient(baseUrl string, c httpClient) LcdClient {
 // GetTx only returns TxResponse
 func (c *lcdClientImpl) GetTx(txHash string) (*txtypes.GetTxResponse, error) {
 
-	response, err := http.Get(fmt.Sprintf("%s/%s/%s", c.baseUrl, lcdTxQueryPath, txHash))
+	response, err := c.Get(fmt.Sprintf("%s/%s/%s", c.baseUrl, lcdTxQueryPath, txHash))
 	if err != nil {
 		return nil, errors.Wrap(err, "lcdClientImpl.GetTx")
 	}
@@ -58,7 +58,10 @@ func (c *lcdClientImpl) GetTx(txHash string) (*txtypes.GetTxResponse, error) {
 		} `protobuf:"bytes,2,opt,name=tx_response,json=txResponse,proto3" json:"tx_response,omitempty"`
 	}
 
-	data, _ := io.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "lcdClientImpl.GetTx")
+	}
 
 	var res txRes
 	if err := json.Unmarshal(data, &res); err != nil {
@@ -93,7 +96,7 @@ func (c *lcdClientImpl) GetTx(txHash string) (*txtypes.GetTxResponse, error) {
 // GetBlockWithTxs implements lcdClient.
 func (c *lcdClientImpl) GetBlockWithTxs(height int64) (*txtypes.GetBlockWithTxsResponse, error) {
 
-	response, err := http.Get(fmt.Sprintf("%s/%s/%d", c.baseUrl, lcdBlockQueryPath, height))
+	response, err := c.Get(fmt.Sprintf("%s/%s/%d", c.baseUrl, lcdBlockQueryPath, height))
 	if err != nil {
 		return nil, errors.Wrap(err, "lcdClientImpl.GetBlockWithTxs")
 	}
@@ -119,7 +122,10 @@ func (c *lcdClientImpl) GetBlockWithTxs(height int64) (*txtypes.GetBlockWithTxsR
 		} `json:"block,omitempty"`
 	}
 
-	data, _ := io.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "lcdClientImpl.GetBlockWithTxs")
+	}
 	var res blockRes
 	if err := json.Unmarshal(data, &res); err != nil {
 		return nil, errors.Wrap(err, "lcdClientImpl.GetBlockWithTxs")

--- a/collector/datastore/lcdclient_test.go
+++ b/collector/datastore/lcdclient_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"errors"
 	"time"
 
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
@@ -40,6 +41,86 @@ func Test_lcdClientImpl_GetBlock(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+
+type errReader struct{}
+
+func (e *errReader) Read(p []byte) (int, error) { return 0, errors.New("read error") }
+func (e *errReader) Close() error               { return nil }
+
+type mockHttp struct {
+	resp *http.Response
+	err  error
+}
+
+func (m *mockHttp) Get(url string) (*http.Response, error) {
+	return m.resp, m.err
+}
+
+const testTxData = `{"tx_response":{"txhash":"ABCDEF","height":"100","gas_wanted":"200000","gas_used":"150000"}}`
+
+func Test_lcdClientImpl_GetTx(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(testTxData))
+	}))
+	defer mockServer.Close()
+
+	c := NewLcdClient(mockServer.URL, &http.Client{})
+	res, err := c.GetTx("ABCDEF")
+	assert.NoError(t, err)
+	assert.NotNil(t, res)
+	assert.EqualValues(t, 100, res.TxResponse.Height)
+	assert.EqualValues(t, 200000, res.TxResponse.GasWanted)
+	assert.EqualValues(t, 150000, res.TxResponse.GasUsed)
+}
+
+func Test_lcdClientImpl_GetTx_HttpError(t *testing.T) {
+	c := &lcdClientImpl{"http://localhost", &mockHttp{err: errors.New("connection refused")}}
+	_, err := c.GetTx("ABCDEF")
+	assert.Error(t, err)
+}
+
+func Test_lcdClientImpl_GetTx_ReadBodyError(t *testing.T) {
+	resp := &http.Response{Body: &errReader{}}
+	c := &lcdClientImpl{"http://localhost", &mockHttp{resp: resp}}
+	_, err := c.GetTx("ABCDEF")
+	assert.Error(t, err)
+}
+
+func Test_lcdClientImpl_GetTx_InvalidJSON(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer mockServer.Close()
+
+	c := NewLcdClient(mockServer.URL, &http.Client{})
+	_, err := c.GetTx("ABCDEF")
+	assert.Error(t, err)
+}
+
+func Test_lcdClientImpl_GetBlock_HttpError(t *testing.T) {
+	c := &lcdClientImpl{"http://localhost", &mockHttp{err: errors.New("connection refused")}}
+	_, err := c.GetBlockWithTxs(100)
+	assert.Error(t, err)
+}
+
+func Test_lcdClientImpl_GetBlock_ReadBodyError(t *testing.T) {
+	resp := &http.Response{Body: &errReader{}}
+	c := &lcdClientImpl{"http://localhost", &mockHttp{resp: resp}}
+	_, err := c.GetBlockWithTxs(100)
+	assert.Error(t, err)
+}
+
+func Test_lcdClientImpl_GetBlock_InvalidJSON(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("not json"))
+	}))
+	defer mockServer.Close()
+
+	c := NewLcdClient(mockServer.URL, &http.Client{})
+	_, err := c.GetBlockWithTxs(100)
+	assert.Error(t, err)
 }
 
 // GetTx implements lcdClient

--- a/parser/dex/srcstore/terraswap/base_datastore.go
+++ b/parser/dex/srcstore/terraswap/base_datastore.go
@@ -40,12 +40,12 @@ func NewBaseStore(rpc rpc.Rpc, client terraswap.QueryClient, cda chainDataAdapte
 
 // GetSourceSyncedHeight implements p_dex.RawDataStore
 func (r *baseRawDataStoreImpl) GetSourceSyncedHeight() (uint64, error) {
-	block, err := r.rpc.Block()
+	res, err := r.rpc.Status()
 	if err != nil {
 		return 0, errors.Wrap(err, "baseRawDataStoreImpl.GetSourceSyncedHeight")
 	}
 
-	height, err := strconv.ParseInt(block.Result.Block.Header.Height, 10, 64)
+	height, err := strconv.ParseInt(res.Result.SyncInfo.LatestBlockHeight, 10, 64)
 	if err != nil {
 		return 0, errors.Wrap(err, "baseRawDataStoreImpl.GetSourceSyncedHeight")
 	}

--- a/pkg/terra/rpc/dto.go
+++ b/pkg/terra/rpc/dto.go
@@ -52,3 +52,9 @@ type RpcAttributeRes struct {
 	Key   string `json:"key"`
 	Value string `json:"value"`
 }
+
+type RpcStatusRes struct {
+	SyncInfo struct {
+		LatestBlockHeight string `json:"latest_block_height"`
+	} `json:"sync_info"`
+}

--- a/pkg/terra/rpc/rpc.go
+++ b/pkg/terra/rpc/rpc.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 
 	"github.com/pkg/errors"
 )
@@ -13,10 +12,11 @@ import (
 const (
 	rpcBlockPath        = "block"
 	rpcBlockResultsPath = "block_results"
+	rpcStatusPath       = "status"
 )
 
 type Rpc interface {
-	RemoteBlockHeight() (uint64, error)
+	Status() (*RpcRes[RpcStatusRes], error)
 	Block(height ...uint64) (*RpcRes[RpcBlockRes], error)
 	BlockResults(height ...uint64) (*RpcRes[RpcBlockResultRes], error)
 }
@@ -42,7 +42,10 @@ func (r *rpcImpl) Block(height ...uint64) (*RpcRes[RpcBlockRes], error) {
 	}
 	defer response.Body.Close()
 
-	data, _ := io.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "rpcImpl.Block")
+	}
 
 	var res RpcRes[RpcBlockRes]
 	if err := json.Unmarshal(data, &res); err != nil {
@@ -64,7 +67,10 @@ func (r *rpcImpl) BlockResults(height ...uint64) (*RpcRes[RpcBlockResultRes], er
 	}
 	defer response.Body.Close()
 
-	data, _ := io.ReadAll(response.Body)
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "rpcImpl.BlockResults")
+	}
 
 	var res RpcRes[RpcBlockResultRes]
 	if err := json.Unmarshal(data, &res); err != nil {
@@ -74,16 +80,24 @@ func (r *rpcImpl) BlockResults(height ...uint64) (*RpcRes[RpcBlockResultRes], er
 	return &res, nil
 }
 
-// RemoteBlockHeight implements Rpc.
-func (r *rpcImpl) RemoteBlockHeight() (uint64, error) {
-	res, err := r.Block()
+// Status implements Rpc.
+func (r *rpcImpl) Status() (*RpcRes[RpcStatusRes], error) {
+	url := fmt.Sprintf("%s/%s", r.baseUrl, rpcStatusPath)
+	response, err := r.client.Get(url)
 	if err != nil {
-		return 0, errors.Wrap(err, "rpcImpl.RemoteBlockHeight")
+		return nil, errors.Wrap(err, "rpcImpl.Status")
+	}
+	defer response.Body.Close()
+
+	data, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, errors.Wrap(err, "rpcImpl.Status")
 	}
 
-	height, err := strconv.ParseInt(res.Result.Block.Header.Height, 10, 64)
-	if err != nil {
-		return 0, errors.Wrap(err, "rpcImpl.RemoteBlockHeight")
+	var res RpcRes[RpcStatusRes]
+	if err := json.Unmarshal(data, &res); err != nil {
+		return nil, errors.Wrap(err, "rpcImpl.Status")
 	}
-	return uint64(height), nil
+
+	return &res, nil
 }

--- a/pkg/terra/rpc/rpc.go
+++ b/pkg/terra/rpc/rpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 )
@@ -13,6 +14,8 @@ const (
 	rpcBlockPath        = "block"
 	rpcBlockResultsPath = "block_results"
 	rpcStatusPath       = "status"
+
+	defaultRpcTimeout = 30 * time.Second
 )
 
 type Rpc interface {
@@ -27,6 +30,9 @@ type rpcImpl struct {
 }
 
 func New(baseUrl string, client *http.Client) Rpc {
+	if client.Timeout == 0 {
+		client.Timeout = defaultRpcTimeout
+	}
 	return &rpcImpl{baseUrl, client}
 }
 


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The parser was using the `/block` or `/block_results` RPC endpoint to determine the source synced height, which fetches full block data unnecessarily.

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Replace `/block` with `/status` RPC endpoint for fetching the latest synced block height. The `/status` endpoint is purpose-built for node sync info and is lighter than fetching a full block.                                                                                                     
- Add `Status()` to the `Rpc` interface, replacing the removed `RemoteBlockHeight()`.                                                               
- Fix `lcdclient.go` to use the injected `httpClient` instead of the package-level `http.Get`.                                                      
- Handle `io.ReadAll` errors that were previously ignored across `rpc.go` and `lcdclient.go`.                                                       
- Add tests for `GetTx` and `GetBlockWithTxs` covering HTTP error, body read error, and invalid JSON cases.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction, block, and RPC data retrieval reliability by detecting response-body and invalid-data errors.
  * Updated synchronization height retrieval to use the latest status information for more accurate results.
* **Testing**
  * Expanded coverage for successful retrievals, HTTP failures, response-body errors, and invalid responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->