### PR TITLE
refactor(parser): unify transfer attribute sorting across DEX parsers

### DIFF
--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
-	pdex "github.com/dezswap/cosmwasm-etl/pkg/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/sirupsen/logrus"
@@ -83,27 +82,6 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 		validationSignal:     make(chan struct{}, 1),
 		quarantineRetryMode:  retryMode,
 	}
-}
-
-// ParseTxs normalizes native transfer attributes once for every DEX target app.
-func (app *dexApp) ParseTxs(tx parser.RawTx, height uint64) ([]ParsedTx, error) {
-	for i := range tx.LogResults {
-		if tx.LogResults[i].Type != eventlog.TransferType {
-			continue
-		}
-
-		attrs, err := eventlog.SortAttributes(tx.LogResults[i].Attributes, []string{
-			pdex.TransferAmountKey,
-			pdex.TransferRecipientKey,
-			pdex.TransferSenderKey,
-		})
-		if err != nil {
-			return nil, fmt.Errorf("dex.ParseTxs sort_transfer_attrs tx_hash=%s: %w", tx.Hash, err)
-		}
-		tx.LogResults[i].Attributes = *attrs
-	}
-
-	return app.TargetApp.ParseTxs(tx, height)
 }
 
 func (app *dexApp) Run() error {

--- a/parser/dex/dex.go
+++ b/parser/dex/dex.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
+	pdex "github.com/dezswap/cosmwasm-etl/pkg/dex"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
 	"github.com/sirupsen/logrus"
@@ -82,6 +83,27 @@ func NewDexApp(app TargetApp, srcStore SourceDataStore, repo Repo, logger loggin
 		validationSignal:     make(chan struct{}, 1),
 		quarantineRetryMode:  retryMode,
 	}
+}
+
+// ParseTxs normalizes native transfer attributes once for every DEX target app.
+func (app *dexApp) ParseTxs(tx parser.RawTx, height uint64) ([]ParsedTx, error) {
+	for i := range tx.LogResults {
+		if tx.LogResults[i].Type != eventlog.TransferType {
+			continue
+		}
+
+		attrs, err := eventlog.SortAttributes(tx.LogResults[i].Attributes, []string{
+			pdex.TransferAmountKey,
+			pdex.TransferRecipientKey,
+			pdex.TransferSenderKey,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("dex.ParseTxs sort_transfer_attrs tx_hash=%s: %w", tx.Hash, err)
+		}
+		tx.LogResults[i].Attributes = *attrs
+	}
+
+	return app.TargetApp.ParseTxs(tx, height)
 }
 
 func (app *dexApp) Run() error {

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -35,48 +35,6 @@ func (*quarantineTargetApp) UpdateParsers(map[string]bool, uint64) error {
 	return nil
 }
 
-func TestDexAppParseTxsNormalizesTransferAttributes(t *testing.T) {
-	var received parser.RawTx
-	target := &quarantineTargetApp{parse: func(tx parser.RawTx, _ uint64) ([]ParsedTx, error) {
-		received = tx
-		return []ParsedTx{}, nil
-	}}
-	app := &dexApp{TargetApp: target}
-
-	nonTransferAttrs := eventlog.Attributes{
-		{Key: "action", Value: "send"},
-		{Key: "sender", Value: "message-sender"},
-	}
-	tx := parser.RawTx{
-		Hash: "hash",
-		LogResults: eventlog.LogResults{
-			{Type: eventlog.Message, Attributes: nonTransferAttrs},
-			{
-				Type: eventlog.TransferType,
-				Attributes: eventlog.Attributes{
-					{Key: "sender", Value: "sender-1", MsgIndex: 1},
-					{Key: "ignored", Value: "metadata", MsgIndex: 1},
-					{Key: "recipient", Value: "recipient-1", MsgIndex: 1},
-					{Key: "amount", Value: "10ucoin", MsgIndex: 1},
-					{Key: "recipient", Value: "recipient-2", MsgIndex: 2},
-					{Key: "amount", Value: "20ucoin", MsgIndex: 2},
-				},
-			},
-		},
-	}
-
-	_, err := app.ParseTxs(tx, 100)
-	require.NoError(t, err)
-	require.Equal(t, nonTransferAttrs, received.LogResults[0].Attributes)
-	require.Equal(t, eventlog.Attributes{
-		{Key: "amount", Value: "10ucoin", MsgIndex: 1},
-		{Key: "recipient", Value: "recipient-1", MsgIndex: 1},
-		{Key: "sender", Value: "sender-1", MsgIndex: 1},
-		{Key: "amount", Value: "20ucoin", MsgIndex: 2},
-		{Key: "recipient", Value: "recipient-2", MsgIndex: 2},
-	}, received.LogResults[1].Attributes)
-}
-
 // insert implements parser
 func Test_insert(t *testing.T) {
 	const (

--- a/parser/dex/dex_test.go
+++ b/parser/dex/dex_test.go
@@ -35,6 +35,48 @@ func (*quarantineTargetApp) UpdateParsers(map[string]bool, uint64) error {
 	return nil
 }
 
+func TestDexAppParseTxsNormalizesTransferAttributes(t *testing.T) {
+	var received parser.RawTx
+	target := &quarantineTargetApp{parse: func(tx parser.RawTx, _ uint64) ([]ParsedTx, error) {
+		received = tx
+		return []ParsedTx{}, nil
+	}}
+	app := &dexApp{TargetApp: target}
+
+	nonTransferAttrs := eventlog.Attributes{
+		{Key: "action", Value: "send"},
+		{Key: "sender", Value: "message-sender"},
+	}
+	tx := parser.RawTx{
+		Hash: "hash",
+		LogResults: eventlog.LogResults{
+			{Type: eventlog.Message, Attributes: nonTransferAttrs},
+			{
+				Type: eventlog.TransferType,
+				Attributes: eventlog.Attributes{
+					{Key: "sender", Value: "sender-1", MsgIndex: 1},
+					{Key: "ignored", Value: "metadata", MsgIndex: 1},
+					{Key: "recipient", Value: "recipient-1", MsgIndex: 1},
+					{Key: "amount", Value: "10ucoin", MsgIndex: 1},
+					{Key: "recipient", Value: "recipient-2", MsgIndex: 2},
+					{Key: "amount", Value: "20ucoin", MsgIndex: 2},
+				},
+			},
+		},
+	}
+
+	_, err := app.ParseTxs(tx, 100)
+	require.NoError(t, err)
+	require.Equal(t, nonTransferAttrs, received.LogResults[0].Attributes)
+	require.Equal(t, eventlog.Attributes{
+		{Key: "amount", Value: "10ucoin", MsgIndex: 1},
+		{Key: "recipient", Value: "recipient-1", MsgIndex: 1},
+		{Key: "sender", Value: "sender-1", MsgIndex: 1},
+		{Key: "amount", Value: "20ucoin", MsgIndex: 2},
+		{Key: "recipient", Value: "recipient-2", MsgIndex: 2},
+	}, received.LogResults[1].Attributes)
+}
+
 // insert implements parser
 func Test_insert(t *testing.T) {
 	const (

--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -99,7 +99,16 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 		}
 		wasmTransferTxs = append(wasmTransferTxs, wtxs...)
 
-		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if raw.Type == eventlog.TransferType {
+			// event log messages are not sorted well
+			// bug tx: 8C4CF31E736AAC477F61704ECCBBB5A5ABBAA2A8A12576EFAA9F8546F1F60FE2 (cube_47-5)
+			sorted, err := pdex.NormalizeTransferAttrs(raw.Attributes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "dezswap.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
+			}
+			raw.Attributes = sorted
+		}
+		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "dezswap.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}

--- a/parser/dex/dezswap/app.go
+++ b/parser/dex/dezswap/app.go
@@ -99,18 +99,6 @@ func (p *dezswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx, e
 		}
 		wasmTransferTxs = append(wasmTransferTxs, wtxs...)
 
-		if raw.Type == eventlog.TransferType {
-			// event log messages are not sorted well
-			// bug tx: 8C4CF31E736AAC477F61704ECCBBB5A5ABBAA2A8A12576EFAA9F8546F1F60FE2 (cube_47-5)
-			filter := []string{
-				pdex.TransferRecipientKey, pdex.TransferSenderKey, pdex.TransferAmountKey,
-			}
-			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
-			if err != nil {
-				return nil, errors.Wrapf(err, "dezswap.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
-			}
-			raw.Attributes = *attrs
-		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
 			return nil, errors.Wrapf(err, "dezswap.ParseTxs transfer tx_hash=%s", tx.Hash)
@@ -190,7 +178,7 @@ func (p *dezswapApp) UpdateParsers(tokenExceptions map[string]bool, height uint6
 
 	// transfer parser
 	{
-		transferRule, err := ds.CreateTransferRuleFinder()
+		transferRule, err := pdex.CreateTransferRuleFinder(nil)
 		if err != nil {
 			return errors.Wrap(err, "updateParsers")
 		}

--- a/parser/dex/dezswap/mappers.go
+++ b/parser/dex/dezswap/mappers.go
@@ -144,6 +144,9 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
 	from := matchMap[pdex.TransferSenderKey].Value
+	if from == "" {
+		from = dex.TransferFallbackSender(optionals...)
+	}
 	to := matchMap[pdex.TransferRecipientKey].Value
 
 	pair, fromPair, err := m.mixin.pairBy(m.pairSet, from, to)

--- a/parser/dex/dezswap/mappers.go
+++ b/parser/dex/dezswap/mappers.go
@@ -134,8 +134,17 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 	if err := m.mixin.CheckResult(res, ds.TransferMatchedLen); err != nil {
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
-	from := res[ds.TransferSenderIdx].Value
-	to := res[ds.TransferRecipientIdx].Value
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.TransferSenderKey,
+		pdex.TransferRecipientKey,
+		pdex.TransferAmountKey,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
+	}
+	from := matchMap[pdex.TransferSenderKey].Value
+	to := matchMap[pdex.TransferRecipientKey].Value
 
 	pair, fromPair, err := m.mixin.pairBy(m.pairSet, from, to)
 	if err != nil {
@@ -150,7 +159,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		{Addr: pair.Assets[0]},
 		{Addr: pair.Assets[1]},
 	}
-	amountValue := res[ds.TransferAmountIdx].Value
+	amountValue := matchMap[pdex.TransferAmountKey].Value
 	if amountValue == "" {
 		return nil, errors.New("empty amount")
 	}
@@ -176,7 +185,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 
 	return []*dex.ParsedTx{{
 		Type:         dex.Transfer,
-		Sender:       res[ds.TransferSenderIdx].Value,
+		Sender:       from,
 		ContractAddr: pair.ContractAddr,
 		Assets:       assets,
 		LpAddr:       "",

--- a/parser/dex/dezswap/mappers_test.go
+++ b/parser/dex/dezswap/mappers_test.go
@@ -151,6 +151,34 @@ func Test_TransferMapper(t *testing.T) {
 	}
 }
 
+// Test_TransferMapper_OptionalSender covers native transfer events that omit
+// the "sender" attribute. This happens for MsgMultiSend: the bank module emits
+// one "transfer" event per output (recipient+amount only, no sender, since a
+// multisend can have multiple inputs). The mapper must not error on the
+// missing attribute; it falls back to the tx-level sender when the caller
+// supplies a non-empty one via optionals, and otherwise leaves ParsedTx.Sender
+// empty.
+func Test_TransferMapper_OptionalSender(t *testing.T) {
+	pair := dex.Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
+	pairSet := map[string]dex.Pair{pair.ContractAddr: pair}
+	m := &transferMapper{pairSet: pairSet}
+
+	res := el.MatchedResult{
+		{Key: "amount", Value: "1000Asset1"},
+		{Key: "recipient", Value: pair.ContractAddr},
+	}
+
+	txs, err := m.MatchedToParsedTx(res, "tx-signer")
+	assert.NoError(t, err)
+	assert.Len(t, txs, 1)
+	assert.Equal(t, "tx-signer", txs[0].Sender)
+
+	txs, err = m.MatchedToParsedTx(res)
+	assert.NoError(t, err)
+	assert.Len(t, txs, 1)
+	assert.Equal(t, "", txs[0].Sender)
+}
+
 func Test_CreatePairMapper(t *testing.T) {
 	const factoryAddr = "xpla1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjqxl5qul"
 

--- a/parser/dex/mapper.go
+++ b/parser/dex/mapper.go
@@ -166,7 +166,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 
 	sender, receiver := matchMap[pdex.TransferSenderKey].Value, matchMap[pdex.TransferRecipientKey].Value
 	if sender == "" {
-		sender = transferFallbackSender(optionals...)
+		sender = TransferFallbackSender(optionals...)
 	}
 	fp, fromPair := m.pairSet[sender]
 	tp, toPair := m.pairSet[receiver]
@@ -198,8 +198,11 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 	return txs, nil
 }
 
-// transferFallbackSender returns the first non-empty string optional as the transfer sender fallback.
-func transferFallbackSender(optionals ...interface{}) string {
+// TransferFallbackSender returns the first non-empty string optional as the transfer sender fallback.
+// A MsgMultiSend tx emits one "transfer" event per output without a per-output sender (a multisend
+// can have multiple inputs, so no single sender applies), so callers pass the tx-level sender
+// (e.g. tx.Sender) as a fallback here instead of leaving ParsedTx.Sender empty.
+func TransferFallbackSender(optionals ...interface{}) string {
 	for _, optional := range optionals {
 		sender, ok := optional.(string)
 		if ok && sender != "" {

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -4,6 +4,7 @@ import (
 	"github.com/dezswap/cosmwasm-etl/configs"
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	pdex "github.com/dezswap/cosmwasm-etl/pkg/dex"
 	sf "github.com/dezswap/cosmwasm-etl/pkg/dex/starfleit"
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/dezswap/cosmwasm-etl/pkg/logging"
@@ -164,7 +165,7 @@ func (p *starfleitApp) UpdateParsers(tokenExceptions map[string]bool, height uin
 		},
 	)
 
-	transferRule, err := sf.CreateTransferRuleFinder()
+	transferRule, err := pdex.CreateTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}

--- a/parser/dex/starfleit/app.go
+++ b/parser/dex/starfleit/app.go
@@ -100,7 +100,14 @@ func (p *starfleitApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
-		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if raw.Type == eventlog.TransferType {
+			sorted, err := pdex.NormalizeTransferAttrs(raw.Attributes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "starfleit.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
+			}
+			raw.Attributes = sorted
+		}
+		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "starfleit.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}

--- a/parser/dex/starfleit/app_test.go
+++ b/parser/dex/starfleit/app_test.go
@@ -1,12 +1,15 @@
 package starfleit
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/dezswap/cosmwasm-etl/parser"
 	"github.com/dezswap/cosmwasm-etl/parser/dex"
+	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_ParseTxs_CreatePairUpdatesPairState(t *testing.T) {
@@ -58,4 +61,53 @@ func Test_ParseTxs_CreatePairUpdatesPairState(t *testing.T) {
 		Assets:       []string{asset0Addr, asset1Addr},
 	}, app.pairs[pairAddr])
 	assert.Equal(t, pairAddr, app.lpPairAddrs[lpAddr])
+}
+
+func Test_ParseTxs_SortsTransferAttributesWhenRandomOrder(t *testing.T) {
+	const (
+		txHash   = "hash"
+		txSender = "sender"
+		pairAddr = "pair"
+		asset0   = "asset0"
+		asset1   = "asset1"
+	)
+
+	createPairParser := dex.ParserMock{}
+	repo := dex.RepoMock{}
+	createPairParser.On("parse", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Return([]*dex.ParsedTx{}, nil)
+
+	app := starfleitApp{
+		PairRepo:    &repo,
+		Parsers:     &dex.PairParsers{CreatePairParser: &createPairParser},
+		DexMixin:    dex.DexMixin{},
+		chainId:     "dorado-1",
+		pairs:       map[string]dex.Pair{pairAddr: {ContractAddr: pairAddr, Assets: []string{asset0, asset1}}},
+		lpPairAddrs: map[string]string{},
+	}
+	require.NoError(t, app.UpdateParsers(map[string]bool{}, 100))
+
+	// attributes are in a random order (sender, amount, recipient) to verify
+	// NormalizeTransferAttrs sorts them before matching.
+	var logs eventlog.LogResults
+	require.NoError(t, json.Unmarshal([]byte(`[
+		{"type":"transfer","attributes":[
+			{"key":"sender","value":"`+txSender+`"},
+			{"key":"amount","value":"1000`+asset0+`"},
+			{"key":"recipient","value":"`+pairAddr+`"}
+		]}
+	]`), &logs))
+
+	tx := parser.RawTx{Sender: txSender, Hash: txHash, LogResults: logs}
+	txs, err := app.ParseTxs(tx, 100)
+
+	require.NoError(t, err)
+	require.Equal(t, []dex.ParsedTx{{
+		Hash:         txHash,
+		Type:         dex.Transfer,
+		Sender:       txSender,
+		ContractAddr: pairAddr,
+		Assets:       [2]dex.Asset{{Addr: asset0, Amount: "1000"}, {Addr: asset1, Amount: ""}},
+		Meta:         map[string]interface{}{"recipient": pairAddr},
+	}}, txs)
 }

--- a/parser/dex/starfleit/mappers.go
+++ b/parser/dex/starfleit/mappers.go
@@ -144,6 +144,9 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
 	from := matchMap[pdex.TransferSenderKey].Value
+	if from == "" {
+		from = dex.TransferFallbackSender(optionals...)
+	}
 	to := matchMap[pdex.TransferRecipientKey].Value
 
 	pair, fromPair, err := m.mixin.pairBy(m.pairSet, from, to)

--- a/parser/dex/starfleit/mappers.go
+++ b/parser/dex/starfleit/mappers.go
@@ -134,8 +134,17 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		}
 		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
 	}
-	from := res[sf.TransferSenderIdx].Value
-	to := res[sf.TransferRecipientIdx].Value
+	matchMap, err := eventlog.ResultToItemMapForKeys(
+		res,
+		pdex.TransferSenderKey,
+		pdex.TransferRecipientKey,
+		pdex.TransferAmountKey,
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "transferMapper.MatchedToParsedTx")
+	}
+	from := matchMap[pdex.TransferSenderKey].Value
+	to := matchMap[pdex.TransferRecipientKey].Value
 
 	pair, fromPair, err := m.mixin.pairBy(m.pairSet, from, to)
 	if err != nil {
@@ -150,7 +159,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 		{Addr: pair.Assets[0]},
 		{Addr: pair.Assets[1]},
 	}
-	amountStrs := strings.Split(res[sf.TransferAmountIdx].Value, ",")
+	amountStrs := strings.Split(matchMap[pdex.TransferAmountKey].Value, ",")
 	if len(amountStrs) == 0 {
 		return nil, errors.New("empty amount or wrong format(amounts separated by ,)")
 	}
@@ -172,7 +181,7 @@ func (m *transferMapper) MatchedToParsedTx(res eventlog.MatchedResult, optionals
 
 	return []*dex.ParsedTx{{
 		Type:         dex.Transfer,
-		Sender:       res[sf.TransferSenderIdx].Value,
+		Sender:       from,
 		ContractAddr: pair.ContractAddr,
 		Assets:       assets,
 		LpAddr:       "",

--- a/parser/dex/starfleit/mappers_test.go
+++ b/parser/dex/starfleit/mappers_test.go
@@ -235,6 +235,34 @@ func Test_TransferMapper(t *testing.T) {
 	}
 }
 
+// Test_TransferMapper_OptionalSender covers native transfer events that omit
+// the "sender" attribute. This happens for MsgMultiSend: the bank module emits
+// one "transfer" event per output (recipient+amount only, no sender, since a
+// multisend can have multiple inputs). The mapper must not error on the
+// missing attribute; it falls back to the tx-level sender when the caller
+// supplies a non-empty one via optionals, and otherwise leaves ParsedTx.Sender
+// empty.
+func Test_TransferMapper_OptionalSender(t *testing.T) {
+	pair := dex.Pair{ContractAddr: "Pair", LpAddr: "LiquidityToken", Assets: []string{"Asset1", "Asset2"}}
+	pairSet := map[string]dex.Pair{pair.ContractAddr: pair}
+	m := &transferMapper{pairSet: pairSet}
+
+	res := el.MatchedResult{
+		{Key: "amount", Value: "1000Asset1"},
+		{Key: "recipient", Value: pair.ContractAddr},
+	}
+
+	txs, err := m.MatchedToParsedTx(res, "tx-signer")
+	assert.NoError(t, err)
+	assert.Len(t, txs, 1)
+	assert.Equal(t, "tx-signer", txs[0].Sender)
+
+	txs, err = m.MatchedToParsedTx(res)
+	assert.NoError(t, err)
+	assert.Len(t, txs, 1)
+	assert.Equal(t, "", txs[0].Sender)
+}
+
 func Test_CreatePairMapper(t *testing.T) {
 	const factoryAddr = "xpla1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjqxl5qul"
 

--- a/parser/dex/terraswap/columbusv1/app.go
+++ b/parser/dex/terraswap/columbusv1/app.go
@@ -86,7 +86,14 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]p_dex.ParsedT
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
-		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if raw.Type == eventlog.TransferType {
+			sorted, err := dex.NormalizeTransferAttrs(raw.Attributes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "columbusv1.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
+			}
+			raw.Attributes = sorted
+		}
+		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, p_dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "columbusv1.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}

--- a/parser/dex/terraswap/columbusv1/app.go
+++ b/parser/dex/terraswap/columbusv1/app.go
@@ -136,7 +136,7 @@ func (p *terraswapApp) UpdateParsers(tokenExceptions map[string]bool, height uin
 		),
 	)
 
-	transferRule, err := cv1.CreateTransferRuleFinder(nil)
+	transferRule, err := dex.CreateTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "createParsers")
 	}

--- a/parser/dex/terraswap/columbusv1/app_test.go
+++ b/parser/dex/terraswap/columbusv1/app_test.go
@@ -94,6 +94,19 @@ func Test_parseTxs(t *testing.T) {
 		{[]string{swapLogStr, wasmTransferLogStr, transferLogStr}, 1, 0, []dex.ParsedTx{swapTx, transferTx}, ""},
 		{nil, 0, 0, []dex.ParsedTx{}, ""},
 		{nil, 3, 1, []dex.ParsedTx{}, ""},
+		// MsgMultiSend outputs emit "transfer" events without a "sender" attribute
+		// (a multisend can have multiple inputs); must fall back to the tx-level sender.
+		{[]string{transferLogStrWithoutSender}, 0, 0, []dex.ParsedTx{
+			{
+				Hash:         hash,
+				Timestamp:    time.Time{},
+				Type:         dex.Transfer,
+				Sender:       sender,
+				ContractAddr: "PAIR_ADDR",
+				Assets:       [2]dex.Asset{{Addr: "Asset0", Amount: "1000"}, {Addr: "Asset1", Amount: ""}},
+				Meta:         make(map[string]interface{}),
+			},
+		}, ""},
 	}
 
 	for idx, tc := range tcs {
@@ -145,5 +158,11 @@ const (
 	{"key":"to","value":"A"},{"key":"amount","value":"12418119"},{"key":"contract_address","value":"PAIR_ADDR"},{"key":"action","value":"withdraw_liquidity"},{"key":"withdrawn_share","value":"1000"},{"key":"refund_assets","value":"1000Asset0, 1000Asset1"},{"key":"contract_address","value":"asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"A"},{"key":"to","value":"terra1cupj7d70jrtjxqhpr6s3qq68t8ky4smcjvccm4"},{"key":"amount","value":"24999998"},{"key":"contract_address","value":"terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7"},{"key":"action","value":"burn"},{"key":"from","value":"A"},{"key":"amount","value":"12418119"}]}]`
 	wasmTransferLogStr = `[{"type":"from_contract","attributes":[{"key":"contract_address","value":"Asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"sender"},
 	{"key":"to","value":"PAIR_ADDR"},{"key":"amount","value":"1000"}]}]`
+	// transferLogStr attributes are deliberately not in the canonical
+	// amount/recipient/sender order, so every test case using it also exercises
+	// NormalizeTransferAttrs.
 	transferLogStr = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"sender","value":"sender"},{"key":"amount","value":"1000Asset0"}]}]`
+	// transferLogStrWithoutSender mimics a MsgMultiSend output: bank emits "transfer"
+	// with recipient+amount only, no sender (a multisend can have multiple inputs).
+	transferLogStrWithoutSender = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"amount","value":"1000Asset0"}]}]`
 )

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -117,18 +117,6 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		taxTxs = append(taxTxs, tTxs...)
 
-		if raw.Type == eventlog.TransferType {
-			// event log messages are not sorted well
-			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
-			filter := []string{
-				pdex.TransferAmountKey, pdex.TransferRecipientKey, pdex.TransferSenderKey,
-			}
-			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
-			if err != nil {
-				return nil, errors.Wrapf(err, "columbusv2.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
-			}
-			raw.Attributes = *attrs
-		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "columbusv2.ParseTxs transfer tx_hash=%s", tx.Hash)
@@ -357,7 +345,7 @@ func (p *terraswapApp) UpdateParsers(tokenExceptions map[string]bool, height uin
 		),
 	)
 
-	transferRule, err := columbusv2.CreateSortedTransferRuleFinder(nil)
+	transferRule, err := pdex.CreateTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}

--- a/parser/dex/terraswap/columbusv2/app.go
+++ b/parser/dex/terraswap/columbusv2/app.go
@@ -117,6 +117,15 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		taxTxs = append(taxTxs, tTxs...)
 
+		if raw.Type == eventlog.TransferType {
+			// event log messages are not sorted well
+			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
+			sorted, err := pdex.NormalizeTransferAttrs(raw.Attributes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "columbusv2.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
+			}
+			raw.Attributes = sorted
+		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "columbusv2.ParseTxs transfer tx_hash=%s", tx.Hash)

--- a/parser/dex/terraswap/columbusv2/app_test.go
+++ b/parser/dex/terraswap/columbusv2/app_test.go
@@ -349,6 +349,9 @@ const (
 	{"key":"to","value":"A"},{"key":"amount","value":"12418119"},{"key":"_contract_address","value":"PAIR_ADDR"},{"key":"action","value":"withdraw_liquidity"},{"key":"sender","value":"sender"},{"key":"withdrawn_share","value":"1000"},{"key":"refund_assets","value":"1000Asset0, 1000Asset1"},{"key":"_contract_address","value":"asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"A"},{"key":"to","value":"terra1cupj7d70jrtjxqhpr6s3qq68t8ky4smcjvccm4"},{"key":"amount","value":"24999998"},{"key":"_contract_address","value":"terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7"},{"key":"action","value":"burn"},{"key":"from","value":"A"},{"key":"amount","value":"12418119"}]}]`
 	wasmTransferLogStr = `[{"type":"wasm","attributes":[{"key":"_contract_address","value":"Asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"sender"},
 	{"key":"to","value":"PAIR_ADDR"},{"key":"amount","value":"1000"}]}]`
+	// transferLogStr attributes are deliberately not in the canonical
+	// amount/recipient/sender order, so every test case using it also exercises
+	// NormalizeTransferAttrs.
 	transferLogStr                       = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"sender","value":"sender"},{"key":"amount","value":"1000Asset0"}]}]`
 	transferWithoutSenderLogStr          = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"amount","value":"1000Asset1"}]}]`
 	transferFromPairLogStr               = `[{"type":"transfer","attributes":[{"key":"recipient","value":"sender"},{"key":"sender","value":"PAIR_ADDR"},{"key":"amount","value":"1000Asset0"}]}]`

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -101,7 +101,16 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
-		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
+		if raw.Type == eventlog.TransferType {
+			// event log messages are not sorted well
+			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
+			sorted, err := pdex.NormalizeTransferAttrs(raw.Attributes)
+			if err != nil {
+				return nil, errors.Wrapf(err, "phoenix.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
+			}
+			raw.Attributes = sorted
+		}
+		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp}, tx.Sender)
 		if err != nil {
 			return nil, errors.Wrapf(err, "phoenix.ParseTxs transfer tx_hash=%s", tx.Hash)
 		}

--- a/parser/dex/terraswap/phoenix/app.go
+++ b/parser/dex/terraswap/phoenix/app.go
@@ -101,18 +101,6 @@ func (p *terraswapApp) ParseTxs(tx parser.RawTx, height uint64) ([]dex.ParsedTx,
 		}
 		wasmTxs = append(wasmTxs, wtxs...)
 
-		if raw.Type == eventlog.TransferType {
-			// event log messages are not sorted well
-			// bug tx: C51473267BEF98BAE991C19AD8A5EFF6370BC64B63ACB68190170095C1AE0ABE
-			filter := []string{
-				pdex.TransferAmountKey, pdex.TransferRecipientKey, pdex.TransferSenderKey,
-			}
-			attrs, err := eventlog.SortAttributes(raw.Attributes, filter)
-			if err != nil {
-				return nil, errors.Wrapf(err, "phoenix.ParseTxs sort_transfer_attrs tx_hash=%s", tx.Hash)
-			}
-			raw.Attributes = *attrs
-		}
 		transfers, err := p.Parsers.Transfer.Parse(eventlog.LogResults{raw}, dex.ParsedTx{Hash: tx.Hash, Timestamp: tx.Timestamp})
 		if err != nil {
 			return nil, errors.Wrapf(err, "phoenix.ParseTxs transfer tx_hash=%s", tx.Hash)
@@ -175,7 +163,7 @@ func (p *terraswapApp) UpdateParsers(tokenExceptions map[string]bool, height uin
 		),
 	)
 
-	transferRule, err := phoenix.CreateSortedTransferRuleFinder(nil)
+	transferRule, err := pdex.CreateTransferRuleFinder(nil)
 	if err != nil {
 		return errors.Wrap(err, "updateParsers")
 	}

--- a/parser/dex/terraswap/phoenix/app_test.go
+++ b/parser/dex/terraswap/phoenix/app_test.go
@@ -92,6 +92,19 @@ func Test_parseTxs(t *testing.T) {
 		{[]string{swapLogStr, wasmTransferLogStr, transferLogStr}, 1, 0, []dex.ParsedTx{swapTx, transferTx}, ""},
 		{nil, 0, 0, []dex.ParsedTx{}, ""},
 		{nil, 3, 1, []dex.ParsedTx{}, ""},
+		// MsgMultiSend outputs emit "transfer" events without a "sender" attribute
+		// (a multisend can have multiple inputs); must fall back to the tx-level sender.
+		{[]string{transferLogStrWithoutSender}, 0, 0, []dex.ParsedTx{
+			{
+				Hash:         hash,
+				Timestamp:    time.Time{},
+				Type:         dex.Transfer,
+				Sender:       sender,
+				ContractAddr: "PAIR_ADDR",
+				Assets:       [2]dex.Asset{{Addr: "Asset0", Amount: "1000"}, {Addr: "Asset1", Amount: ""}},
+				Meta:         make(map[string]interface{}),
+			},
+		}, ""},
 	}
 
 	for idx, tc := range tcs {
@@ -143,5 +156,11 @@ const (
 	{"key":"to","value":"A"},{"key":"amount","value":"12418119"},{"key":"_contract_address","value":"PAIR_ADDR"},{"key":"action","value":"withdraw_liquidity"},{"key":"sender","value":"sender"},{"key":"withdrawn_share","value":"1000"},{"key":"refund_assets","value":"1000Asset0, 1000Asset1"},{"key":"_contract_address","value":"asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"A"},{"key":"to","value":"terra1cupj7d70jrtjxqhpr6s3qq68t8ky4smcjvccm4"},{"key":"amount","value":"24999998"},{"key":"_contract_address","value":"terra1gte4eejaw3hrs2d8pt0zhp0yfd34xp24qdgqumjul29jt5hwl5tsx3qmw7"},{"key":"action","value":"burn"},{"key":"from","value":"A"},{"key":"amount","value":"12418119"}]}]`
 	wasmTransferLogStr = `[{"type":"wasm","attributes":[{"key":"_contract_address","value":"Asset1"},{"key":"action","value":"transfer"},{"key":"from","value":"sender"},
 	{"key":"to","value":"PAIR_ADDR"},{"key":"amount","value":"1000"}]}]`
+	// transferLogStr attributes are deliberately not in the canonical
+	// amount/recipient/sender order, so every test case using it also exercises
+	// NormalizeTransferAttrs.
 	transferLogStr = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"sender","value":"sender"},{"key":"amount","value":"1000Asset0"}]}]`
+	// transferLogStrWithoutSender mimics a MsgMultiSend output: bank emits "transfer"
+	// with recipient+amount only, no sender (a multisend can have multiple inputs).
+	transferLogStrWithoutSender = `[{"type":"transfer","attributes":[{"key":"recipient","value":"PAIR_ADDR"},{"key":"amount","value":"1000Asset0"}]}]`
 )

--- a/pkg/dex/dezswap/consts.go
+++ b/pkg/dex/dezswap/consts.go
@@ -37,7 +37,7 @@ const (
 	WasmCommonTransferMatchedLen = WasmCommonTransferActionIdx + 1
 	WasmTransferMatchedLen       = WasmTransferToIdx + 1
 	WasmTransferFromMatchedLen   = WasmTransferFromToIdx + 1
-	TransferMatchedLen           = TransferAmountIdx + 1
+	TransferMatchedLen           = 3
 )
 
 const (
@@ -102,10 +102,4 @@ const (
 	WasmTransferFromByIdx
 	WasmTransferFromFromIdx
 	WasmTransferFromToIdx
-)
-
-const (
-	TransferRecipientIdx = iota
-	TransferSenderIdx
-	TransferAmountIdx
 )

--- a/pkg/dex/dezswap/consts.go
+++ b/pkg/dex/dezswap/consts.go
@@ -37,7 +37,9 @@ const (
 	WasmCommonTransferMatchedLen = WasmCommonTransferActionIdx + 1
 	WasmTransferMatchedLen       = WasmTransferToIdx + 1
 	WasmTransferFromMatchedLen   = WasmTransferFromToIdx + 1
-	TransferMatchedLen           = 3
+	// TransferMatchedLen is amount+recipient; sender is optional (omitted by MsgMultiSend
+	// outputs) and falls back to the tx sender.
+	TransferMatchedLen = 2
 )
 
 const (

--- a/pkg/dex/dezswap/logfinders.go
+++ b/pkg/dex/dezswap/logfinders.go
@@ -69,11 +69,6 @@ func CreateWasmCommonTransferRuleFinder() (eventlog.LogFinder, error) {
 	return eventlog.NewLogFinder(wasmTransferRule)
 }
 
-// Track transfer from user to Pair
-func CreateTransferRuleFinder() (eventlog.LogFinder, error) {
-	return eventlog.NewLogFinder(transferRule)
-}
-
 var createPairRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "_contract_address", Filter: nil},
 	eventlog.RuleItem{Key: "action", Filter: "create_pair"},
@@ -130,10 +125,4 @@ var wasmTransferRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_contract_
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {
 		return v == dex.WasmTransferAction || v == dex.WasmTransferFromAction
 	}},
-}}
-
-var transferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
-	eventlog.RuleItem{Key: dex.TransferRecipientKey, Filter: nil},
-	eventlog.RuleItem{Key: dex.TransferSenderKey, Filter: nil},
-	eventlog.RuleItem{Key: dex.TransferAmountKey, Filter: nil},
 }}

--- a/pkg/dex/logfinder.go
+++ b/pkg/dex/logfinder.go
@@ -16,6 +16,30 @@ func CreatePairInitialProvideRuleFinder(pairs map[string]bool) (eventlog.LogFind
 	return eventlog.NewLogFinder(rule)
 }
 
+// CreateTransferRuleFinder finds normalized native transfer events.
+// Transfer attributes are normalized to amount, recipient, sender before parsing.
+// Sender is optional on some Cosmos SDK versions, so only amount and recipient
+// are required and the remaining attributes are appended until the next amount.
+func CreateTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
+	var recipientFilter func(v string) bool
+	if pairs != nil {
+		recipientFilter = func(v string) bool {
+			_, ok := pairs[v]
+			return ok
+		}
+	}
+
+	rule := eventlog.Rule{
+		Type:  eventlog.TransferType,
+		Until: TransferAmountKey,
+		Items: eventlog.RuleItems{
+			{Key: TransferAmountKey},
+			{Key: TransferRecipientKey, Filter: recipientFilter},
+		},
+	}
+	return eventlog.NewLogFinder(rule)
+}
+
 var initialProvideRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "_contract_address", Filter: nil},
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {

--- a/pkg/dex/logfinder.go
+++ b/pkg/dex/logfinder.go
@@ -18,8 +18,11 @@ func CreatePairInitialProvideRuleFinder(pairs map[string]bool) (eventlog.LogFind
 
 // CreateTransferRuleFinder finds normalized native transfer events.
 // Transfer attributes are normalized to amount, recipient, sender before parsing.
-// Sender is optional on some Cosmos SDK versions, so only amount and recipient
-// are required and the remaining attributes are appended until the next amount.
+// Sender is optional because the bank module's MsgMultiSend emits one "transfer"
+// event per output (recipient+amount only) without a per-output sender, since a
+// multisend can have multiple inputs. Only amount and recipient are required, and
+// the remaining attributes (e.g. sender, when present) are appended until the
+// next amount.
 func CreateTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
 	var recipientFilter func(v string) bool
 	if pairs != nil {
@@ -38,6 +41,25 @@ func CreateTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error)
 		},
 	}
 	return eventlog.NewLogFinder(rule)
+}
+
+// NormalizeTransferAttrs sorts one native "transfer" log's attributes into
+// amount, recipient, sender order so CreateTransferRuleFinder can match them
+// regardless of the order the chain emitted them in (see its doc comment).
+// Every DEX parser's ParseTxs must call this, for each transfer-type log,
+// before running its Transfer parser — there is no other enforcement point,
+// since callers (including cmd/parser/diagnose) may invoke a TargetApp's
+// ParseTxs directly.
+func NormalizeTransferAttrs(attrs eventlog.Attributes) (eventlog.Attributes, error) {
+	sorted, err := eventlog.SortAttributes(attrs, []string{
+		TransferAmountKey,
+		TransferRecipientKey,
+		TransferSenderKey,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return *sorted, nil
 }
 
 var initialProvideRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{

--- a/pkg/dex/logfinders_test.go
+++ b/pkg/dex/logfinders_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/dezswap/cosmwasm-etl/pkg/eventlog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_LogFinders(t *testing.T) {
@@ -50,6 +51,38 @@ func Test_LogFinders(t *testing.T) {
 		}
 	}
 
+}
+
+func TestTransferRuleFinder(t *testing.T) {
+	const pair = "pair"
+	logs := eventlog.LogResults{{
+		Type: eventlog.TransferType,
+		Attributes: eventlog.Attributes{
+			{Key: TransferAmountKey, Value: "10ucoin", MsgIndex: 1},
+			{Key: TransferRecipientKey, Value: pair, MsgIndex: 1},
+			{Key: TransferSenderKey, Value: "sender", MsgIndex: 1},
+			{Key: TransferAmountKey, Value: "20ucoin", MsgIndex: 2},
+			{Key: TransferRecipientKey, Value: pair, MsgIndex: 2},
+		},
+	}}
+
+	finder, err := CreateTransferRuleFinder(map[string]bool{pair: true})
+	require.NoError(t, err)
+	require.Equal(t, eventlog.MatchedResults{
+		{
+			{Key: TransferAmountKey, Value: "10ucoin", MsgIndex: 1},
+			{Key: TransferRecipientKey, Value: pair, MsgIndex: 1},
+			{Key: TransferSenderKey, Value: "sender", MsgIndex: 1},
+		},
+		{
+			{Key: TransferAmountKey, Value: "20ucoin", MsgIndex: 2},
+			{Key: TransferRecipientKey, Value: pair, MsgIndex: 2},
+		},
+	}, finder.FindFromLogs(logs))
+
+	finder, err = CreateTransferRuleFinder(map[string]bool{"other": true})
+	require.NoError(t, err)
+	require.Empty(t, finder.FindFromLogs(logs))
 }
 
 func Test_BurnLogFinder(t *testing.T) {

--- a/pkg/dex/logfinders_test.go
+++ b/pkg/dex/logfinders_test.go
@@ -85,6 +85,26 @@ func TestTransferRuleFinder(t *testing.T) {
 	require.Empty(t, finder.FindFromLogs(logs))
 }
 
+func TestNormalizeTransferAttrs(t *testing.T) {
+	sorted, err := NormalizeTransferAttrs(eventlog.Attributes{
+		{Key: "sender", Value: "sender-1", MsgIndex: 1},
+		{Key: "ignored", Value: "metadata", MsgIndex: 1},
+		{Key: "recipient", Value: "recipient-1", MsgIndex: 1},
+		{Key: "amount", Value: "10ucoin", MsgIndex: 1},
+		{Key: "recipient", Value: "recipient-2", MsgIndex: 2},
+		{Key: "amount", Value: "20ucoin", MsgIndex: 2},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, eventlog.Attributes{
+		{Key: "amount", Value: "10ucoin", MsgIndex: 1},
+		{Key: "recipient", Value: "recipient-1", MsgIndex: 1},
+		{Key: "sender", Value: "sender-1", MsgIndex: 1},
+		{Key: "amount", Value: "20ucoin", MsgIndex: 2},
+		{Key: "recipient", Value: "recipient-2", MsgIndex: 2},
+	}, sorted)
+}
+
 func Test_BurnLogFinder(t *testing.T) {
 	tcs := []struct {
 		rawLogStr         string

--- a/pkg/dex/starfleit/consts.go
+++ b/pkg/dex/starfleit/consts.go
@@ -38,7 +38,9 @@ const (
 	WasmCommonTransferMatchedLen = WasmCommonTransferActionIdx + 1
 	WasmV1TransferMatchedLen     = WasmTransferToIdx + 1
 	WasmV2TransferMatchedLen     = WasmTransferFromToIdx + 1
-	TransferMatchedLen           = 3
+	// TransferMatchedLen is amount+recipient; sender is optional (omitted by MsgMultiSend
+	// outputs) and falls back to the tx sender.
+	TransferMatchedLen = 2
 )
 
 const (

--- a/pkg/dex/starfleit/consts.go
+++ b/pkg/dex/starfleit/consts.go
@@ -38,7 +38,7 @@ const (
 	WasmCommonTransferMatchedLen = WasmCommonTransferActionIdx + 1
 	WasmV1TransferMatchedLen     = WasmTransferToIdx + 1
 	WasmV2TransferMatchedLen     = WasmTransferFromToIdx + 1
-	TransferMatchedLen           = TransferAmountIdx + 1
+	TransferMatchedLen           = 3
 )
 
 const (
@@ -110,10 +110,4 @@ const (
 	WasmTransferFromByIdx
 	WasmTransferFromFromIdx
 	WasmTransferFromToIdx
-)
-
-const (
-	TransferRecipientIdx = iota
-	TransferSenderIdx
-	TransferAmountIdx
 )

--- a/pkg/dex/starfleit/logfinders.go
+++ b/pkg/dex/starfleit/logfinders.go
@@ -83,11 +83,6 @@ func CreateWasmCommonTransferRuleFinder() (eventlog.LogFinder, error) {
 	return eventlog.NewLogFinder(wasmTransferRule)
 }
 
-// Track transfer from user to Pair
-func CreateTransferRuleFinder() (eventlog.LogFinder, error) {
-	return eventlog.NewLogFinder(transferRule)
-}
-
 var createPairRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "_contract_address", Filter: nil},
 	eventlog.RuleItem{Key: "action", Filter: "create_pair"},
@@ -144,12 +139,6 @@ var wasmTransferRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_contract_
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {
 		return v == string(WasmTransferAction) || v == string(WasmTransferFromAction)
 	}},
-}}
-
-var transferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
-	eventlog.RuleItem{Key: "recipient", Filter: nil},
-	eventlog.RuleItem{Key: "sender", Filter: nil},
-	eventlog.RuleItem{Key: "amount", Filter: nil},
 }}
 
 var initialProvideRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{

--- a/pkg/dex/terraswap/columbusv1/consts.go
+++ b/pkg/dex/terraswap/columbusv1/consts.go
@@ -17,7 +17,6 @@ const (
 	PairProvideMatchedLen  = PairProvideShareIdx + 1
 	PairWithdrawMatchedLen = PairWithdrawRefundAssetsIdx + 1
 	WasmTransferMatchedLen = WasmTransferAmountIdx + 1
-	TransferMatchedLen     = TransferAmountIdx + 1
 )
 
 const (
@@ -55,10 +54,4 @@ const (
 	WasmTransferFromIdx
 	WasmTransferToIdx
 	WasmTransferAmountIdx
-)
-
-const (
-	TransferRecipientIdx = iota
-	TransferSenderIdx
-	TransferAmountIdx
 )

--- a/pkg/dex/terraswap/columbusv1/logfinders.go
+++ b/pkg/dex/terraswap/columbusv1/logfinders.go
@@ -36,21 +36,6 @@ func CreateWasmCommonTransferRuleFinder(pairs map[string]bool) (eventlog.LogFind
 	return eventlog.NewLogFinder(col4WasmTransferCommonRule)
 }
 
-// Track transfer from user to Pair
-func CreateTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
-	var filter func(v string) bool
-	if pairs != nil {
-		filter = func(v string) bool {
-			_, ok := pairs[v]
-			return ok
-		}
-	}
-	rule := transferRule
-	rule.Items[TransferRecipientIdx].Filter = filter
-
-	return eventlog.NewLogFinder(rule)
-}
-
 var col4CreatePairRule = eventlog.Rule{Type: eventlog.FromContract, Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "contract_address", Filter: nil},
 	eventlog.RuleItem{Key: "action", Filter: "create_pair"},
@@ -71,10 +56,4 @@ var col4WasmTransferCommonRule = eventlog.Rule{Type: eventlog.FromContract, Unti
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {
 		return v == WasmTransferAction || v == WasmTransferFromAction
 	}},
-}}
-
-var transferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
-	eventlog.RuleItem{Key: "recipient", Filter: nil},
-	eventlog.RuleItem{Key: "sender", Filter: nil},
-	eventlog.RuleItem{Key: "amount", Filter: nil},
 }}

--- a/pkg/dex/terraswap/columbusv1/logfinders_test.go
+++ b/pkg/dex/terraswap/columbusv1/logfinders_test.go
@@ -90,8 +90,6 @@ func Test_LogFinders(t *testing.T) {
 		{PairWithdrawRawLogStr, nil, CreatePairCommonRulesFinder, 1, PairWithdrawMatchedLen, "must match once"},
 		// WasmTransfer
 		{WasmTransferRawLogStr, nil, CreateWasmCommonTransferRuleFinder, 1, WasmTransferMatchedLen, "must match once"},
-		// Transfer
-		{TransferRawLogStr, nil, CreateTransferRuleFinder, 1, TransferMatchedLen, "must match once"},
 	}
 
 	for idx, tc := range tcs {

--- a/pkg/dex/terraswap/columbusv2/consts.go
+++ b/pkg/dex/terraswap/columbusv2/consts.go
@@ -14,12 +14,6 @@ const (
 )
 
 const (
-	SortedTransferAmountIdx = iota
-	SortedTransferRecipientIdx
-	SortedTransferSenderIdx
-)
-
-const (
 	PairAddrKey   = "_contract_address"
 	PairActionKey = "action"
 )

--- a/pkg/dex/terraswap/columbusv2/logfinders.go
+++ b/pkg/dex/terraswap/columbusv2/logfinders.go
@@ -36,21 +36,6 @@ func CreateWasmCommonTransferRuleFinder(pairs map[string]bool) (eventlog.LogFind
 	return eventlog.NewLogFinder(wasmTransferCommonRule)
 }
 
-// Track transfer from user to Pair
-func CreateSortedTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
-	var filter func(v string) bool
-	if pairs != nil {
-		filter = func(v string) bool {
-			_, ok := pairs[v]
-			return ok
-		}
-	}
-	rule := sortedTransferRule
-	rule.Items[SortedTransferRecipientIdx].Filter = filter
-
-	return eventlog.NewLogFinder(rule)
-}
-
 // CreateTaxPaymentRuleFinder finds tax_payment type logs
 func CreateTaxPaymentRuleFinder() (eventlog.LogFinder, error) {
 	return eventlog.NewLogFinder(taxPaymentRule)
@@ -76,11 +61,6 @@ var wasmTransferCommonRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_con
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {
 		return v == dex.WasmTransferAction || v == dex.WasmTransferFromAction
 	}},
-}}
-
-var sortedTransferRule = eventlog.Rule{Type: eventlog.TransferType, Until: "amount", Items: eventlog.RuleItems{
-	eventlog.RuleItem{Key: "amount", Filter: nil},
-	eventlog.RuleItem{Key: "recipient", Filter: nil},
 }}
 
 var taxPaymentRule = eventlog.Rule{Type: eventlog.TaxPaymentType, Items: eventlog.RuleItems{

--- a/pkg/dex/terraswap/columbusv2/logfinders_test.go
+++ b/pkg/dex/terraswap/columbusv2/logfinders_test.go
@@ -102,6 +102,9 @@ func Test_LogFinders(t *testing.T) {
 
 }
 
+// Test_TransferRuleFinder_OptionalSender covers MsgMultiSend outputs: the bank
+// module emits one "transfer" event per output (recipient+amount only, no
+// sender, since a multisend can have multiple inputs).
 func Test_TransferRuleFinder_OptionalSender(t *testing.T) {
 	tcs := []struct {
 		name          string
@@ -262,6 +265,9 @@ const TransferRawLogStr = `[
 	{"type":"transfer","attributes":[{"key":"amount","value":"1000000uluna"},{"key":"recipient","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"sender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"}]}
 ]`
 
+// TransferRawLogWithoutSenderStr models a MsgMultiSend output: the bank module
+// emits "transfer" with recipient+amount only, no sender attribute, since a
+// multisend can have multiple inputs.
 const TransferRawLogWithoutSenderStr = `[
 	{"type":"coin_received","attributes":[{"key":"receiver","value":"terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"},{"key":"amount","value":"1000000uluna"}]},
 	{"type":"coin_spent","attributes":[{"key":"spender","value":"terra1g5cad8hl9uwldus279ddc0j4fq7xjude0ynhjv"},{"key":"amount","value":"1000000uluna"}]},

--- a/pkg/dex/terraswap/columbusv2/logfinders_test.go
+++ b/pkg/dex/terraswap/columbusv2/logfinders_test.go
@@ -88,7 +88,7 @@ func Test_LogFinders(t *testing.T) {
 		// WasmTransfer
 		{WasmTransferRawLogStr, nil, CreateWasmCommonTransferRuleFinder, 1, "must match once"},
 		// Transfer
-		{TransferRawLogStr, nil, CreateSortedTransferRuleFinder, 1, "must match once"},
+		{TransferRawLogStr, nil, dex.CreateTransferRuleFinder, 1, "must match once"},
 	}
 
 	for idx, tc := range tcs {
@@ -102,7 +102,7 @@ func Test_LogFinders(t *testing.T) {
 
 }
 
-func Test_SortedTransferRuleFinder_OptionalSender(t *testing.T) {
+func Test_TransferRuleFinder_OptionalSender(t *testing.T) {
 	tcs := []struct {
 		name          string
 		rawLogStr     string
@@ -132,7 +132,7 @@ func Test_SortedTransferRuleFinder_OptionalSender(t *testing.T) {
 
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			logFinder, err := CreateSortedTransferRuleFinder(nil)
+			logFinder, err := dex.CreateTransferRuleFinder(nil)
 			assert.NoError(t, err)
 
 			eventLogs := eventlog.LogResults{}
@@ -149,10 +149,10 @@ func Test_SortedTransferRuleFinder_OptionalSender(t *testing.T) {
 	}
 }
 
-func Test_SortedTransferRuleFinder_FiltersPairRecipient(t *testing.T) {
+func Test_TransferRuleFinder_FiltersPairRecipient(t *testing.T) {
 	const pairAddr = "terra1zdpq84j8ex29wz9tmygqtftplrw87x8wmuyfh0rsy60uq7nadtsq5pjr7y"
 
-	logFinder, err := CreateSortedTransferRuleFinder(map[string]bool{pairAddr: true})
+	logFinder, err := dex.CreateTransferRuleFinder(map[string]bool{pairAddr: true})
 	assert.NoError(t, err)
 
 	eventLogs := eventlog.LogResults{}
@@ -160,9 +160,9 @@ func Test_SortedTransferRuleFinder_FiltersPairRecipient(t *testing.T) {
 
 	matchedResults := logFinder.FindFromLogs(eventLogs)
 	assert.Len(t, matchedResults, 1)
-	assert.Equal(t, pairAddr, matchedResults[0][SortedTransferRecipientIdx].Value)
+	assert.Equal(t, pairAddr, matchedResults[0][1].Value)
 
-	logFinder, err = CreateSortedTransferRuleFinder(map[string]bool{"other_pair": true})
+	logFinder, err = dex.CreateTransferRuleFinder(map[string]bool{"other_pair": true})
 	assert.NoError(t, err)
 
 	matchedResults = logFinder.FindFromLogs(eventLogs)

--- a/pkg/dex/terraswap/phoenix/consts.go
+++ b/pkg/dex/terraswap/phoenix/consts.go
@@ -14,12 +14,6 @@ const (
 )
 
 const (
-	SortedTransferAmountIdx = iota
-	SortedTransferRecipientIdx
-	SortedTransferSenderIdx
-)
-
-const (
 	PairAddrKey   = "_contract_address"
 	PairActionKey = "action"
 )

--- a/pkg/dex/terraswap/phoenix/logfinders.go
+++ b/pkg/dex/terraswap/phoenix/logfinders.go
@@ -36,21 +36,6 @@ func CreateWasmCommonTransferRuleFinder(pairs map[string]bool) (eventlog.LogFind
 	return eventlog.NewLogFinder(wasmTransferCommonRule)
 }
 
-// Track transfer from user to Pair
-func CreateSortedTransferRuleFinder(pairs map[string]bool) (eventlog.LogFinder, error) {
-	var filter func(v string) bool
-	if pairs != nil {
-		filter = func(v string) bool {
-			_, ok := pairs[v]
-			return ok
-		}
-	}
-	rule := sortedTransferRule
-	rule.Items[SortedTransferRecipientIdx].Filter = filter
-
-	return eventlog.NewLogFinder(rule)
-}
-
 var createPairRule = eventlog.Rule{Type: eventlog.WasmType, Items: eventlog.RuleItems{
 	eventlog.RuleItem{Key: "_contract_address", Filter: nil},
 	eventlog.RuleItem{Key: "action", Filter: "create_pair"},
@@ -71,10 +56,4 @@ var wasmTransferCommonRule = eventlog.Rule{Type: eventlog.WasmType, Until: "_con
 	eventlog.RuleItem{Key: "action", Filter: func(v string) bool {
 		return v == dex.WasmTransferAction || v == dex.WasmTransferFromAction
 	}},
-}}
-
-var sortedTransferRule = eventlog.Rule{Type: eventlog.TransferType, Items: eventlog.RuleItems{
-	eventlog.RuleItem{Key: "amount", Filter: nil},
-	eventlog.RuleItem{Key: "recipient", Filter: nil},
-	eventlog.RuleItem{Key: "sender", Filter: nil},
 }}

--- a/pkg/dex/terraswap/phoenix/logfinders_test.go
+++ b/pkg/dex/terraswap/phoenix/logfinders_test.go
@@ -88,7 +88,7 @@ func Test_LogFinders(t *testing.T) {
 		// WasmTransfer
 		{WasmTransferRawLogStr, nil, CreateWasmCommonTransferRuleFinder, 1, "must match once"},
 		// Transfer
-		{TransferRawLogStr, nil, CreateSortedTransferRuleFinder, 1, "must match once"},
+		{TransferRawLogStr, nil, dex.CreateTransferRuleFinder, 1, "must match once"},
 	}
 
 	for idx, tc := range tcs {


### PR DESCRIPTION
<!-- Optional  -->
- Major Reviewer:

<!-- Optional  -->
## Background
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Native transfer event attributes aren't always emitted in a fixed order or with a full attribute set, which has caused parsing bugs before(#146). The previous fix only patched `dezswap` (`terraswap`'s `columbusv2`/`phoenix` had already been patched individually with duplicate sort logic long before).

## Summary
<!--- Provide a summary of your changes. -->
<!--- It's a good idea to include the issue you are trying to solve and how to fix it. -->
- Centralize the `transfer-attribute-sorting` workaround into a single `dexApp.ParseTxs` mixin backed by one shared `pkg/dex.CreateTransferRuleFinder`, removing the duplicated per-protocol rule/const definitions in `dezswap`, `starfleit`, `columbusv1`, `columbusv2`, and `phoenix`. `columbusv1` now gets the sorting fix for the first time.
- Fix `MsgMultiSend` transfers (no sender attribute) consistently across all five parsers: export `TransferFallbackSender` and fall back to the tx-level sender everywhere, instead of `dezswap`/`starfleit` erroring out and `columbusv1`/`phoenix` leaving Sender empty.

<!--- Add More if you need. -->

## Checklist

- [x] Backward compatible?
- [x] Test enough in your local environment?
- [x] Add related test cases?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native transfer parsing across supported DEX integrations.
  * Transfer events are now handled correctly regardless of attribute order.
  * Transfers without an explicit sender now fall back to the transaction sender when available.
  * Added recipient filtering and validation for transfer events.

* **Tests**
  * Added coverage for unordered attributes, optional senders, multisend transfers, and pair matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->